### PR TITLE
Add column meta data

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/ColumnMetadata.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/ColumnMetadata.java
@@ -1,0 +1,208 @@
+package com.mysema.query.sql;
+
+import java.sql.Types;
+
+import com.google.common.base.Preconditions;
+import com.mysema.query.types.Path;
+
+/**
+ * Provides metadata like the column name, JDBC type and constraints
+ */
+public class ColumnMetadata {
+
+    /**
+     * Returns this path's column metadata if present. Otherwise returns default
+     * metadata where the column name is equal to the path's name.
+     */
+    public static ColumnMetadata getColumnMetadata(Path<?> path) {
+        Path<?> parent = path.getMetadata().getParent();
+        if (parent != null && parent instanceof RelationalPath) {
+            ColumnMetadata columnMetadata = ((RelationalPath<?>) parent).getColumnMetadata(path);
+            if (columnMetadata != null) {
+                return columnMetadata;
+            }
+        }
+        return ColumnMetadata.named(path.getMetadata().getName());
+    }
+
+    /**
+     * Creates default column meta data with the given column name, but without
+     * any type or constraint information. Use the fluent builder methods to
+     * further configure it.
+     * 
+     * @throws NullPointerException
+     *             if the name is null
+     */
+    public static ColumnMetadata named(String name) {
+        return new ColumnMetadata(name, null, true, UNDEFINED, UNDEFINED, UNDEFINED, true, true);
+    }
+
+    private static int UNDEFINED = -1;
+
+    private final String name;
+    private final Integer jdbcType;
+    private final boolean nullable;
+    private final int length;
+    private final int precision;
+    private final int scale;
+    private final boolean updateable;
+    private final boolean insertable;
+
+    private ColumnMetadata(String name, Integer jdbcType, boolean nullable, int length,
+            int precision, int scale, boolean updateable, boolean insertable) {
+        this.name = Preconditions.checkNotNull(name, "Name cannot be null");
+        this.jdbcType = jdbcType;
+        this.nullable = nullable;
+        this.length = length;
+        this.precision = precision;
+        this.scale = scale;
+        this.updateable = updateable;
+        this.insertable = insertable;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean hasJdbcType() {
+        return jdbcType != null;
+    }
+
+    /**
+     * The JDBC type of this column.
+     * 
+     * @see Types
+     * @see ColumnMetadata#hasJdbcType()
+     * @throws IllegalStateException
+     *             if this metadata has no type information
+     */
+    public int getJdbcType() {
+        Preconditions.checkState(hasJdbcType(), name + " has no jdbc type");
+        return jdbcType;
+    }
+
+    /**
+     * Returns a new column with the given type information
+     * 
+     * @see Types
+     */
+    public ColumnMetadata ofType(int jdbcType) {
+        return new ColumnMetadata(name, jdbcType, nullable, length, precision, scale, updateable,
+                insertable);
+    }
+
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    /**
+     * Returns a new column with a not null constraint
+     */
+    public ColumnMetadata notNull() {
+        return new ColumnMetadata(name, jdbcType, false, length, precision, scale, updateable,
+                insertable);
+    }
+
+    /**
+     * The length constraint of this column.
+     * 
+     * @see ColumnMetadata#hasLength()
+     * @throws IllegalStateException
+     *             if this column has no length constraint
+     */
+    public int getLength() {
+        Preconditions.checkState(hasLength(), name + " has no length");
+        return length;
+    }
+
+    public boolean hasLength() {
+        return length != UNDEFINED;
+    }
+
+    /**
+     * Returns a new column with the given length constraint. The length must be
+     * > 0.
+     * 
+     * @throws IllegalStateException
+     *             if precision and scale have already been defined
+     * @throws IllegalArgumentException
+     *             if the length is invalid
+     */
+    public ColumnMetadata withlength(int length) {
+        Preconditions.checkState(scale == UNDEFINED && precision == UNDEFINED,
+                "Cannot define both length and scale/precision");
+        Preconditions.checkArgument(length > 0, "Length must be > 0");
+        return new ColumnMetadata(name, jdbcType, nullable, length, precision, scale, updateable,
+                insertable);
+    }
+
+    /**
+     * Returns the precision of this numeric column.
+     * 
+     * @see ColumnMetadata#hasPrecisionAndScale()
+     * @throws IllegalStateException
+     *             if this column has no precision
+     */
+    public int getPrecision() {
+        Preconditions.checkState(hasPrecisionAndScale(), name + " has no precision");
+        return precision;
+    }
+
+    /**
+     * Returns the scale of this numeric column
+     * 
+     * @see ColumnMetadata#hasPrecisionAndScale()
+     * @throws IllegalStateException
+     *             if this column has no scale
+     */
+    public int getScale() {
+        Preconditions.checkState(hasPrecisionAndScale(), name + " has no scale");
+        return scale;
+    }
+
+    public boolean hasPrecisionAndScale() {
+        return scale != UNDEFINED && precision != UNDEFINED;
+    }
+
+    /**
+     * Returns a new column with the given precision and scale constraint. Both
+     * must be > 0.
+     * 
+     * @throws IllegalStateException
+     *             if a length constraint has already been added
+     * @throws IllegalArgumentException
+     *             if precision or scale are invalid
+     */
+    public ColumnMetadata withPrecisionAndScale(int precision, int scale) {
+        Preconditions.checkState(length == UNDEFINED,
+                "Cannot define both length and scale/precision");
+        Preconditions.checkArgument(precision > 0, "Precision must be > 0");
+        Preconditions.checkArgument(scale > 0, "Scale must be > 0");
+        return new ColumnMetadata(name, jdbcType, nullable, length, precision, scale, updateable,
+                insertable);
+    }
+
+    public boolean isUpdateable() {
+        return updateable;
+    }
+
+    /**
+     * Returns a new column with a no-update constraint.
+     */
+    public ColumnMetadata nonUpdateable() {
+        return new ColumnMetadata(name, jdbcType, nullable, length, precision, scale, false,
+                insertable);
+    }
+
+    public boolean isInsertable() {
+        return insertable;
+    }
+
+    /**
+     * Returns a new column with a no-insert constraint.
+     */
+    public ColumnMetadata nonInsertable() {
+        return new ColumnMetadata(name, jdbcType, nullable, length, precision, scale, updateable,
+                false);
+    }
+}

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/Configuration.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/Configuration.java
@@ -167,7 +167,7 @@ public final class Configuration {
         if (hasTableColumnTypes && path != null && !clazz.equals(Null.class)
                 && path.getMetadata().getParent() instanceof RelationalPath) {
             String table = ((RelationalPath)path.getMetadata().getParent()).getTableName();
-            String column = path.getMetadata().getName();
+            String column = ColumnMetadata.getColumnMetadata(path).getName();
             Type<T> type = (Type)javaTypeMapping.getType(table, column);
             if (type != null) {
                 return type;

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/RelationalPath.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/RelationalPath.java
@@ -23,27 +23,28 @@ import com.mysema.query.types.Path;
 import com.mysema.query.types.ProjectionRole;
 
 /**
- * RelationalPath extends {@link EntityPath} to provide access to relational metadata
+ * RelationalPath extends {@link EntityPath} to provide access to relational
+ * metadata
  * 
  * @author tiwe
- *
+ * 
  */
 public interface RelationalPath<T> extends EntityPath<T>, ProjectionRole<T> {
-   
+
     /**
      * Get the schema name
      * 
      * @return
      */
     String getSchemaName();
-    
+
     /**
      * Get the table name
      * 
      * @return
      */
     String getTableName();
-    
+
     /**
      * Get all columns
      * 
@@ -73,4 +74,11 @@ public interface RelationalPath<T> extends EntityPath<T>, ProjectionRole<T> {
      */
     Collection<ForeignKey<?>> getInverseForeignKeys();
 
+    /**
+     * Returns the metadata for this path or null if none was assigned. See
+     * {@link ColumnMetadata#getColumnMetadata(Path)} for a null safe
+     * alternative
+     */
+    @Nullable
+    ColumnMetadata getColumnMetadata(Path<?> column);
 }

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/RelationalPathBase.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/RelationalPathBase.java
@@ -18,44 +18,58 @@ import static com.google.common.collect.ImmutableList.copyOf;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.Maps;
 import com.mysema.query.types.FactoryExpression;
 import com.mysema.query.types.Path;
 import com.mysema.query.types.PathMetadata;
 import com.mysema.query.types.PathMetadataFactory;
 import com.mysema.query.types.path.BeanPath;
+import com.mysema.query.types.path.BooleanPath;
+import com.mysema.query.types.path.DatePath;
+import com.mysema.query.types.path.DateTimePath;
+import com.mysema.query.types.path.EnumPath;
+import com.mysema.query.types.path.NumberPath;
+import com.mysema.query.types.path.StringPath;
+import com.mysema.query.types.path.TimePath;
 
 /**
  * RelationalPathBase is a base class for {@link RelationalPath} implementations
  * 
  * @author tiwe
- *
- * @param <T> entity type
+ * 
+ * @param <T>
+ *            entity type
  */
+@SuppressWarnings("rawtypes")
 public class RelationalPathBase<T> extends BeanPath<T> implements RelationalPath<T> {
-    
+
     private static final long serialVersionUID = -7031357250283629202L;
-    
+
     @Nullable
     private PrimaryKey<T> primaryKey;
-    
+
     private final List<Path<?>> columns = new ArrayList<Path<?>>();
-    
+
+    private final Map<Path<?>, ColumnMetadata> metadata = Maps.newHashMap();
+
     private final List<ForeignKey<?>> foreignKeys = new ArrayList<ForeignKey<?>>();
-    
+
     private final List<ForeignKey<?>> inverseForeignKeys = new ArrayList<ForeignKey<?>>();
-    
+
     private final String schema, table;
-    
+
     private transient FactoryExpression<T> projection;
 
     public RelationalPathBase(Class<? extends T> type, String variable, String schema, String table) {
         this(type, PathMetadataFactory.forVariable(variable), schema, table);
     }
 
-    public RelationalPathBase(Class<? extends T> type, PathMetadata<?> metadata, String schema, String table) {
+    public RelationalPathBase(Class<? extends T> type, PathMetadata<?> metadata, String schema,
+            String table) {
         super(type, metadata);
         this.schema = schema;
         this.table = table;
@@ -65,53 +79,99 @@ public class RelationalPathBase<T> extends BeanPath<T> implements RelationalPath
         primaryKey = new PrimaryKey<T>(this, columns);
         return primaryKey;
     }
-    
+
     protected <F> ForeignKey<F> createForeignKey(Path<?> local, String foreign) {
         ForeignKey<F> foreignKey = new ForeignKey<F>(this, local, foreign);
         foreignKeys.add(foreignKey);
         return foreignKey;
     }
-    
-    protected <F> ForeignKey<F> createForeignKey(List<? extends Path<?>> local, 
-            List<String> foreign) {
+
+    protected <F> ForeignKey<F> createForeignKey(List<? extends Path<?>> local, List<String> foreign) {
         ForeignKey<F> foreignKey = new ForeignKey<F>(this, copyOf(local), copyOf(foreign));
         foreignKeys.add(foreignKey);
         return foreignKey;
     }
-    
+
     protected <F> ForeignKey<F> createInvForeignKey(Path<?> local, String foreign) {
         ForeignKey<F> foreignKey = new ForeignKey<F>(this, local, foreign);
         inverseForeignKeys.add(foreignKey);
         return foreignKey;
     }
-    
-    protected <F> ForeignKey<F> createInvForeignKey(List<? extends Path<?>> local, 
+
+    protected <F> ForeignKey<F> createInvForeignKey(List<? extends Path<?>> local,
             List<String> foreign) {
         ForeignKey<F> foreignKey = new ForeignKey<F>(this, copyOf(local), copyOf(foreign));
         inverseForeignKeys.add(foreignKey);
         return foreignKey;
     }
-    
+
+    protected StringPath createStringColumn(String name, ColumnMetadata metadata) {
+        StringPath stringPath = createString(name);
+        this.metadata.put(stringPath, metadata);
+        return stringPath;
+    }
+
+    protected BooleanPath createBooleanColumn(String property, ColumnMetadata metadata) {
+        BooleanPath booleanPath = createBoolean(property);
+        this.metadata.put(booleanPath, metadata);
+        return booleanPath;
+    }
+
+    protected <A extends Comparable> DatePath<A> createDateColumn(String property,
+            Class<? super A> type, ColumnMetadata metadata) {
+        DatePath<A> datePath = createDate(property, type);
+        this.metadata.put(datePath, metadata);
+        return datePath;
+    }
+
+    protected <A extends Comparable> DateTimePath<A> createDateTimeColumn(String property,
+            Class<? super A> type, ColumnMetadata metadata) {
+        DateTimePath<A> dateTimePath = createDateTime(property, type);
+        this.metadata.put(dateTimePath, metadata);
+        return dateTimePath;
+    }
+
+    protected <A extends Comparable> TimePath<A> createTimeColumn(String property,
+            Class<? super A> type, ColumnMetadata metadata) {
+        TimePath<A> timePath = createTime(property, type);
+        this.metadata.put(timePath, metadata);
+        return timePath;
+    }
+
+    protected <A extends Enum<A>> EnumPath<A> createEnumColumn(String property, Class<A> type,
+            ColumnMetadata metadata) {
+        EnumPath<A> enumPath = createEnum(property, type);
+        this.metadata.put(enumPath, metadata);
+        return enumPath;
+    }
+
+    protected <A extends Number & Comparable<?>> NumberPath<A> createNumberColumn(String property,
+            Class<? super A> type, ColumnMetadata metadata) {
+        NumberPath<A> numberPath = createNumber(property, type);
+        this.metadata.put(numberPath, metadata);
+        return numberPath;
+    }
+
     @Override
     public FactoryExpression<T> getProjection() {
         if (projection == null) {
-            projection = RelationalPathUtils.createProjection(this);  
+            projection = RelationalPathUtils.createProjection(this);
         }
-        return projection;        
+        return projection;
     }
-    
+
     public Path<?>[] all() {
         Path<?>[] all = new Path[columns.size()];
         columns.toArray(all);
         return all;
     }
-    
+
     @Override
     protected <P extends Path<?>> P add(P path) {
         columns.add(path);
         return path;
     }
-    
+
     @Override
     public List<Path<?>> getColumns() {
         return columns;
@@ -136,10 +196,15 @@ public class RelationalPathBase<T> extends BeanPath<T> implements RelationalPath
     public String getSchemaName() {
         return schema;
     }
-    
+
     @Override
     public String getTableName() {
         return table;
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(Path<?> column) {
+        return metadata.get(column);
     }
 
 }

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLSerializer.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLSerializer.java
@@ -93,7 +93,7 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
     }
 
     private void appendAsColumnName(Path<?> path) {
-        final String column = path.getMetadata().getName();
+    	String column = ColumnMetadata.getColumnMetadata(path).getName();
         append(templates.quoteIdentifier(column));
     }
 
@@ -637,7 +637,7 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
             visit(metadata.getParent(), context);
             append(".");
         }
-        append(templates.quoteIdentifier(metadata.getName()));
+        appendAsColumnName(path);
         return null;
     }
 

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/dml/AnnotationMapper.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/dml/AnnotationMapper.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import com.mysema.query.QueryException;
 import com.mysema.query.sql.Column;
+import com.mysema.query.sql.ColumnMetadata;
 import com.mysema.query.sql.RelationalPath;
 import com.mysema.query.sql.types.Null;
 import com.mysema.query.types.Path;
@@ -51,7 +52,7 @@ public class AnnotationMapper implements Mapper<Object> {
         try {
             Map<String, Path<?>> columnToPath = new HashMap<String, Path<?>>();
             for (Path<?> column : path.getColumns()) {
-                columnToPath.put(column.getMetadata().getName(), column);
+                columnToPath.put(ColumnMetadata.getColumnMetadata(column).getName(), column);
             }
             Map<Path<?>, Object> values = new HashMap<Path<?>, Object>();        
             for (Field field : ReflectionUtils.getFields(object.getClass())) {

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/dml/SQLInsertClause.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/dml/SQLInsertClause.java
@@ -36,6 +36,7 @@ import com.mysema.query.QueryFlag.Position;
 import com.mysema.query.QueryMetadata;
 import com.mysema.query.dml.InsertClause;
 import com.mysema.query.sql.AbstractSQLSubQuery;
+import com.mysema.query.sql.ColumnMetadata;
 import com.mysema.query.sql.Configuration;
 import com.mysema.query.sql.RelationalPath;
 import com.mysema.query.sql.SQLSerializer;
@@ -50,11 +51,12 @@ import com.mysema.util.ResultSetAdapter;
 
 /**
  * SQLInsertClause defines an INSERT INTO clause
- *
+ * 
  * @author tiwe
- *
+ * 
  */
-public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implements InsertClause<SQLInsertClause> {
+public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implements
+        InsertClause<SQLInsertClause> {
 
     private static final Logger logger = LoggerFactory.getLogger(SQLInsertClause.class);
 
@@ -88,13 +90,14 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
         this.subQueryBuilder = subQuery;
     }
 
-    public SQLInsertClause(Connection connection, Configuration configuration, RelationalPath<?> entity,
-            AbstractSQLSubQuery<?> subQuery) {
+    public SQLInsertClause(Connection connection, Configuration configuration,
+            RelationalPath<?> entity, AbstractSQLSubQuery<?> subQuery) {
         this(connection, configuration, entity);
         this.subQueryBuilder = subQuery;
     }
 
-    public SQLInsertClause(Connection connection, Configuration configuration, RelationalPath<?> entity) {
+    public SQLInsertClause(Connection connection, Configuration configuration,
+            RelationalPath<?> entity) {
         super(configuration);
         this.connection = connection;
         this.entity = entity;
@@ -103,7 +106,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
 
     /**
      * Add the given String literal at the given position as a query flag
-     *
+     * 
      * @param position
      * @param flag
      * @return
@@ -115,7 +118,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
 
     /**
      * Add the given Expression at the given position as a query flag
-     *
+     * 
      * @param position
      * @param flag
      * @return
@@ -125,10 +128,9 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
         return this;
     }
 
-
     /**
      * Add the current state of bindings as a batch item
-     *
+     * 
      * @return
      */
     public SQLInsertClause addBatch() {
@@ -150,9 +152,10 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
     }
 
     /**
-     * Execute the clause and return the generated key with the type of the given path.
-     * If no rows were created, null is returned, otherwise the key of the first row is returned.
-     *
+     * Execute the clause and return the generated key with the type of the
+     * given path. If no rows were created, null is returned, otherwise the key
+     * of the first row is returned.
+     * 
      * @param <T>
      * @param path
      * @return
@@ -160,13 +163,14 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
     @SuppressWarnings("unchecked")
     @Nullable
     public <T> T executeWithKey(Path<T> path) {
-        return executeWithKey((Class<T>)path.getType(), path);
+        return executeWithKey((Class<T>) path.getType(), path);
     }
 
     /**
      * Execute the clause and return the generated key cast to the given type.
-     * If no rows were created, null is returned, otherwise the key of the first row is returned.
-     *
+     * If no rows were created, null is returned, otherwise the key of the first
+     * row is returned.
+     * 
      * @param <T>
      * @param type
      * @return
@@ -177,7 +181,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
 
     private <T> T executeWithKey(Class<T> type, @Nullable Path<T> path) {
         ResultSet rs = executeWithKeys();
-        try{
+        try {
             if (rs.next()) {
                 return configuration.get(rs, path, 1, type);
             } else {
@@ -185,23 +189,24 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
             }
         } catch (SQLException e) {
             throw new QueryException(e.getMessage(), e);
-        }finally{
+        } finally {
             close(rs);
         }
     }
 
     /**
-     * Execute the clause and return the generated key with the type of the given path.
-     * If no rows were created, or the referenced column is not a generated key, null is returned.
-     * Otherwise, the key of the first row is returned.
-     *
+     * Execute the clause and return the generated key with the type of the
+     * given path. If no rows were created, or the referenced column is not a
+     * generated key, null is returned. Otherwise, the key of the first row is
+     * returned.
+     * 
      * @param <T>
      * @param path
      * @return
      */
     @SuppressWarnings("unchecked")
     public <T> List<T> executeWithKeys(Path<T> path) {
-        return executeWithKeys((Class<T>)path.getType(), path);
+        return executeWithKeys((Class<T>) path.getType(), path);
     }
 
     public <T> List<T> executeWithKeys(Class<T> type) {
@@ -210,7 +215,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
 
     private <T> List<T> executeWithKeys(Class<T> type, @Nullable Path<T> path) {
         ResultSet rs = executeWithKeys();
-        try{
+        try {
             List<T> rv = new ArrayList<T>();
             while (rs.next()) {
                 rv.add(configuration.get(rs, path, 1, type));
@@ -218,12 +223,12 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
             return rv;
         } catch (SQLException e) {
             throw new QueryException(e.getMessage(), e);
-        }finally{
+        } finally {
             close(rs);
         }
     }
 
-    private PreparedStatement createStatement(boolean withKeys) throws SQLException{
+    private PreparedStatement createStatement(boolean withKeys) throws SQLException {
         SQLSerializer serializer = new SQLSerializer(configuration, true);
         if (subQueryBuilder != null) {
             subQuery = subQueryBuilder.list(values.toArray(new Expression[values.size()]));
@@ -234,8 +239,8 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
             serializer.serializeForInsert(metadata, entity, columns, values, subQuery);
             stmt = prepareStatementAndSetParameters(serializer, withKeys);
         } else {
-            serializer.serializeForInsert(metadata, entity, batches.get(0).getColumns(),
-                    batches.get(0).getValues(), batches.get(0).getSubQuery());
+            serializer.serializeForInsert(metadata, entity, batches.get(0).getColumns(), batches
+                    .get(0).getValues(), batches.get(0).getSubQuery());
             stmt = prepareStatementAndSetParameters(serializer, withKeys);
 
             // add first batch
@@ -245,8 +250,10 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
             for (int i = 1; i < batches.size(); i++) {
                 SQLInsertBatch batch = batches.get(i);
                 serializer = new SQLSerializer(configuration, true);
-                serializer.serializeForInsert(metadata, entity, batch.getColumns(), batch.getValues(), batch.getSubQuery());
-                setParameters(stmt, serializer.getConstants(), serializer.getConstantPaths(), metadata.getParams());
+                serializer.serializeForInsert(metadata, entity, batch.getColumns(),
+                        batch.getValues(), batch.getSubQuery());
+                setParameters(stmt, serializer.getConstants(), serializer.getConstantPaths(),
+                        metadata.getParams());
                 stmt.addBatch();
             }
         }
@@ -262,7 +269,9 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
             if (entity.getPrimaryKey() != null) {
                 String[] target = new String[entity.getPrimaryKey().getLocalColumns().size()];
                 for (int i = 0; i < target.length; i++) {
-                    target[i] = entity.getPrimaryKey().getLocalColumns().get(i).getMetadata().getName();
+                    Path<?> path = entity.getPrimaryKey().getLocalColumns().get(i);
+                    String column = ColumnMetadata.getColumnMetadata(path).getName();
+                    target[i] = column;
                 }
                 stmt = connection.prepareStatement(queryString, target);
             } else {
@@ -271,13 +280,14 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
         } else {
             stmt = connection.prepareStatement(queryString);
         }
-        setParameters(stmt, serializer.getConstants(), serializer.getConstantPaths(), metadata.getParams());
+        setParameters(stmt, serializer.getConstants(), serializer.getConstantPaths(),
+                metadata.getParams());
         return stmt;
     }
 
     /**
      * Execute the clause and return the generated keys as a ResultSet
-     *
+     * 
      * @return
      */
     public ResultSet executeWithKeys() {
@@ -300,7 +310,8 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
                 }
             };
         } catch (SQLException e) {
-            throw new QueryException("Caught " + e.getClass().getSimpleName() + " for " + queryString, e);
+            throw new QueryException("Caught " + e.getClass().getSimpleName() + " for "
+                    + queryString, e);
         }
     }
 
@@ -315,7 +326,8 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
                 return executeBatch(stmt);
             }
         } catch (SQLException e) {
-            throw new QueryException("Caught " + e.getClass().getSimpleName() + " for " + queryString, e);
+            throw new QueryException("Caught " + e.getClass().getSimpleName() + " for "
+                    + queryString, e);
         } finally {
             if (stmt != null) {
                 close(stmt);
@@ -327,7 +339,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
     public SQLInsertClause select(SubQueryExpression<?> sq) {
         subQuery = sq;
         for (Map.Entry<ParamExpression<?>, Object> entry : sq.getMetadata().getParams().entrySet()) {
-            metadata.setParam((ParamExpression)entry.getKey(), entry.getValue());
+            metadata.setParam((ParamExpression) entry.getKey(), entry.getValue());
         }
         return this;
     }
@@ -336,7 +348,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
     public <T> SQLInsertClause set(Path<T> path, T value) {
         columns.add(path);
         if (value instanceof Expression<?>) {
-            values.add((Expression<?>)value);
+            values.add((Expression<?>) value);
         } else if (value != null) {
             values.add(new ConstantImpl<T>(value));
         } else {
@@ -381,9 +393,9 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
     }
 
     /**
-     * Populate the INSERT clause with the properties of the given bean.
-     * The properties need to match the fields of the clause's entity instance.
-     *
+     * Populate the INSERT clause with the properties of the given bean. The
+     * properties need to match the fields of the clause's entity instance.
+     * 
      * @param bean
      * @return
      */
@@ -392,8 +404,9 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
     }
 
     /**
-     * Populate the INSERT clause with the properties of the given bean using the given Mapper.
-     *
+     * Populate the INSERT clause with the properties of the given bean using
+     * the given Mapper.
+     * 
      * @param obj
      * @param mapper
      * @return
@@ -402,7 +415,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
     public <T> SQLInsertClause populate(T obj, Mapper<T> mapper) {
         Map<Path<?>, Object> values = mapper.createMap(entity, obj);
         for (Map.Entry<Path<?>, Object> entry : values.entrySet()) {
-            set((Path)entry.getKey(), entry.getValue());
+            set((Path) entry.getKey(), entry.getValue());
         }
         return this;
     }

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/dml/SQLMergeClause.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/dml/SQLMergeClause.java
@@ -33,6 +33,7 @@ import com.mysema.query.QueryFlag;
 import com.mysema.query.QueryFlag.Position;
 import com.mysema.query.QueryMetadata;
 import com.mysema.query.dml.StoreClause;
+import com.mysema.query.sql.ColumnMetadata;
 import com.mysema.query.sql.Configuration;
 import com.mysema.query.sql.RelationalPath;
 import com.mysema.query.sql.SQLQuery;
@@ -336,7 +337,7 @@ public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements
         if (withKeys) {
             String[] target = new String[keys.size()];
             for (int i = 0; i < target.length; i++) {
-                target[i] = keys.get(i).getMetadata().getName();
+                target[i] = ColumnMetadata.getColumnMetadata(keys.get(i)).getName();
             }
             stmt = connection.prepareStatement(queryString, target);
         } else {

--- a/querydsl-sql/src/test/java/com/mysema/query/ColumnMetadataTest.java
+++ b/querydsl-sql/src/test/java/com/mysema/query/ColumnMetadataTest.java
@@ -1,0 +1,102 @@
+package com.mysema.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Types;
+
+import org.junit.Test;
+
+import com.mysema.query.sql.ColumnMetadata;
+import com.mysema.query.sql.domain.QEmployee;
+
+public class ColumnMetadataTest {
+
+    @Test
+    public void defaultColumn() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        assertEquals("Person", column.getName());
+        assertFalse(column.hasJdbcType());
+        assertFalse(column.hasLength());
+        assertFalse(column.hasPrecisionAndScale());
+        assertTrue(column.isInsertable());
+        assertTrue(column.isUpdateable());
+        assertTrue(column.isNullable());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void exceptionOnMissingType() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.getJdbcType();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void exceptionOnMissingLength() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.getLength();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void exceptionOnMissingPrecision() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.getPrecision();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void exceptionOnMissingScale() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.getScale();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void notBothPrecisionAndLength() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.withlength(1).withPrecisionAndScale(1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void lengthMustBePositive() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.withlength(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void scaleMustBePositive() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.withPrecisionAndScale(1, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void precisionMustBePositive() {
+        ColumnMetadata column = ColumnMetadata.named("Person");
+        column.withPrecisionAndScale(-1, 1);
+    }
+
+    @Test
+    public void testFullyConfigured() {
+        ColumnMetadata column = ColumnMetadata.named("Person").withlength(10).nonInsertable()
+                .nonUpdateable().notNull().ofType(Types.BIGINT);
+        assertEquals("Person", column.getName());
+        assertTrue(column.hasJdbcType());
+        assertEquals(Types.BIGINT, column.getJdbcType());
+        assertTrue(column.hasLength());
+        assertEquals(10, column.getLength());
+        assertFalse(column.hasPrecisionAndScale());
+        assertFalse(column.isInsertable());
+        assertFalse(column.isUpdateable());
+        assertFalse(column.isNullable());
+    }
+
+    @Test
+    public void extractFromRelationalPath() {
+        ColumnMetadata column = ColumnMetadata.getColumnMetadata(QEmployee.employee.id);
+        assertEquals("ID", column.getName());
+    }
+
+    @Test
+    public void fallBackToDefaultWhenMissing() {
+        ColumnMetadata column = ColumnMetadata.getColumnMetadata(QEmployee.employee.salary);
+        assertEquals("SALARY", column.getName());
+    }
+}

--- a/querydsl-sql/src/test/java/com/mysema/query/sql/ForeignKeyTest.java
+++ b/querydsl-sql/src/test/java/com/mysema/query/sql/ForeignKeyTest.java
@@ -34,7 +34,7 @@ public class ForeignKeyTest {
         foreignKey = new ForeignKey<Employee>(employee, 
                ImmutableList.of(employee.superiorId, employee.firstname), 
                ImmutableList.of("ID", "FN"));
-        assertEquals("employee.SUPERIOR_ID = employee2.ID && employee.FIRSTNAME = employee2.FN", foreignKey.on(employee2).toString());
+        assertEquals("employee.SUPERIOR_ID = employee2.ID && employee.firstname = employee2.FN", foreignKey.on(employee2).toString());
     }
 
 }

--- a/querydsl-sql/src/test/java/com/mysema/query/sql/domain/QEmployee.java
+++ b/querydsl-sql/src/test/java/com/mysema/query/sql/domain/QEmployee.java
@@ -15,6 +15,7 @@ package com.mysema.query.sql.domain;
 
 import java.math.BigDecimal;
 
+import com.mysema.query.sql.ColumnMetadata;
 import com.mysema.query.sql.ForeignKey;
 import com.mysema.query.sql.PrimaryKey;
 import com.mysema.query.sql.RelationalPathBase;
@@ -33,9 +34,9 @@ public class QEmployee extends RelationalPathBase<Employee> {
     
     public static final QEmployee employee = new QEmployee("EMPLOYEE");
 
-    public final NumberPath<Integer> id = createNumber("ID", Integer.class);
+    public final NumberPath<Integer> id = createNumberColumn("id", Integer.class, ColumnMetadata.named("ID"));
 
-    public final StringPath firstname = createString("FIRSTNAME");
+    public final StringPath firstname = createStringColumn("firstname", ColumnMetadata.named("FIRSTNAME"));
 
     public final StringPath lastname = createString("LASTNAME");
 


### PR DESCRIPTION
Since the possible need for column meta data arose in several tickets (See #283 and #468), I have come up with a largely backwards compatible way of getting it in.

The only incompatible change is the addition of a method to RelationalPath. Even if someone implemented this interface directly, the fix would be trivial.

Otherwise the change is noninvasive since it behaves as before when no column meta data is specified.
