### PR TITLE
Disable validation for DefaultQueryMetadata created in ReplaceVisitor

### DIFF
--- a/querydsl-core/src/main/java/com/mysema/query/support/ReplaceVisitor.java
+++ b/querydsl-core/src/main/java/com/mysema/query/support/ReplaceVisitor.java
@@ -13,14 +13,14 @@
  */
 package com.mysema.query.support;
 
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.collect.ImmutableList;
 import com.mysema.query.*;
 import com.mysema.query.types.*;
 import com.mysema.query.types.template.BooleanTemplate;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Map;
 
 /**
  * ReplaceVisitor is a deep visitor that can be customized to replace segments of
@@ -80,6 +80,7 @@ public class ReplaceVisitor implements Visitor<Expression<?>, Void> {
     @Override
     public Expression<?> visit(SubQueryExpression<?> expr, @Nullable Void context) {
         QueryMetadata md = new DefaultQueryMetadata();
+        md.setValidate(false);
         md.setDistinct(expr.getMetadata().isDistinct());
         md.setModifiers(expr.getMetadata().getModifiers());
         md.setUnique(expr.getMetadata().isUnique());

--- a/querydsl-jpa/src/test/java/com/mysema/query/AbstractJPATest.java
+++ b/querydsl-jpa/src/test/java/com/mysema/query/AbstractJPATest.java
@@ -1172,6 +1172,14 @@ public abstract class AbstractJPATest {
     }
 
     @Test
+    public void SubQuery4() {
+        QCat cat = QCat.cat;
+        QCat other = new QCat("other");
+        query().from(cat)
+               .list(cat.name, new JPASubQuery().from(other).where(other.name.eq(cat.name)).count());
+    }
+
+    @Test
     public void Substring() {
         for (String str : query().from(cat).list(cat.name.substring(1,2))) {
             assertEquals(1, str.length());


### PR DESCRIPTION
Fixes https://github.com/querydsl/querydsl/issues/1014

Most SubQuery implementations use non validating QueryMetadata instances. It is safer to use non validating subquery instances also in ReplaceVisitor.
