### PR TITLE
The bug in com.mysema.query.DefaultQueryMetadata.equals() method

### DIFF
--- a/querydsl-core/src/main/java/com/mysema/query/DefaultQueryMetadata.java
+++ b/querydsl-core/src/main/java/com/mysema/query/DefaultQueryMetadata.java
@@ -381,7 +381,7 @@ public class DefaultQueryMetadata implements QueryMetadata, Cloneable {
                 && Objects.equal(q.getHaving(), having)
                 && q.isDistinct() == distinct
                 && q.isUnique() == unique
-                && q.getJoins().equals(joins.getJoins())
+                && q.getJoins().equals(getJoins())
                 && Objects.equal(q.getModifiers(), modifiers)
                 && q.getOrderBy().equals(orderBy)
                 && q.getParams().equals(params)


### PR DESCRIPTION
If you run this code (in version from 3.0 to 3.5):

```
DefaultQueryMetadata meta = new DefaultQueryMetadata();
meta.addJoin(JoinType.DEFAULT, new ConstantImpl<String>("1"));
System.out.println("Test = " + meta.equals(meta.clone()));
```

You must see "Test = false", because in DefaultQueryMetadata.equals() using code: 
"... && q.getJoins().equals(joins)", but since version 3.0 method getJoins() returns joinTarget if joins.size()==0 (getJoins() { addLastJoin(); return joins; }, and q.getJoins().equals(joins) == false for some object (if joins.size()==0). I think, it's quite serious bug. However, it can be fixed, only if using q.getJoins().equals(getJoins()) instead of q.getJoins().equals(joins).
