### PR TITLE
Problems to read boolean values in databases which do not support boolean type.

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/types/BooleanType.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/types/BooleanType.java
@@ -34,7 +34,8 @@ public class BooleanType extends AbstractType<Boolean> {
 
     @Override
     public Boolean getValue(ResultSet rs, int startIndex) throws SQLException {
-        return rs.getBoolean(startIndex);
+        final boolean value = rs.getBoolean(startIndex);
+        return rs.wasNull() ? null : value;
     }
 
     @Override


### PR DESCRIPTION
In the first commit, I changed the code to read the boolean value using getBoolean to support the read of boolean values in databases which do not support boolean type (Oracle).
In the second commit, I updated the change to support null values, because the getBoolean returns native boolean, so to return null value I checked if the database value is null (resultSet.wasNull).
