### PR TITLE
fix a grammatical problem

### DIFF
--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
@@ -577,7 +577,7 @@ query.from(employee)
   <sect2>
     <title>Exposing the original query</title>
 
-    <para>If you need to do tune the original Query before the execution of the query you
+    <para>If you need to tune the original Query before the execution of the query you
       can expose it like this:
     </para>
 


### PR DESCRIPTION
This pull request just brings in a small correction of a grammatical problem in the JPA subquery part of the reference doc.
