### PR TITLE
Problems with nextval

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/HSQLDBTemplates.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/HSQLDBTemplates.java
@@ -36,6 +36,8 @@ public class HSQLDBTemplates extends SQLTemplates {
         setAutoIncrement(" identity");        
         add(Ops.TRIM, "trim(both from {0})");
         add(Ops.NEGATE, "{0} * -1", 7);
+
+        add(Ops.NEXTVAL, "next value for {0s}");
         
         add(Ops.MathOps.ROUND, "round({0},0)");
         add(Ops.MathOps.LN, "log({0})");

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLExpressions.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLExpressions.java
@@ -36,7 +36,7 @@ public final class SQLExpressions {
     }    
     
     public static final <T extends Number> SimpleExpression<T> nextval(Class<T> type, String sequence) {
-        return SimpleOperation.create(type, SQLTemplates.NEXTVAL, ConstantImpl.create("seq"));
+        return SimpleOperation.create(type, SQLTemplates.NEXTVAL, ConstantImpl.create(sequence));
     }
     
     private SQLExpressions() {}


### PR DESCRIPTION
I'm working with HSQLDB and Oracle an I found two problems.
  1.- The nextval operator in HSQLDB is not the same than the default (nextval(..) -> next value for ..).
  2.- The nextval expression is not setting the sequence name.

The fix is trivial.

Thanks and regards.
