### PR TITLE
Escape top level variables for OpenJPA

### DIFF
--- a/querydsl-jpa/src/main/java/com/mysema/query/jpa/OpenJPATemplates.java
+++ b/querydsl-jpa/src/main/java/com/mysema/query/jpa/OpenJPATemplates.java
@@ -14,6 +14,7 @@
 package com.mysema.query.jpa;
 
 import com.mysema.query.types.Ops;
+import com.mysema.query.types.PathType;
 
 /**
  * OpenJPATemplates extends JPQLTemplates with OpenJPA specific extensions
@@ -27,6 +28,7 @@ public class OpenJPATemplates extends JPQLTemplates{
 
     public OpenJPATemplates() {
         this(DEFAULT_ESCAPE);
+        add(PathType.VARIABLE, "{0s}_");
         add(Ops.ALIAS, "{0} {1}");
         add(Ops.NEGATE, "-1 * {0}", 7);
     }

--- a/querydsl-jpa/src/test/java/com/mysema/query/jpa/JPQLSerializerTest.java
+++ b/querydsl-jpa/src/test/java/com/mysema/query/jpa/JPQLSerializerTest.java
@@ -13,12 +13,6 @@
  */
 package com.mysema.query.jpa;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-
-import org.junit.Test;
-
 import com.mysema.query.DefaultQueryMetadata;
 import com.mysema.query.JoinType;
 import com.mysema.query.QueryMetadata;
@@ -32,6 +26,11 @@ import com.mysema.query.types.Predicate;
 import com.mysema.query.types.path.EntityPathBase;
 import com.mysema.query.types.path.NumberPath;
 import com.mysema.query.types.path.StringPath;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 public class JPQLSerializerTest {
 
@@ -195,5 +194,18 @@ public class JPQLSerializerTest {
         assertEquals("select cat\n" +
                      "from Cat cat\n" +
                      "order by cat.name asc nulls last", serializer.toString());
+    }
+
+    @Test
+    public void OpenJPA_Variables() {
+        QCat cat = QCat.cat;
+        JPQLSerializer serializer = new JPQLSerializer(OpenJPATemplates.DEFAULT);
+        QueryMetadata md = new DefaultQueryMetadata();
+        md.addJoin(JoinType.DEFAULT, cat);
+        md.addJoin(JoinType.INNERJOIN, cat.mate);
+        md.addJoinCondition(cat.mate.alive);
+        serializer.serialize(md, false, null);
+        assertEquals("select cat_\nfrom Cat cat_\n  inner join cat_.mate on cat_.mate.alive",
+                serializer.toString());
     }
 }


### PR DESCRIPTION
Fixes by appending the underscore char to top level variables for OpenJPA #659
