### PR TITLE
Support for group expression nesting

### DIFF
--- a/querydsl-core/pom.xml
+++ b/querydsl-core/pom.xml
@@ -39,6 +39,26 @@
       <version>${cglib.version}</version>
     </dependency>
     
+     <!-- backwards compatibility -->
+    <dependency>
+      <groupId>com.infradna.tool</groupId>
+      <artifactId>bridge-method-annotation</artifactId>
+      <version>${bridge-method.version}</version>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>annotation-indexer</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet.hudson</groupId>
+      <artifactId>annotation-indexer</artifactId>
+      <version>1.2</version>
+      <optional>true</optional>
+    </dependency>
+    
     <!--  test -->    
     <dependency>
       <groupId>jdepend</groupId>
@@ -53,7 +73,38 @@
       <plugin>
         <groupId>com.springsource.bundlor</groupId>
         <artifactId>com.springsource.bundlor.maven</artifactId>
-      </plugin>    
+      </plugin>
+      <plugin>
+        <groupId>com.infradna.tool</groupId>
+        <artifactId>bridge-method-injector</artifactId>
+        <version>${bridge-method.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.infradna.tool</groupId>
+            <artifactId>bridge-method-annotation</artifactId>
+            <version>${bridge-method.version}</version>
+            <optional>true</optional>
+            <exclusions>
+              <exclusion>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>annotation-indexer</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.jvnet.hudson</groupId>
+            <artifactId>annotation-indexer</artifactId>
+            <version>1.2</version>
+          </dependency>
+        </dependencies>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -79,5 +130,8 @@
       </plugin>
     </plugins>
   </build>
-
+  
+  <properties>
+    <bridge-method.version>1.11</bridge-method.version>
+  </properties>
 </project>

--- a/querydsl-core/src/main/java/com/mysema/query/group/GMap.java
+++ b/querydsl-core/src/main/java/com/mysema/query/group/GMap.java
@@ -13,19 +13,14 @@
  */
 package com.mysema.query.group;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.mysema.commons.lang.Pair;
 
-/**
- * @author tiwe
- *
- * @param <K>
- * @param <V>
- */
 class GMap<K, V> extends AbstractGroupExpression<Pair<K, V>, Map<K, V>> {
-    
+
     private static final long serialVersionUID = 7106389414200843920L;
 
     public GMap(QPair<K,V> qpair) {
@@ -50,4 +45,73 @@ class GMap<K, V> extends AbstractGroupExpression<Pair<K, V>, Map<K, V>> {
             
         };
     }
+    
+    static class Mixin<K, V, T, U, R extends Map<? super T, ? super U>> extends AbstractGroupExpression<Pair<K, V>, R> {
+
+        private static final long serialVersionUID = 1939989270493531116L;
+
+        private class GroupCollectorImpl implements GroupCollector<Pair<K, V>, R> {
+            
+            private final GroupCollector<Pair<T, U>, R> groupCollector;
+            
+            private final Map<K, GroupCollector<K, T>> keyCollectors = new LinkedHashMap<K, GroupCollector<K, T>>();
+            
+            private final Map<GroupCollector<K, T>, GroupCollector<V, U>> valueCollectors = new HashMap<GroupCollector<K, T>, GroupCollector<V, U>>();
+            
+            public GroupCollectorImpl() {
+                this.groupCollector = mixin.createGroupCollector();
+            }
+            
+            @Override
+            public void add(Pair<K, V> pair) {
+                K first = pair.getFirst();
+                GroupCollector<K, T> keyCollector = keyCollectors.get(first);
+                if (keyCollector == null) {
+                    keyCollector = keyExpression.createGroupCollector();
+                    keyCollectors.put(first, keyCollector);
+                }
+                keyCollector.add(first);
+                GroupCollector<V, U> valueCollector = valueCollectors.get(keyCollector);
+                if (valueCollector == null) {
+                    valueCollector = valueExpression.createGroupCollector();
+                    valueCollectors.put(keyCollector, valueCollector);
+                } 
+                V second = pair.getSecond();
+                valueCollector.add(second);
+            }
+
+            @Override
+            public R get() {
+                for (GroupCollector<K, T> keyCollector : keyCollectors.values()) {
+                    T key = keyCollector.get();
+                    GroupCollector<V, U> valueCollector = valueCollectors.remove(keyCollector);
+                    U value = valueCollector.get();
+                    groupCollector.add(Pair.of(key, value));
+                }
+                keyCollectors.clear();
+                return groupCollector.get();
+            }
+
+        }
+        
+        private final GroupExpression<Pair<T, U>, R> mixin;
+        
+        private final GroupExpression<K, T> keyExpression;
+        private final GroupExpression<V, U> valueExpression;
+        
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        public Mixin(GroupExpression<K, T> keyExpression, GroupExpression<V, U> valueExpression, AbstractGroupExpression<Pair<T, U>, R> mixin) {
+            super((Class) mixin.getType(), QPair.create(keyExpression.getExpression(), valueExpression.getExpression()));
+            this.keyExpression = keyExpression;
+            this.valueExpression = valueExpression;
+            this.mixin = mixin;
+        }
+
+        @Override
+        public GroupCollector<Pair<K, V>, R> createGroupCollector() {
+            return new GroupCollectorImpl();
+        }
+        
+    }
+
 }

--- a/querydsl-core/src/main/java/com/mysema/query/group/MixinGroupExpression.java
+++ b/querydsl-core/src/main/java/com/mysema/query/group/MixinGroupExpression.java
@@ -1,0 +1,53 @@
+package com.mysema.query.group;
+
+public class MixinGroupExpression<E, F, R> extends AbstractGroupExpression<E, R> {
+    
+    private static final long serialVersionUID = -5419707469727395643L;
+
+    private class GroupCollectorImpl implements GroupCollector<E, R> {
+       
+        private final GroupCollector<F, R> mixinGroupCollector;
+        
+        private GroupCollector<E, F> groupCollector;
+        
+        public GroupCollectorImpl() {
+            mixinGroupCollector = mixin.createGroupCollector();
+        }
+        
+        public void add(E input) {
+            if (groupCollector == null) {
+                groupCollector = groupExpression.createGroupCollector();
+            }
+            groupCollector.add(input);
+        }
+        
+        
+        @Override
+        public R get() {
+            if (groupCollector != null) {
+                F output = groupCollector.get();
+                mixinGroupCollector.add(output);
+                groupCollector = null;
+            }
+            return mixinGroupCollector.get();
+        }
+
+    }
+
+    private final GroupExpression<F, R> mixin;
+    
+    private final GroupExpression<E, F> groupExpression;
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public MixinGroupExpression(GroupExpression<E, F> groupExpression, GroupExpression<F, R> mixin) {
+        super((Class) mixin.getType(), groupExpression.getExpression());
+        this.mixin = mixin;
+        this.groupExpression = groupExpression;
+    }
+
+    @Override
+    public GroupCollector<E, R> createGroupCollector() {
+        return new GroupCollectorImpl();
+    } 
+    
+}

--- a/querydsl-core/src/test/java/com/mysema/query/group/AbstractGroupByTest.java
+++ b/querydsl-core/src/test/java/com/mysema/query/group/AbstractGroupByTest.java
@@ -23,6 +23,94 @@ import com.mysema.query.types.path.StringPath;
 
 public abstract class AbstractGroupByTest {
 
+    protected static final Projectable BASIC_RESULTS = projectable(
+            row(null, "null post", 7, "comment 7"),
+            row(null, "null post", 8, "comment 8"),
+            row(1, "post 1", 1, "comment 1"),
+            row(1, "post 1", 2, "comment 2"),
+            row(1, "post 1", 3, "comment 3"),
+            row(2, "post 2", 4, "comment 4"),
+            row(2, "post 2", 5, "comment 5"),
+            row(3, "post 3", 6, "comment 6")
+    );
+
+    protected static final Projectable MAP_RESULTS = projectable(
+            row(null, "null post", pair(7, "comment 7")),
+            row(null, "null post", pair(8, "comment 8")),
+            row(1, "post 1", pair(1, "comment 1")),
+            row(1, "post 1", pair(2, "comment 2")),
+            row(1, "post 1", pair(3, "comment 3")),
+            row(2, "post 2", pair(5, "comment 5")),
+            row(3, "post 3", pair(6, "comment 6"))
+    );
+
+    protected static final Projectable MAP2_RESULTS = projectable(
+            row(null, pair(7, "comment 7")),
+            row(null,  pair(8, "comment 8")),
+            row(1, pair(1, "comment 1")),
+            row(1, pair(2, "comment 2")),
+            row(1, pair(3, "comment 3")),
+            row(2, pair(5, "comment 5")),
+            row(3, pair(6, "comment 6"))
+    );
+
+    protected static final Projectable MAP3_RESULTS = projectable(
+        row(1, pair(1, pair(1, "comment 1"))),
+        row(1, pair(1, pair(2, "comment 2"))),
+        row(2, pair(2, pair(5, "comment 5"))),
+        row(3, pair(3, pair(6, "comment 6"))),
+        row(null, pair(null, pair(7, "comment 7"))),
+        row(null, pair(null,  pair(8, "comment 8"))),
+        row(1, pair(1, pair(3, "comment 3")))
+    );
+
+    protected static final Projectable MAP4_RESULTS = projectable(
+        row(1, pair(pair(1, "comment 1"), "post 1")),
+        row(1, pair(pair(1, "comment 2"), "post 1")),
+        row(2, pair(pair(2, "comment 5"), "post 2")),
+        row(3, pair(pair(3, "comment 6"), "post 3")),
+        row(null, pair(pair(null, "comment 7"), "null post")),
+        row(null, pair(pair(null, "comment 8"), "null post")),
+        row(1, pair(pair(1, "comment 3"), "post 1"))
+    );
+
+    protected static final Projectable POST_W_COMMENTS = projectable(
+            row(null, null, "null post", comment(7)),
+            row(null, null, "null post", comment(8)),
+            row(1, 1, "post 1", comment(1)),
+            row(1, 1, "post 1", comment(2)),
+            row(1, 1, "post 1", comment(3)),
+            row(2, 2, "post 2", comment(5)),
+            row(3, 3, "post 3", comment(6))
+    );
+
+    protected static final Projectable POST_W_COMMENTS2 = projectable(
+            row(null, "null post", comment(7)),
+            row(null, "null post", comment(8)),
+            row(1, "post 1", comment(1)),
+            row(1, "post 1", comment(2)),
+            row(1, "post 1", comment(3)),
+            row(2, "post 2", comment(5)),
+            row(3, "post 3", comment(6))
+    );
+
+    // [ user.name, latestPost(post.id, post.name), latestPost.comments() ]
+    protected static final Projectable USERS_W_LATEST_POST_AND_COMMENTS = projectable(
+            row("Jane", "Jane", 2, "post 2", comment(4)),
+            row("Jane", "Jane", 2, "post 2", comment(5)),
+            row("John", "John", 1, "post 1", comment(1)),
+            row("John", "John", 1, "post 1", comment(2)),
+            row("John", "John", 1, "post 1", comment(3))
+    );
+
+//    protected static final Projectable USERS_W_LATEST_POST_AND_COMMENTS2 = projectable(
+//            row("John", 1, "post 1", comment(1)),
+//            row("Jane", 2, "post 2", comment(4)),
+//            row("John", 1, "post 1", comment(2)),
+//            row("Jane", 2, "post 2", comment(5)),
+//            row("John", 1, "post 1", comment(3))
+//    );
+
     protected static final SimplePath<Post> post = new SimplePath<Post>(Post.class, "post");
 
     protected static final SimplePath<User> user = new SimplePath<User>(User.class, "user");
@@ -63,6 +151,12 @@ public abstract class AbstractGroupByTest {
             public <T> CloseableIterator<T> iterate(Expression<T> arg) {
                 return (CloseableIterator)iterator(rows);
             }
+
+            @Override
+            public CloseableIterator<Tuple> iterate(Expression<?>... args) {
+                return iterator(rows);
+            }
+            
         };
     }
 
@@ -78,5 +172,33 @@ public abstract class AbstractGroupByTest {
         return new IteratorAdapter<Tuple>(tuples.iterator());
     }
 
+    public abstract void Group_Order();
 
+    public abstract void First_Set_And_List();
+
+    public abstract void Group_By_Null();
+
+    public abstract void NoSuchElementException();
+
+    public abstract void ClassCastException();
+
+    public abstract void Map();
+
+    public abstract void Map2();
+    
+    public abstract void Map3();
+
+    public abstract void Map4();
+
+    public abstract void Array_Access();
+
+    public abstract void Transform_Results();
+
+    public abstract void Transform_As_Bean();
+
+    public abstract void OneToOneToMany_Projection();
+    
+    public abstract void OneToOneToMany_Projection_As_Bean();
+
+    public abstract void OneToOneToMany_Projection_As_Bean_And_Constructor();
 }

