### PR TITLE
Added Date/time JPQL functions to ElipseLinkTemplates

### DIFF
--- a/querydsl-jpa/src/main/java/com/mysema/query/jpa/EclipseLinkTemplates.java
+++ b/querydsl-jpa/src/main/java/com/mysema/query/jpa/EclipseLinkTemplates.java
@@ -49,6 +49,13 @@ public class EclipseLinkTemplates extends JPQLTemplates {
         add(Ops.STRING_CAST, "cast({0} as varchar)");        
         add(Ops.CHAR_AT, "substring({0},{1}+1,1)");
 
+		add(Ops.DateTimeOps.MILLISECOND, "extract(microsecond from {0})");
+		add(Ops.DateTimeOps.SECOND, "extract(second from {0})");
+		add(Ops.DateTimeOps.MINUTE, "extract(minute from {0})");
+		add(Ops.DateTimeOps.HOUR, "extract(hour from {0})");
+		add(Ops.DateTimeOps.DAY_OF_MONTH, "extract(day from {0})");
+		add(Ops.DateTimeOps.MONTH, "extract(month from {0})");
+		add(Ops.DateTimeOps.YEAR, "extract(year from {0})");
     }
     
     @Override


### PR DESCRIPTION
Since EclipseLink 2.4, new date/time JPQL functions were introduced as described in the java docs:
http://www.eclipse.org/eclipselink/api/2.4/org/eclipse/persistence/jpa/jpql/parser/ExtractExpression.html

Actually, the year(), month(), day(), hour(), minute(), second() aren't specified by JPA spec, but they are in the JPQL default template. I know that these keywords are supported by Hibernate, DataNucleus and Batoo, but on EclipseLink was provided another way to do the same.
