### PR TITLE
Simplify signature.

### DIFF
--- a/querydsl-sql/src/test/java/com/mysema/query/ExtendedSQLQuery.java
+++ b/querydsl-sql/src/test/java/com/mysema/query/ExtendedSQLQuery.java
@@ -19,7 +19,6 @@ import java.util.List;
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.query.sql.AbstractSQLQuery;
 import com.mysema.query.sql.Configuration;
-import com.mysema.query.sql.SQLCommonQuery;
 import com.mysema.query.sql.SQLTemplates;
 import com.mysema.query.types.Expression;
 import com.mysema.query.types.FactoryExpression;
@@ -29,7 +28,7 @@ import com.mysema.query.types.QBean;
  * @author tiwe
  *
  */
-public class ExtendedSQLQuery extends AbstractSQLQuery<ExtendedSQLQuery> implements SQLCommonQuery<ExtendedSQLQuery> {
+public class ExtendedSQLQuery extends AbstractSQLQuery<ExtendedSQLQuery> {
 
     public ExtendedSQLQuery(SQLTemplates templates) {
         super(null, new Configuration(templates), new DefaultQueryMetadata());


### PR DESCRIPTION
Since AbstractSQLQuery and further up the hierarchy are already an SQLCommonQuery, this signature is already inherited.
