### PR TITLE
Allow explicit SQL joins to expressions

### DIFF
--- a/querydsl-jdo/src/main/java/com/mysema/query/jdo/sql/AbstractSQLQuery.java
+++ b/querydsl-jdo/src/main/java/com/mysema/query/jdo/sql/AbstractSQLQuery.java
@@ -33,12 +33,7 @@ import com.mysema.query.sql.WithBuilder;
 import com.mysema.query.support.Expressions;
 import com.mysema.query.support.ProjectableQuery;
 import com.mysema.query.support.QueryMixin;
-import com.mysema.query.types.Expression;
-import com.mysema.query.types.ExpressionUtils;
-import com.mysema.query.types.OperationImpl;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.Predicate;
-import com.mysema.query.types.SubQueryExpression;
+import com.mysema.query.types.*;
 import com.mysema.query.types.expr.Wildcard;
 import com.mysema.query.types.query.ListSubQuery;
 import com.mysema.query.types.template.NumberTemplate;
@@ -93,11 +88,11 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & com.mysem
     @Override
     @SuppressWarnings("unchecked")
     public T from(SubQueryExpression<?> subQuery, Path<?> alias) {
-        return queryMixin.from(ExpressionUtils.as((Expression)subQuery, alias));
+        return queryMixin.from(ExpressionUtils.as((Expression) subQuery, alias));
     }
 
     @Override
-    public T fullJoin(RelationalPath<?> o) {
+    public T fullJoin(EntityPath<?> o) {
         return queryMixin.fullJoin(o);
     }
 
@@ -121,7 +116,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & com.mysem
     }
 
     @Override
-    public T innerJoin(RelationalPath<?> o) {
+    public T innerJoin(EntityPath<?> o) {
         return queryMixin.innerJoin(o);
     }
 
@@ -141,7 +136,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & com.mysem
     }
 
     @Override
-    public T join(RelationalPath<?> o) {
+    public T join(EntityPath<?> o) {
         return queryMixin.join(o);
     }
 
@@ -161,7 +156,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & com.mysem
     }
 
     @Override
-    public T leftJoin(RelationalPath<?> o) {
+    public T leftJoin(EntityPath<?> o) {
         return queryMixin.leftJoin(o);
     }
 
@@ -190,7 +185,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & com.mysem
     }
 
     @Override
