### PR TITLE
Use SQLServerTemplates for SQLServerQueryFactory

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/mssql/SQLServerQueryFactory.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/mssql/SQLServerQueryFactory.java
@@ -19,7 +19,7 @@ import javax.inject.Provider;
 
 import com.mysema.query.sql.AbstractSQLQueryFactory;
 import com.mysema.query.sql.Configuration;
-import com.mysema.query.sql.MySQLTemplates;
+import com.mysema.query.sql.SQLServerTemplates;
 import com.mysema.query.sql.SQLTemplates;
 
 /**
@@ -35,7 +35,7 @@ public class SQLServerQueryFactory extends AbstractSQLQueryFactory<SQLServerQuer
     }
 
     public SQLServerQueryFactory(Provider<Connection> connection) {
-        this(new Configuration(new MySQLTemplates()), connection);
+        this(new Configuration(new SQLServerTemplates()), connection);
     }
 
     public SQLServerQueryFactory(SQLTemplates templates, Provider<Connection> connection) {


### PR DESCRIPTION
I noticed that the SQLServerQueryFactory uses the MySQLTemplates.

I think this is a mistake.