--- a/querydsl-core/src/test/java/com/mysema/query/group/GroupByListTest.java
+++ b/querydsl-core/src/test/java/com/mysema/query/group/GroupByListTest.java
@@ -23,77 +23,24 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.junit.Test;
 
-import com.mysema.query.Projectable;
+import com.mysema.commons.lang.CloseableIterator;
+import com.mysema.commons.lang.IteratorAdapter;
+import com.mysema.commons.lang.Pair;
+import com.mysema.query.Tuple;
 import com.mysema.query.types.Projections;
 
 public class GroupByListTest extends AbstractGroupByTest {
-
-    protected static final Projectable BASIC_RESULTS = projectable(
-            row(null, "null post", 7, "comment 7"),
-            row(null, "null post", 8, "comment 8"),
-            row(1, "post 1", 1, "comment 1"),
-            row(1, "post 1", 2, "comment 2"),
-            row(1, "post 1", 3, "comment 3"),
-            row(2, "post 2", 4, "comment 4"),
-            row(2, "post 2", 5, "comment 5"),
-            row(3, "post 3", 6, "comment 6")
-    );
-
-    protected static final Projectable MAP_RESULTS = projectable(
-            row(null, "null post", pair(7, "comment 7")),
-            row(null, "null post", pair(8, "comment 8")),
-            row(1, "post 1", pair(1, "comment 1")),
-            row(1, "post 1", pair(2, "comment 2")),
-            row(1, "post 1", pair(3, "comment 3")),
-            row(2, "post 2", pair(5, "comment 5")),
-            row(3, "post 3", pair(6, "comment 6"))
-    );
-
-    protected static final Projectable MAP2_RESULTS = projectable(
-            row(null, pair(7, "comment 7")),
-            row(null,  pair(8, "comment 8")),
-            row(1, pair(1, "comment 1")),
-            row(1, pair(2, "comment 2")),
-            row(1, pair(3, "comment 3")),
-            row(2, pair(5, "comment 5")),
-            row(3, pair(6, "comment 6"))
-    );
-
-    protected static final Projectable POST_W_COMMENTS = projectable(
-            row(null, null, "null post", comment(7)),
-            row(null, null, "null post", comment(8)),
-            row(1, 1, "post 1", comment(1)),
-            row(1, 1, "post 1", comment(2)),
-            row(1, 1, "post 1", comment(3)),
-            row(2, 2, "post 2", comment(5)),
-            row(3, 3, "post 3", comment(6))
-    );
-
-    protected static final Projectable POST_W_COMMENTS2 = projectable(
-            row(null, "null post", comment(7)),
-            row(null, "null post", comment(8)),
-            row(1, "post 1", comment(1)),
-            row(1, "post 1", comment(2)),
-            row(1, "post 1", comment(3)),
-            row(2, "post 2", comment(5)),
-            row(3, "post 3", comment(6))
-    );
-
-    // [ user.name, latestPost(post.id, post.name), latestPost.comments() ]
-    protected static final Projectable USERS_W_LATEST_POST_AND_COMMENTS = projectable(
-            row("Jane", "Jane", 2, "post 2", comment(4)),
-            row("Jane", "Jane", 2, "post 2", comment(5)),
-            row("John", "John", 1, "post 1", comment(1)),
-            row("John", "John", 1, "post 1", comment(2)),
-            row("John", "John", 1, "post 1", comment(3))
-    );
-
+    
     @Test
     public void Group_Order() {
         List<Group> results = BASIC_RESULTS
@@ -176,6 +123,64 @@ public class GroupByListTest extends AbstractGroupByTest {
         Map<Integer, String> comments = results.get(1);
         assertEquals(3, comments.size());
         assertEquals("comment 2", comments.get(2));
+    }
+ 
+    @Test
+    public void Map3() {        
+        List<Map<Integer, Map<Integer, String>>> actual = MAP3_RESULTS.transform(
+            groupBy(postId).list(map(postId, map(commentId, commentText))));
+        
+        Object postId = null;
+        Map<Integer, Map<Integer, String>> posts = null;
+        List<Map<Integer, Map<Integer, String>>> expected = new LinkedList<Map<Integer, Map<Integer, String>>>();
+        for (Iterator<Tuple> iterator = MAP3_RESULTS.iterate(); iterator.hasNext();) {
+            Tuple tuple = iterator.next();
+            Object[] array = tuple.toArray();
+            
+            if (posts == null || !(postId == array[0] || postId != null && postId.equals(array[0]))) {
+                posts = new LinkedHashMap<Integer, Map<Integer,String>>();
+                expected.add(posts);
+            }
+            postId = array[0];
+            @SuppressWarnings("unchecked")
+            Pair<Integer, Pair<Integer, String>> pair = (Pair<Integer, Pair<Integer, String>>) array[1];
+            Integer first = pair.getFirst();
+            Map<Integer, String> comments = posts.get(first);
+            if (comments == null) {
+                comments = new LinkedHashMap<Integer, String>();
+                posts.put(first, comments);
+            }
+            Pair<Integer, String> second = pair.getSecond();
+            comments.put(second.getFirst(), second.getSecond());
+        }      
+        assertEquals(expected.toString(), actual.toString());
+    }
+
+    @Test
+    public void Map4() {    
+        CloseableIterator<Map<Map<Integer, String>, String>> results = MAP4_RESULTS.transform(
+            groupBy(postId).iterate(map(map(postId, commentText), postName)));
+        List<Map<Map<Integer, String>, String>> actual = IteratorAdapter.asList(results);
+        
+        Object commentId = null;
+        Map<Map<Integer, String>, String> comments = null;
+        List<Map<Map<Integer, String>, String>> expected = new LinkedList<Map<Map<Integer, String>, String>>();
+        for (Iterator<Tuple> iterator = MAP4_RESULTS.iterate(); iterator.hasNext();) {
+            Tuple tuple = iterator.next();
+            Object[] array = tuple.toArray();
+ 
+            if (comments == null || !(commentId == array[0] || commentId != null && commentId.equals(array[0]))) {
+                comments = new LinkedHashMap<Map<Integer, String>, String>();
+                expected.add(comments);
+            }
+            commentId = array[0];
+            @SuppressWarnings("unchecked")
+            Pair<Pair<Integer, String>, String> pair = (Pair<Pair<Integer, String>, String>) array[1];
+            Pair<Integer, String> first = pair.getFirst(); 
+            Map<Integer, String> posts = Collections.singletonMap(first.getFirst(), first.getSecond());
+            comments.put(posts, pair.getSecond());
+        }      
+        assertEquals(expected.toString(), actual.toString());
     }
 
     @Test

--- a/querydsl-core/template.mf
+++ b/querydsl-core/template.mf
@@ -2,6 +2,7 @@ Bundle-SymbolicName: com.mysema.querydsl.core
 Bundle-Name: Querydsl Core
 Bundle-Vendor: Mysema
 Bundle-ManifestVersion: 2
+Excluded-Imports: com.infradna.tool.bridge_method_injector
 Import-Template:
   com.mysema.commons.lang.*;version="${mysema.lang.version}",
   javax.annotation.*;version="0",  


### PR DESCRIPTION
Here's support for nested group expressions. Map nesting is especially useful for me (and I recollect someone else asking for it) but there is support for nested set and list as well. Tests for maps are included. 

I had to make a small non-backwards compatible change to GroupBy interface in order to make proper use of the new features, but this should not be a problem. Already compiler code will continue working thanks to Kohsuke's bridge method annotation library and it's clever bytecode mutilation plugin. I also made some of the generics more specific but that won't cause such bytecode incompatibilities.

My original idea was to partition collections though simple arithmetic operations (count().divide(PARTITION_SIZE).floor()) thus the support for lists and sets but I never got around to actually implement it when I realized that calculations would tightly involve collections subproject (or some other that understands basic java) which I'm not familiar of.
