### PR TITLE
Call equals method instead of reference equality.

### DIFF
--- a/querydsl-apt/src/test/java/com/mysema/query/domain/ExpressionTest.java
+++ b/querydsl-apt/src/test/java/com/mysema/query/domain/ExpressionTest.java
@@ -13,6 +13,8 @@
  */
 package com.mysema.query.domain;
 
+import static com.google.common.base.Objects.equal;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -113,7 +115,7 @@ public class ExpressionTest {
                         continue;
                     }
                     Object rv = method.invoke(expr, args);
-                    if (method.invoke(expr, args) != rv) {
+                    if (!equal(method.invoke(expr, args), rv)) {
                         failures.add(expr.getClass().getSimpleName()+"."+method.getName()+" is unstable");
                     }
                 }


### PR DESCRIPTION
https://travis-ci.org/querydsl/querydsl/jobs/24346384#L1132 

It reports 'failures', but isn't reference equality always false here?
