### PR TITLE
PostgresTemplates Fixes

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/PostgresTemplates.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/PostgresTemplates.java
@@ -78,9 +78,17 @@ public class PostgresTemplates extends SQLTemplates {
         add(Ops.DateTimeOps.HOUR, "extract(hour from {0})");
         add(Ops.DateTimeOps.MINUTE, "extract(minute from {0})");
         add(Ops.DateTimeOps.SECOND, "extract(second from {0})");
+        add(Ops.DateTimeOps.CURRENT_TIMESTAMP, "current_timestamp");
+        add(Ops.DateTimeOps.CURRENT_DATE, "current_date");
+        add(Ops.DateTimeOps.CURRENT_TIME, "current_time");
         
 //        add(Ops.DateTimeOps.DATE_ADD, "timestamp {0} + interval '{1s} {2s}s'");
 
+    }
+    
+    @Override
+    public void setPrintSchema(boolean printSchema) {
+        super.setPrintSchema(printSchema);
     }
 
 }


### PR DESCRIPTION
Fixed current_date, current_time and current_timestamp. Added printSchema as a public option - should this be a public option at SQLTemplates level?
