### PR TITLE
Use an atomic group to strip non-operations.

### DIFF
--- a/querydsl-core/src/main/java/com/mysema/query/support/Normalization.java
+++ b/querydsl-core/src/main/java/com/mysema/query/support/Normalization.java
@@ -26,7 +26,7 @@ public final class Normalization {
 
     // TODO simplify
     private static final Pattern FULL_OPERATION = Pattern.compile(
-            "(?<![\\d\\*/\"' ])" + "(\\b|\\(|\\s+)"  +
+            "(?>\\A|[^\\d\\*/\"' ]+)" + "(\\b|\\(|\\s+)"  +
             "(" + NUMBER + WS + "[+\\-/*]" + WS + ")+" + NUMBER + WS +
             "(?![\\d\\*/\"' ])");
 


### PR DESCRIPTION
The querydsl performance test is faster, so in general use(faster stripping of non-operations) this might be better.
