### PR TITLE
ConstructorExpression typing of transformers.

### DIFF
--- a/querydsl-core/src/main/java/com/mysema/query/types/ConstructorExpression.java
+++ b/querydsl-core/src/main/java/com/mysema/query/types/ConstructorExpression.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -65,7 +64,7 @@ public class ConstructorExpression<T> extends ExpressionBase<T> implements Facto
     @Nullable
     private transient Constructor<?> constructor;
 
-    private transient Collection<? extends Function<Object[], Object[]>> transformers;
+    private transient Iterable<Function<Object[], Object[]>> transformers;
 
     public ConstructorExpression(Class<T> type, Class<?>[] paramTypes, Expression<?>... args) {
         this(type, paramTypes, ImmutableList.copyOf(args));

--- a/querydsl-core/src/main/java/com/mysema/query/util/ConstructorUtils.java
+++ b/querydsl-core/src/main/java/com/mysema/query/util/ConstructorUtils.java
@@ -13,23 +13,21 @@
  */
 package com.mysema.query.util;
 
-import static com.google.common.collect.ImmutableList.copyOf;
-import static com.google.common.collect.Collections2.filter;
+import static com.google.common.collect.Iterables.filter;
 import static com.mysema.util.ArrayUtils.isEmpty;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Primitives;
 import com.mysema.query.types.ExpressionException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -126,13 +124,14 @@ public class ConstructorUtils {
      * @param constructor
      * @return
      */
-    public static Collection<? extends Function<Object[], Object[]>> getTransformers(Constructor<?> constructor) {
-        ArrayList<ArgumentTransformer> transformers = Lists.newArrayList(
+    public static Iterable<Function<Object[], Object[]>> getTransformers(Constructor<?> constructor) {
+        Iterable<ArgumentTransformer> transformers = Lists.newArrayList(
                 new PrimitiveAwareVarArgsTransformer(constructor),
                 new PrimitiveTransformer(constructor),
                 new VarArgsTransformer(constructor));
 
-        return copyOf(filter(transformers, applicableFilter));
+        return ImmutableList
+                .<Function<Object[], Object[]>>copyOf(filter(transformers, applicableFilter));
     }
 
     private static Class<?> normalize(Class<?> clazz) {


### PR DESCRIPTION
Since in the ConstructorExpression you only need the Iterable and Function interfaces, I changed the code to pass only those interfaces.
