### PR TITLE
Improve projection code generation

### DIFF
--- a/querydsl-codegen/src/main/java/com/mysema/query/codegen/ProjectionSerializer.java
+++ b/querydsl-codegen/src/main/java/com/mysema/query/codegen/ProjectionSerializer.java
@@ -13,21 +13,18 @@
  */
 package com.mysema.query.codegen;
 
-import java.io.IOException;
+import com.google.common.base.Function;
+import com.google.common.collect.Sets;
+import com.mysema.codegen.CodeWriter;
+import com.mysema.codegen.model.*;
+import com.mysema.query.types.ConstructorExpression;
+import com.mysema.query.types.Expression;
+import com.mysema.query.types.expr.NumberExpression;
 
 import javax.annotation.Generated;
 import javax.inject.Inject;
-
-import com.google.common.base.Function;
-import com.mysema.codegen.CodeWriter;
-import com.mysema.codegen.model.ClassType;
-import com.mysema.codegen.model.Constructor;
-import com.mysema.codegen.model.Parameter;
-import com.mysema.codegen.model.Type;
-import com.mysema.codegen.model.TypeCategory;
-import com.mysema.codegen.model.Types;
-import com.mysema.query.types.ConstructorExpression;
-import com.mysema.query.types.expr.NumberExpression;
+import java.io.IOException;
+import java.util.Set;
 
 /**
  * ProjectionSerializer is a {@link Serializer} implementation for projection types
@@ -60,7 +57,7 @@ public final class ProjectionSerializer implements Serializer{
 
         // imports
         writer.imports(NumberExpression.class.getPackage());
-        writer.imports(ConstructorExpression.class, Generated.class);
+        writer.imports(Expression.class, ConstructorExpression.class, Generated.class);
 
         // javadoc
         writer.javadoc(queryType + " is a Querydsl Projection type for " + simpleName);
@@ -85,14 +82,24 @@ public final class ProjectionSerializer implements Serializer{
         intro(model, writer);
 
         String localName = writer.getRawName(model);
+        Set<Integer> sizes = Sets.newHashSet();
 
         for (Constructor c : model.getConstructors()) {
+            final boolean asExpr = sizes.add(c.getParameters().size());
             // begin
             writer.beginConstructor(c.getParameters(), new Function<Parameter,Parameter>() {
                 @Override
                 public Parameter apply(Parameter p) {
-                    return new Parameter(p.getName(), typeMappings.getExprType(p.getType(),
-                            model, false, false, true));
+                    Type type;
+                    if (!asExpr) {
+                        type = typeMappings.getExprType(p.getType(),
+                                model, false, false, true);
+                    } else if (p.getType().isFinal()) {
+                        type = new ClassType(Expression.class, p.getType());
+                    } else {
+                        type = new ClassType(Expression.class, new TypeExtends(p.getType()));
+                    }
+                    return new Parameter(p.getName(), type);
                 }
             });
 

--- a/querydsl-codegen/src/test/java/com/mysema/query/codegen/ProjectionSerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/mysema/query/codegen/ProjectionSerializerTest.java
@@ -13,22 +13,16 @@
  */
 package com.mysema.query.codegen;
 
-import static org.junit.Assert.*;
+import com.mysema.codegen.JavaWriter;
+import com.mysema.codegen.model.*;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Arrays;
 
-import org.junit.Test;
-
-import com.mysema.codegen.JavaWriter;
-import com.mysema.codegen.model.Constructor;
-import com.mysema.codegen.model.Parameter;
-import com.mysema.codegen.model.SimpleType;
-import com.mysema.codegen.model.Type;
-import com.mysema.codegen.model.TypeCategory;
-import com.mysema.codegen.model.Types;
+import static org.junit.Assert.assertTrue;
 
 
 public class ProjectionSerializerTest {
@@ -47,9 +41,9 @@ public class ProjectionSerializerTest {
         Writer writer = new StringWriter();
         ProjectionSerializer serializer = new ProjectionSerializer(new JavaTypeMappings());
         serializer.serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
-        assertTrue(writer.toString().contains("StringExpression firstName"));
-        assertTrue(writer.toString().contains("StringExpression lastName"));
-        assertTrue(writer.toString().contains("NumberExpression<Integer> age"));
+        assertTrue(writer.toString().contains("Expression<String> firstName"));
+        assertTrue(writer.toString().contains("Expression<String> lastName"));
+        assertTrue(writer.toString().contains("Expression<Integer> age"));
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/mysema/querydsl/issues/697 by using `Expression<T>` typed parameters when possible.