-    public T rightJoin(RelationalPath<?> o) {
+    public T rightJoin(EntityPath<?> o) {
         return queryMixin.rightJoin(o);
     }
 

--- a/querydsl-jpa/src/main/java/com/mysema/query/jpa/AbstractSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/mysema/query/jpa/AbstractSQLQuery.java
@@ -33,12 +33,7 @@ import com.mysema.query.sql.WithBuilder;
 import com.mysema.query.support.Expressions;
 import com.mysema.query.support.ProjectableQuery;
 import com.mysema.query.support.QueryMixin;
-import com.mysema.query.types.Expression;
-import com.mysema.query.types.ExpressionUtils;
-import com.mysema.query.types.OperationImpl;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.Predicate;
-import com.mysema.query.types.SubQueryExpression;
+import com.mysema.query.types.*;
 import com.mysema.query.types.expr.Wildcard;
 import com.mysema.query.types.query.ListSubQuery;
 import com.mysema.query.types.template.NumberTemplate;
@@ -101,11 +96,11 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & Query<T>>
     @Override
     @SuppressWarnings("unchecked")
     public T from(SubQueryExpression<?> subQuery, Path<?> alias) {
-        return queryMixin.from(ExpressionUtils.as((Expression)subQuery, alias));
+        return queryMixin.from(ExpressionUtils.as((Expression) subQuery, alias));
     }
 
     @Override
-    public T fullJoin(RelationalPath<?> o) {
+    public T fullJoin(EntityPath<?> o) {
         return queryMixin.fullJoin(o);
     }
 
@@ -129,7 +124,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & Query<T>>
     }
 
     @Override
-    public T innerJoin(RelationalPath<?> o) {
+    public T innerJoin(EntityPath<?> o) {
         return queryMixin.innerJoin(o);
     }
 
@@ -149,7 +144,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & Query<T>>
     }
 
     @Override
-    public T join(RelationalPath<?> o) {
+    public T join(EntityPath<?> o) {
         return queryMixin.join(o);
     }
 
@@ -169,7 +164,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & Query<T>>
     }
 
     @Override
-    public T leftJoin(RelationalPath<?> o) {
+    public T leftJoin(EntityPath<?> o) {
         return queryMixin.leftJoin(o);
     }
 
@@ -198,7 +193,7 @@ public abstract class AbstractSQLQuery<T extends AbstractSQLQuery<T> & Query<T>>
     }
 
     @Override
-    public T rightJoin(RelationalPath<?> o) {
+    public T rightJoin(EntityPath<?> o) {
         return queryMixin.rightJoin(o);
     }
 

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/AbstractSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/AbstractSQLQuery.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import com.mysema.query.types.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,16 +43,6 @@ import com.mysema.query.Tuple;
 import com.mysema.query.support.Expressions;
 import com.mysema.query.support.ProjectableQuery;
 import com.mysema.query.support.QueryMixin;
-import com.mysema.query.types.Expression;
-import com.mysema.query.types.ExpressionUtils;
-import com.mysema.query.types.FactoryExpression;
-import com.mysema.query.types.OperationImpl;
-import com.mysema.query.types.ParamExpression;
-import com.mysema.query.types.ParamNotSetException;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.Predicate;
-import com.mysema.query.types.QTuple;
-import com.mysema.query.types.SubQueryExpression;
 import com.mysema.query.types.query.ListSubQuery;
 import com.mysema.query.types.template.NumberTemplate;
 import com.mysema.query.types.template.SimpleTemplate;
@@ -243,11 +234,11 @@ public abstract class AbstractSQLQuery<Q extends AbstractSQLQuery<Q> & Query<Q>>
     @Override
     @SuppressWarnings("unchecked")
     public Q from(SubQueryExpression<?> subQuery, Path<?> alias) {
-        return queryMixin.from(ExpressionUtils.as((Expression)subQuery, alias));
+        return queryMixin.from(ExpressionUtils.as((Expression) subQuery, alias));
     }
 
     @Override
-    public Q fullJoin(RelationalPath<?> target) {
+    public Q fullJoin(EntityPath<?> target) {
         return queryMixin.fullJoin(target);
     }
 
@@ -267,7 +258,7 @@ public abstract class AbstractSQLQuery<Q extends AbstractSQLQuery<Q> & Query<Q>>
     }
 
     @Override
-    public Q innerJoin(RelationalPath<?> target) {
+    public Q innerJoin(EntityPath<?> target) {
         return queryMixin.innerJoin(target);
     }
 
@@ -287,7 +278,7 @@ public abstract class AbstractSQLQuery<Q extends AbstractSQLQuery<Q> & Query<Q>>
     }
 
     @Override
-    public Q join(RelationalPath<?> target) {
+    public Q join(EntityPath<?> target) {
         return queryMixin.join(target);
     }
 
@@ -307,7 +298,7 @@ public abstract class AbstractSQLQuery<Q extends AbstractSQLQuery<Q> & Query<Q>>
     }
 
     @Override
-    public Q leftJoin(RelationalPath<?> target) {
+    public Q leftJoin(EntityPath<?> target) {
         return queryMixin.leftJoin(target);
     }
 
@@ -327,7 +318,7 @@ public abstract class AbstractSQLQuery<Q extends AbstractSQLQuery<Q> & Query<Q>>
     }
 
     @Override
-    public Q rightJoin(RelationalPath<?> target) {
+    public Q rightJoin(EntityPath<?> target) {
         return queryMixin.rightJoin(target);
     }
 

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/AbstractSQLSubQuery.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/AbstractSQLSubQuery.java
@@ -21,13 +21,7 @@ import com.mysema.query.QueryMetadata;
 import com.mysema.query.support.DetachableQuery;
 import com.mysema.query.support.Expressions;
 import com.mysema.query.support.QueryMixin;
-import com.mysema.query.types.Expression;
-import com.mysema.query.types.ExpressionUtils;
-import com.mysema.query.types.OperationImpl;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.Predicate;
-import com.mysema.query.types.SubQueryExpression;
-import com.mysema.query.types.TemplateExpressionImpl;
+import com.mysema.query.types.*;
 
 /**
  * Abstract superclass for SubQuery implementations
@@ -130,7 +124,7 @@ public class AbstractSQLSubQuery<Q extends AbstractSQLSubQuery<Q>> extends Detac
     }
 
     @Override
-    public Q fullJoin(RelationalPath<?> target) {
+    public Q fullJoin(EntityPath<?> target) {
         return queryMixin.fullJoin(target);
     }
 
@@ -150,7 +144,7 @@ public class AbstractSQLSubQuery<Q extends AbstractSQLSubQuery<Q>> extends Detac
     }
 
     @Override
-    public Q innerJoin(RelationalPath<?> target) {
+    public Q innerJoin(EntityPath<?> target) {
         return queryMixin.innerJoin(target);
     }
 
@@ -170,7 +164,7 @@ public class AbstractSQLSubQuery<Q extends AbstractSQLSubQuery<Q>> extends Detac
     }
 
     @Override
-    public Q join(RelationalPath<?> target) {
+    public Q join(EntityPath<?> target) {
         return queryMixin.join(target);
     }
 
@@ -190,7 +184,7 @@ public class AbstractSQLSubQuery<Q extends AbstractSQLSubQuery<Q>> extends Detac
     }
 
     @Override
-    public Q leftJoin(RelationalPath<?> target) {
+    public Q leftJoin(EntityPath<?> target) {
         return queryMixin.leftJoin(target);
     }
 
@@ -219,7 +213,7 @@ public class AbstractSQLSubQuery<Q extends AbstractSQLSubQuery<Q>> extends Detac
     }
 
     @Override
-    public Q rightJoin(RelationalPath<?> target) {
+    public Q rightJoin(EntityPath<?> target) {
         return queryMixin.rightJoin(target);
     }
 

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLCommonQuery.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLCommonQuery.java
@@ -16,10 +16,7 @@ package com.mysema.query.sql;
 import com.mysema.query.JoinFlag;
 import com.mysema.query.Query;
 import com.mysema.query.QueryFlag.Position;
-import com.mysema.query.types.Expression;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.Predicate;
-import com.mysema.query.types.SubQueryExpression;
+import com.mysema.query.types.*;
 
 /**
  * SQLCommonQuery is a common interface for SQLQuery and SQLSubQuery
@@ -99,7 +96,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @param o
      * @return
      */
-    Q fullJoin(RelationalPath<?> o);
+    Q fullJoin(EntityPath<?> o);
 
     /**
      * Adds a full join to the given target
@@ -131,7 +128,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @param o
      * @return
      */
-    Q innerJoin(RelationalPath<?> o);
+    Q innerJoin(EntityPath<?> o);
 
     /**
      * Adds a full join to the given target
@@ -163,7 +160,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @param o
      * @return
      */
-    Q join(RelationalPath<?> o);
+    Q join(EntityPath<?> o);
 
     /**
      * Adds a full join to the given target
@@ -195,7 +192,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @param o
      * @return
      */
-    Q leftJoin(RelationalPath<?> o);
+    Q leftJoin(EntityPath<?> o);
 
     /**
      * Adds a full join to the given target
@@ -235,7 +232,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @param o
      * @return
      */
-    Q rightJoin(RelationalPath<?> o);
+    Q rightJoin(EntityPath<?> o);
 
     /**
      * Adds a full join to the given target


### PR DESCRIPTION
Currently you can join expressions (such as `Path` interface) only through implicit join in a `FROM` clause. Many database engines (e.g. PostgreSQL) have trouble with mixing explicit and implicit joins so the user should always have a choice between them.

Example use case:

```
final PathBuilder<Tuple> path = new PathBuilder<>(Tuple.class, "some_alias");
query.withRecursive(
    path,
    field1,
    field2
).as(
    sq().unionAll(
        someSubQuery,
        sq().from(someTable).join(path).on(...).leftJoin(...).on(...)
    )
)      
```

Explicit join in a subquery is required for it to work correctly on Postgres.
