### PR TITLE
Improved exception message in case, no valid constructor was found.

### DIFF
--- a/querydsl-core/src/main/java/com/mysema/query/types/ConstructorExpression.java
+++ b/querydsl-core/src/main/java/com/mysema/query/types/ConstructorExpression.java
@@ -70,7 +70,15 @@ public class ConstructorExpression<T> extends ExpressionBase<T> implements Facto
                 }
             }
         }
-        throw new ExpressionException("Got no matching constructor");
+        // prepare error message
+        final StringBuilder formattedTypes = new StringBuilder();
+        for(Class<?> typ : givenTypes) {
+            if(formattedTypes.length() > 0) {
+                formattedTypes.append(", ");
+            }
+            formattedTypes.append(typ.getName());
+        }
+        throw new ExpressionException("Got no matching constructor. Class: " + type.getName() +", Parameters: " + formattedTypes.toString());
     }
 
     public static <D> ConstructorExpression<D> create(Class<D> type, Expression<?>... args) {


### PR DESCRIPTION
Quick patch, I made while debugging some issues with some hand-written Q-classes (in Scala BTW). Not sure, If there are any mkString utility methods around, that's why the StringBuilded was used.

Best Regards,
Tobias
