### PR TITLE
QueryDSL Collections failed to search by equality of Longs 

### DIFF
--- a/querydsl-collections/src/test/java/com/mysema/query/collections/EntityWithLongId.java
+++ b/querydsl-collections/src/test/java/com/mysema/query/collections/EntityWithLongId.java
@@ -1,0 +1,23 @@
+package com.mysema.query.collections;
+
+import com.mysema.query.annotations.QueryEntity;
+import com.mysema.query.annotations.QueryProjection;
+
+@QueryEntity
+public class EntityWithLongId {
+
+    private Long id;
+
+    @QueryProjection
+    public EntityWithLongId(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/querydsl-collections/src/test/java/com/mysema/query/collections/EntityWithLongIdTest.java
+++ b/querydsl-collections/src/test/java/com/mysema/query/collections/EntityWithLongIdTest.java
@@ -1,0 +1,29 @@
+package com.mysema.query.collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class EntityWithLongIdTest {
+
+    private List<EntityWithLongId> entities = Arrays.asList(
+            new EntityWithLongId(999L),
+            new EntityWithLongId(1000L),
+            new EntityWithLongId(1001L),
+            new EntityWithLongId(1003L)
+    );
+
+    @Test
+    public void SimpleEquals() {
+        QEntityWithLongId root = QEntityWithLongId.entityWithLongId;
+        ColQuery query = new ColQueryImpl().from(root, entities);
+        query.where(root.id.eq(1000L));
+
+        Long found = query.singleResult(root.id);
+        Assert.assertNotNull(found);
+        Assert.assertEquals(found.longValue(), 1000);
+    }
+
+}


### PR DESCRIPTION
Hi Guys,

I added simple test to reproduce issue we recently found.
Codegen generates something like:

```
entity.getId() == av1
```

And it fails if id field is type of Long
