### PR TITLE
Generic round

### DIFF
--- a/querydsl-core/src/main/java/com/mysema/query/types/expr/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/mysema/query/types/expr/NumberExpression.java
@@ -73,16 +73,13 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
     }
 
     @Nullable
-    private volatile NumberExpression<T> abs, sum, min, max, floor, ceil;
+    private volatile NumberExpression<T> abs, sum, min, max, floor, ceil, round;
 
     @Nullable
     private volatile NumberExpression<Double> avg, sqrt;
 
     @Nullable
     private volatile NumberExpression<T> negation;
-
-    @Nullable
-    private volatile NumberExpression<Integer> round;
 
     public NumberExpression(Expression<T> mixin) {
         super(mixin);
@@ -611,9 +608,9 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
      * @see java.lang.Math#round(double)
      * @see java.lang.Math#round(float)
      */
-    public NumberExpression<Integer> round() {
+    public NumberExpression<T> round() {
         if (round == null) {
-            round = NumberOperation.create(Integer.class, MathOps.ROUND, mixin);
+	    round = NumberOperation.create(getType(), MathOps.ROUND, mixin);
         }
         return round;
     }


### PR DESCRIPTION
One may have some things in the db which are different numeric type than int and round still makes sense. Think of BigDecimal for example.

On the other hand the round is handled in the code currently differently than floor, ceil, etc. Is there a reason for that? Am I missing something? If not we should treat round the same way. And that is this patch.
