### PR TITLE
guava.version from 14.0 to 18.0

### DIFF
--- a/querydsl-root/pom.xml
+++ b/querydsl-root/pom.xml
@@ -39,7 +39,7 @@
     <teradata.version>13.10.00.35</teradata.version>
     <firebird.version>2.2.5</firebird.version>
     
-    <guava.version>14.0</guava.version>
+    <guava.version>18.0</guava.version>
     <codegen.version>0.6.3</codegen.version>
     <mysema.lang.version>0.2.4</mysema.lang.version>
     <cglib.version>2.2.2</cglib.version>    


### PR DESCRIPTION
Updating guava to latest stable version 18.0 (in special, gauva14.0 is not deployable to JavaEE7 containers, see issue1433 at googlecode -> guava).
