### PR TITLE
Use of EnumMaps instead of HashMaps for enums.

### DIFF
--- a/querydsl-jpa/src/main/java/com/mysema/query/jpa/JPQLSerializer.java
+++ b/querydsl-jpa/src/main/java/com/mysema/query/jpa/JPQLSerializer.java
@@ -15,7 +15,7 @@ package com.mysema.query.jpa;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +98,7 @@ public class JPQLSerializer extends SerializerBase<JPQLSerializer> {
 
     private static final String ON = " on ";
 
-    private static final Map<JoinType, String> joinTypes = new HashMap<JoinType, String>();
+    private static final Map<JoinType, String> joinTypes = new EnumMap<JoinType, String>(JoinType.class);
 
     private final JPQLTemplates templates;
 

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLExpressions.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLExpressions.java
@@ -13,7 +13,7 @@
  */
 package com.mysema.query.sql;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import com.mysema.query.types.ConstantImpl;
@@ -43,11 +43,14 @@ import com.mysema.query.types.expr.Wildcard;
 @SuppressWarnings("rawtypes")
 public final class SQLExpressions {
 
-    private static final Map<DatePart, Operator> DATE_ADD_OPS = new HashMap<DatePart, Operator>();
+    private static final Map<DatePart, Operator> DATE_ADD_OPS
+            = new EnumMap<DatePart, Operator>(DatePart.class);
 
-    private static final Map<DatePart, Operator> DATE_DIFF_OPS = new HashMap<DatePart, Operator>();
+    private static final Map<DatePart, Operator> DATE_DIFF_OPS
+            = new EnumMap<DatePart, Operator>(DatePart.class);
 
-    private static final Map<DatePart, Operator> DATE_TRUNC_OPS = new HashMap<DatePart, Operator>();
+    private static final Map<DatePart, Operator> DATE_TRUNC_OPS
+            = new EnumMap<DatePart, Operator>(DatePart.class);
 
     static {
         DATE_ADD_OPS.put(DatePart.year, Ops.DateTimeOps.ADD_YEARS);


### PR DESCRIPTION
EnumMaps are tweaked for optimal performance when using enums as keys.
