### PR TITLE
First developments for querydsl-elasticsearch.

### DIFF
--- a/querydsl-apt/src/main/java/com/mysema/query/apt/elasticsearch/ElasticsearchAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/mysema/query/apt/elasticsearch/ElasticsearchAnnotationProcessor.java
@@ -1,0 +1,33 @@
+package com.mysema.query.apt.elasticsearch;
+
+import com.mysema.query.annotations.*;
+import com.mysema.query.apt.AbstractQuerydslProcessor;
+import com.mysema.query.apt.Configuration;
+import com.mysema.query.apt.DefaultConfiguration;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+
+/**
+ * Annotation processor to create Querydsl query types for Elasticsearch annotated classes
+ *
+ * @author Kevin Leturc
+ */
+@SupportedAnnotationTypes({"com.mysema.query.annotations.*"})
+public class ElasticsearchAnnotationProcessor extends AbstractQuerydslProcessor {
+
+    @Override
+    protected Configuration createConfiguration(RoundEnvironment roundEnv) {
+        Class<? extends Annotation> entities = QueryEntities.class;
+        Class<? extends Annotation> entity = QueryEntity.class;
+        Class<? extends Annotation> superType = QuerySupertype.class;
+        Class<? extends Annotation> embedded = QueryEmbedded.class;
+        Class<? extends Annotation> skip = QueryTransient.class;
+        return new DefaultConfiguration(roundEnv,
+                processingEnv.getOptions(), Collections.<String>emptySet(),
+                entities, entity, superType, null, embedded, skip);
+    }
+
+}

--- a/querydsl-elasticsearch/pom.xml
+++ b/querydsl-elasticsearch/pom.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.mysema.querydsl</groupId>
+    <artifactId>querydsl-root</artifactId>
+    <version>3.6.1.BUILD-SNAPSHOT</version>
+    <relativePath>../querydsl-root/pom.xml</relativePath>
+  </parent>
+
+  <groupId>com.mysema.querydsl</groupId>
+  <artifactId>querydsl-elasticsearch</artifactId>
+  <name>Querydsl - Elasticsearch support</name>
+  <description>Elasticsearch support for Querydsl</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <elasticsearch.version>1.3.4</elasticsearch.version>
+    <jackson.version>2.4.2</jackson.version>
+    <osgi.import.package>
+      org.elasticsearch.*;version="0.0.0",
+      com.fasterxml.jackson.core.*;version="0.0.0",
+      ${osgi.import.package.root}
+    </osgi.import.package>
+  </properties>
+
+  <dependencies>
+
+    <!-- Elasticsearch -->
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>${elasticsearch.version}</version>
+    </dependency>
+
+    <!-- Jackson JSON Mapper -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.mysema.querydsl</groupId>
+      <artifactId>querydsl-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.querydsl</groupId>
+      <artifactId>querydsl-apt</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+
+    <!-- test -->
+    <dependency>
+      <groupId>com.mysema.querydsl</groupId>
+      <artifactId>querydsl-core</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>com.mysema.maven</groupId>
+        <artifactId>apt-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-process</goal>
+              <goal>add-test-sources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>target/generated-test-sources/java</outputDirectory>
+              <processor>com.mysema.query.apt.elasticsearch.ElasticsearchAnnotationProcessor</processor>
+              <logOnlyOnError>true</logOnlyOnError>
+              <options>
+                <defaultOverwrite>true</defaultOverwrite>
+              </options>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>extra-jars</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/apt.xml</descriptor>
+                <descriptor>src/main/assembly.xml</descriptor>
+              </descriptors>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verification</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <systemProperties>
+                <property>
+                  <name>version</name>
+                  <value>${project.version}</value>
+                </property>
+              </systemProperties>
+              <includes>
+                <include>com/mysema/query/PackageVerification.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/querydsl-elasticsearch/src/apt/META-INF/services/javax.annotation.processing.Processor
+++ b/querydsl-elasticsearch/src/apt/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.mysema.query.apt.elasticsearch.ElasticsearchAnnotationProcessor

--- a/querydsl-elasticsearch/src/main/apt.xml
+++ b/querydsl-elasticsearch/src/main/apt.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>apt</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>src/apt</directory>	
+	  <outputDirectory>/</outputDirectory>
+	</fileSet>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>	
+	  <outputDirectory>/</outputDirectory>
+	</fileSet>			
+  </fileSets>  
+</assembly>

--- a/querydsl-elasticsearch/src/main/assembly.xml
+++ b/querydsl-elasticsearch/src/main/assembly.xml
@@ -1,0 +1,25 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>apt-one-jar</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>src/apt</directory>	
+	  <outputDirectory>/</outputDirectory>
+	</fileSet>
+    <fileSet>
+      <directory>src/license</directory>	
+	  <outputDirectory>/license</outputDirectory>
+	</fileSet>			
+  </fileSets>	
+  <dependencySets>
+    <dependencySet>
+      <unpack>true</unpack>
+    </dependencySet>
+  </dependencySets>
+</assembly>
+

--- a/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/ElasticsearchQuery.java
+++ b/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/ElasticsearchQuery.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2014, Mysema Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mysema.query.elasticsearch;
+
+import com.google.common.base.Function;
+import com.mysema.commons.lang.CloseableIterator;
+import com.mysema.commons.lang.IteratorAdapter;
+import com.mysema.query.*;
+import com.mysema.query.support.QueryMixin;
+import com.mysema.query.types.*;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ElasticsearchQuery provides a general Querydsl query implementation with a pluggable String to Bean transformation
+ *
+ * @param <K>
+ * @author Kevin Leturc
+ */
+public abstract class ElasticsearchQuery<K> implements SimpleQuery<ElasticsearchQuery<K>>, SimpleProjectable<K> {
+
+    private final QueryMixin<ElasticsearchQuery<K>> queryMixin;
+
+    private final Client client;
+
+    private final Function<SearchHit, K> transformer;
+
+    private final ElasticsearchSerializer serializer;
+
+    private final EntityPath<K> entityPath;
+
+    public ElasticsearchQuery(Client client, Function<SearchHit, K> transformer, ElasticsearchSerializer serializer,
+                              EntityPath<K> entityPath) {
+        this.queryMixin = new QueryMixin<ElasticsearchQuery<K>>(this, new DefaultQueryMetadata().noValidate(), false);
+        this.client = client;
+        this.transformer = transformer;
+        this.serializer = serializer;
+        this.entityPath = entityPath;
+    }
+
+    @Override
+    public boolean exists() {
+        return count() > 0;
+    }
+
+    @Override
+    public boolean notExists() {
+        return !exists();
+    }
+
+    @Override
+    public CloseableIterator<K> iterate() {
+        return new IteratorAdapter<K>(list().iterator());
+    }
+
+    public List<K> list(Path<?>... paths) {
+        queryMixin.addProjection(paths);
+        return list();
+    }
+
+    @Override
+    public List<K> list() {
+        // Test if there're limit or offset, and if not, set them to retrieve all results
+        // because by default elasticsearch returns only 10 results
+        QueryMetadata metadata = queryMixin.getMetadata();
+        QueryModifiers modifiers = metadata.getModifiers();
+        if (modifiers.getLimit() == null && modifiers.getOffset() == null) {
+            long count = count();
+            if (count > 0l) {
+                // Set the limit only if there's result
+                metadata.setModifiers(new QueryModifiers(count, 0L));
+            }
+        }
+
+        // Execute search
+        SearchResponse searchResponse = executeSearch();
+        List<K> results = new ArrayList<K>();
+        for (SearchHit hit : searchResponse.getHits().getHits()) {
+            results.add(transformer.apply(hit));
+        }
+        return results;
+    }
+
+    public K singleResult(Path<?>... paths) {
+        queryMixin.addProjection(paths);
+        return singleResult();
+    }
+
+    @Nullable
+    @Override
+    public K singleResult() {
+        // Set the size of response
+        queryMixin.getMetadata().setModifiers(new QueryModifiers(1L, 0L));
+
+        SearchResponse searchResponse = executeSearch();
+        SearchHits hits = searchResponse.getHits();
+        if (hits.getTotalHits() > 0) {
+            return transformer.apply(hits.getAt(0));
+        } else {
+            return null;
+        }
+    }
+
+    public K uniqueResult(Path<?>... paths) {
+        queryMixin.addProjection(paths);
+        return uniqueResult();
+    }
+
+    @Nullable
+    @Override
+    public K uniqueResult() {
+        // Set the size of response
+        // Set 2 as limit because it has to be ony one result which match the condition
+        queryMixin.getMetadata().setModifiers(new QueryModifiers(2L, 0L));
+
+        SearchResponse searchResponse = executeSearch();
+        SearchHits hits = searchResponse.getHits();
+        long totalHits = hits.getTotalHits();
+        if (totalHits == 1l) {
+            return transformer.apply(hits.getAt(0));
+        } else if (totalHits > 1l) {
+            throw new NonUniqueResultException();
+        } else {
+            return null;
+        }
+    }
+
+    public SearchResults<K> listResults(Path<?>... paths) {
+        queryMixin.addProjection(paths);
+        return listResults();
+    }
+
+    @Override
+    public SearchResults<K> listResults() {
+        long total = count();
+        if (total > 0l) {
+            return new SearchResults<K>(list(), queryMixin.getMetadata().getModifiers(), total);
+        } else {
+            return SearchResults.emptyResults();
+        }
+    }
+
+    @Override
+    public long count() {
+        Predicate filter = createFilter(queryMixin.getMetadata());
+        return client.prepareCount().setQuery(createQuery(filter)).execute().actionGet().getCount();
+    }
+
+    @Override
+    public ElasticsearchQuery<K> limit(@Nonnegative long limit) {
+        return queryMixin.limit(limit);
+    }
+
+    @Override
+    public ElasticsearchQuery<K> offset(@Nonnegative long offset) {
+        return queryMixin.offset(offset);
+    }
+
+    @Override
+    public ElasticsearchQuery<K> restrict(QueryModifiers modifiers) {
+        return queryMixin.restrict(modifiers);
+    }
+
+    @Override
+    public ElasticsearchQuery<K> orderBy(OrderSpecifier<?>... o) {
+        return queryMixin.orderBy(o);
+    }
+
+    @Override
+    public <T> ElasticsearchQuery<K> set(ParamExpression<T> param, T value) {
+        return queryMixin.set(param, value);
+    }
+
+    @Override
+    public ElasticsearchQuery<K> distinct() {
+        return queryMixin.distinct();
+    }
+
+    @Override
+    public ElasticsearchQuery<K> where(Predicate... o) {
+        return queryMixin.where(o);
+    }
+
+    @Nullable
+    protected Predicate createFilter(QueryMetadata metadata) {
+        return metadata.getWhere();
+    }
+
+    private QueryBuilder createQuery(@Nullable Predicate predicate) {
+        if (predicate != null) {
+            return (QueryBuilder) serializer.handle(predicate);
+        } else {
+            return QueryBuilders.matchAllQuery();
+        }
+    }
+
+    private SearchResponse executeSearch() {
+        QueryMetadata metadata = queryMixin.getMetadata();
+        Predicate filter = createFilter(metadata);
+        return executeSearch(getIndex(), getType(), filter, metadata.getProjection(), metadata.getModifiers(),
+                metadata.getOrderBy());
+    }
+
+    private SearchResponse executeSearch(String index, String type, Predicate filter,
+            List<Expression<?>> projections, QueryModifiers modifiers, List<OrderSpecifier<?>> orderBys) {
+        SearchRequestBuilder requestBuilder = client.prepareSearch(index).setTypes(type);
+
+        // Set query
+        requestBuilder.setQuery(createQuery(filter));
+
+        // Add order by
+        for (OrderSpecifier<?> sort : orderBys) {
+            requestBuilder.addSort(serializer.toSort(sort));
+        }
+
+        // Add projections
+        if (!projections.isEmpty()) {
+            List<String> sourceFields = new ArrayList<String>();
+            for (Expression<?> projection : projections) {
+                sourceFields.add(projection.accept(serializer, null).toString());
+            }
+            requestBuilder.setFetchSource(sourceFields.toArray(new String[sourceFields.size()]), null);
+        }
+
+        // Add limit and offset
+        Integer limit = modifiers.getLimitAsInteger();
+        Integer offset = modifiers.getOffsetAsInteger();
+        if (limit != null) {
+            requestBuilder.setSize(limit);
+        }
+        if (offset != null) {
+            requestBuilder.setFrom(offset);
+        }
+
+        return requestBuilder.execute().actionGet();
+    }
+
+    public String getIndex() {
+        return getIndex(entityPath.getType());
+    }
+
+    public abstract String getIndex(Class<? extends K> entityType);
+
+    public String getType() {
+        return getType(entityPath.getType());
+    }
+
+    public abstract String getType(Class<? extends K> entityType);
+
+}

--- a/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/ElasticsearchSerializer.java
+++ b/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/ElasticsearchSerializer.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2014, Mysema Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mysema.query.elasticsearch;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.mysema.query.types.*;
+import org.apache.lucene.queryparser.flexible.core.util.StringUtils;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.IdsQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Set;
+
+import static org.elasticsearch.index.query.QueryBuilders.queryString;
+
+/**
+ * Serializes the given Querydsl query to a String query for Elasticsearch
+ *
+ * @author Kevin Leturc
+ */
+public class ElasticsearchSerializer implements Visitor<Object, BoolQueryBuilder> {
+
+    /** AND and OR operands. */
+    private static final Set<Operator<?>> AND_OR = Sets.<Operator<?>>newHashSet(Ops.AND, Ops.OR);
+
+    public Object handle(Expression<?> expression) {
+        BoolQueryBuilder context = QueryBuilders.boolQuery();
+        QueryBuilder query = (QueryBuilder) expression.accept(this, context);
+        if (!context.hasClauses() && query != null) {
+            context.must(query);
+        }
+        return context;
+    }
+
+    public SortBuilder toSort(OrderSpecifier<?> orderBy) {
+        Object key = orderBy.getTarget().accept(this, null);
+        return SortBuilders.fieldSort(key.toString()).order(orderBy.getOrder() == Order.ASC ? SortOrder.ASC : SortOrder.DESC);
+    }
+
+    @Nullable
+    @Override
+    public Object visit(Constant<?> expr, @Nullable BoolQueryBuilder context) {
+        if (Enum.class.isAssignableFrom(expr.getType())) {
+            return ((Enum<?>) expr.getConstant()).name();
+        } else {
+            return expr.getConstant();
+        }
+    }
+
+    @Nullable
+    @Override
+    public Object visit(FactoryExpression<?> expr, @Nullable BoolQueryBuilder context) {
+        return null;
+    }
+
+    public String asDBKey(Operation<?> expr, int index) {
+        return StringUtils.toString(asDBValue(expr, index));
+    }
+
+    public Object asDBValue(Operation<?> expr, int index) {
+        return expr.getArg(index).accept(this, null);
+    }
+
+    @Nullable
+    @Override
+    public Object visit(Operation<?> expr, @Nullable BoolQueryBuilder context) {
+        Preconditions.checkNotNull(context);
+        Operator<?> op = expr.getOperator();
+        if (op == Ops.EQ) {
+            Expression<?> keyArg = expr.getArg(0);
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            if (keyArg instanceof Path<?> && isIdPath((Path<?>) expr.getArg(0))) {
+                return QueryBuilders.idsQuery().ids(value);
+            } else {
+                // Currently all queries are made with ignore case sensitive
+                // Because the query to get exact value have to be run on a not_analyzed field
+                return QueryBuilders.queryString(value).field(asDBKey(expr, 0));
+            }
+
+        } else if (op == Ops.EQ_IGNORE_CASE) {
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            return QueryBuilders.queryString(value).field(asDBKey(expr, 0));
+
+        } else if (op == Ops.NE) {
+            // Decompose the query as NOT and EQ query
+            return visit(
+                    OperationImpl.create(
+                            Boolean.class,
+                            Ops.NOT,
+                            OperationImpl.create(
+                                    Boolean.class,
+                                    Ops.EQ,
+                                    expr.getArg(0),
+                                    expr.getArg(1))),
+                    context);
+
+        } else if (op == Ops.STRING_IS_EMPTY) {
+            return QueryBuilders.queryString("").field(asDBKey(expr, 0));
+
+        } else if (op == Ops.AND || op == Ops.OR) {
+            Operation<?> left = (Operation<?>) expr.getArg(0);
+            Operation<?> right = (Operation<?>) expr.getArg(1);
+            // Perform the left expression
+            QueryBuilder leftResult = visitSubAndOr(op, context, left);
+            // Perform the right expression
+            QueryBuilder rightResult = visitSubAndOr(op, context, right);
+
+            if (op == Ops.AND) {
+                safeMust(context, leftResult);
+                safeMust(context, rightResult);
+            } else {
+                safeShould(context, leftResult);
+                safeShould(context, rightResult);
+            }
+            return null;
+
+        } else if (op == Ops.IN) {
+
+            int constIndex = 0;
+            int exprIndex = 1;
+            if (expr.getArg(1) instanceof Constant<?>) {
+                constIndex = 1;
+                exprIndex = 0;
+            }
+            Expression<?> keyExpr = expr.getArg(exprIndex);
+            if (keyExpr instanceof Path<?> && isIdPath((Path<?>) keyExpr)) {
+                IdsQueryBuilder idsQuery = QueryBuilders.idsQuery();
+                // Hope this is the only case for Elasticsearch ids
+                Collection<?> values = (Collection<?>) ((Constant<?>) expr.getArg(constIndex)).getConstant();
+                for (Object value : values) {
+                    idsQuery.addIds(StringUtils.toString(value));
+                }
+                return idsQuery;
+            } else {
+                // Currently all queries are made with ignore case sensitive
+                // Because the query to get exact value have to be run on a not_analyzed field
+                BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+                String key = asDBKey(expr, exprIndex);
+                if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
+                    Collection<?> values = (Collection<?>) ((Constant<?>) expr.getArg(constIndex)).getConstant();
+                    for (Object value : values) {
+                        boolQuery.should(QueryBuilders.queryString(StringUtils.toString(value)).field(key));
+                    }
+                    return boolQuery;
+
+                } else {
+                }
+            }
+
+        } else if (op == Ops.NOT_IN) {
+            // Decompose the query as NOT and IN query
+            return visit(
+                    OperationImpl.create(
+                            Boolean.class,
+                            Ops.NOT,
+                            OperationImpl.create(
+                                    Boolean.class,
+                                    Ops.IN,
+                                    expr.getArg(1))),
+                    context);
+
+        } else if (op == Ops.BETWEEN) {
+            Object from = asDBValue(expr, 1);
+            Object to = asDBValue(expr, 2);
+            return QueryBuilders.rangeQuery(asDBKey(expr, 0)).from(from).to(to);
+
+        } else if (op == Ops.LT) {
+            return QueryBuilders.rangeQuery(asDBKey(expr, 0)).lt(asDBValue(expr, 1));
+
+        } else if (op == Ops.GT) {
+            return QueryBuilders.rangeQuery(asDBKey(expr, 0)).gt(asDBValue(expr, 1));
+
+        } else if (op == Ops.LOE) {
+            return QueryBuilders.rangeQuery(asDBKey(expr, 0)).lte(asDBValue(expr, 1));
+
+        } else if (op == Ops.GOE) {
+            return QueryBuilders.rangeQuery(asDBKey(expr, 0)).gte(asDBValue(expr, 1));
+
+        } else if (op == Ops.STARTS_WITH) {
+            // Currently all queries are made with ignore case sensitive
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            return QueryBuilders.queryString(value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
+
+        } else if (op == Ops.STARTS_WITH_IC) {
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            return QueryBuilders.queryString(value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
+
+        } else if (op == Ops.ENDS_WITH) {
+            // Currently all queries are made with ignore case sensitive
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            return QueryBuilders.queryString("*" + value).field(asDBKey(expr, 0)).analyzeWildcard(true);
+
+        } else if (op == Ops.ENDS_WITH_IC) {
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            return QueryBuilders.queryString("*" + value).field(asDBKey(expr, 0)).analyzeWildcard(true);
+
+        } else if (op == Ops.STRING_CONTAINS) {
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            return QueryBuilders.queryString("*" + value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
+
+        } else if (op == Ops.NOT) {
+            // Handle the not's child
+            BoolQueryBuilder subContext = QueryBuilders.boolQuery();
+            QueryBuilder result = (QueryBuilder) expr.getArg(0).accept(this, subContext);
+            if (result == null) {
+                result = subContext;
+            }
+            return QueryBuilders.boolQuery().mustNot(result);
+
+        }
+
+        throw new UnsupportedOperationException("Illegal operation " + expr);
+    }
+
+    @Nullable
+    @Override
+    public Object visit(ParamExpression<?> expr, @Nullable BoolQueryBuilder context) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Object visit(Path<?> expr, @Nullable BoolQueryBuilder context) {
+        PathMetadata<?> metadata = expr.getMetadata();
+        return getKeyForPath(expr, metadata);
+    }
+
+    @Nullable
+    @Override
+    public Object visit(SubQueryExpression<?> expr, @Nullable BoolQueryBuilder context) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Object visit(TemplateExpression<?> expr, @Nullable BoolQueryBuilder context) {
+        return null;
+    }
+
+    protected String getKeyForPath(Path<?> expr, PathMetadata<?> metadata) {
+        if (isIdPath(expr)) {
+            return "_id";
+        } else {
+            return metadata.getElement().toString();
+        }
+    }
+
+    protected boolean isIdPath(Path<?> expr) {
+        return "id".equals(expr.getMetadata().getElement().toString());
+    }
+
+    private QueryBuilder visitSubAndOr(Operator<?> op, BoolQueryBuilder context, Operation<?> subOperation) {
+        QueryBuilder result;
+        if (AND_OR.contains(subOperation.getOperator()) && subOperation.getOperator() != op) {
+            // Opposite case, if current operator is an AND so sub operation is a OR, so create a sub query
+            result = QueryBuilders.boolQuery();
+            subOperation.accept(this, (BoolQueryBuilder) result);
+        } else {
+            // Here let's do recursive if sub operation has the same operator than the current one (result is null)
+            // or it's another operator than AND/OR so add it to query
+            result = (QueryBuilder) subOperation.accept(this, context);
+        }
+        return result;
+    }
+
+    private void safeMust(BoolQueryBuilder context, QueryBuilder query) {
+        if (query != null) {
+            context.must(query);
+        }
+    }
+
+    private void safeShould(BoolQueryBuilder context, QueryBuilder query) {
+        if (query != null) {
+            context.should(query);
+        }
+    }
+
+}

--- a/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/jackson/JacksonElasticsearchQueries.java
+++ b/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/jackson/JacksonElasticsearchQueries.java
@@ -1,0 +1,114 @@
+package com.mysema.query.elasticsearch.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.mysema.query.elasticsearch.ElasticsearchQuery;
+import com.mysema.query.elasticsearch.ElasticsearchSerializer;
+import com.mysema.query.types.EntityPath;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.search.SearchHit;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+/**
+ * JacksonElasticsearchQueries is a factory to provide ElasticsearchQuery basic implementation.
+ *
+ * @author kevinleturc
+ */
+public class JacksonElasticsearchQueries {
+
+    private final Client client;
+
+    /**
+     * Default constructor.
+     *
+     * @param client The elasticsearch client.
+     */
+    public JacksonElasticsearchQueries(Client client) {
+        this.client = client;
+    }
+
+    public <K> ElasticsearchQuery<K> query(EntityPath<K> entityPath, String index, String type) {
+        return query(entityPath, index, type, new ElasticsearchSerializer());
+    }
+
+    public <K> ElasticsearchQuery<K> query(EntityPath<K> entityPath, String index, String type, ElasticsearchSerializer serializer) {
+        return query(entityPath, index, type, serializer, defaultTransformer(entityPath));
+    }
+
+    public <K> ElasticsearchQuery<K> query(EntityPath<K> entityPath, String index, String type, Function<SearchHit, K> transformer) {
+        return query(entityPath, index, type, new ElasticsearchSerializer(), transformer);
+    }
+
+    public <K> ElasticsearchQuery<K> query(EntityPath<K> entityPath, final String index, final String type, ElasticsearchSerializer serializer, Function<SearchHit, K> transformer) {
+        return new ElasticsearchQuery<K>(client, transformer, serializer, entityPath) {
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public String getIndex(Class<? extends K> entityType) {
+                return index;
+            }
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public String getType(Class<? extends K> entityType) {
+                return type;
+            }
+
+        };
+    }
+
+    /**
+     * Returns the default transformer.
+     *
+     * @param entityPath The entity path.
+     * @param <K> The entity type.
+     * @return The default transformer.
+     */
+    private <K> Function<SearchHit, K> defaultTransformer(final EntityPath<K> entityPath) {
+        final ObjectMapper mapper = new ObjectMapper();
+        return new Function<SearchHit, K>() {
+
+            /**
+             * {@inheritDoc}
+             */
+            @Nullable
+            @Override
+            public K apply(@Nullable SearchHit input) {
+                try {
+                    Class<? extends K> entityType = entityPath.getType();
+                    K bean = mapper.readValue(input.getSourceAsString(), entityType);
+
+                    Field idField = null;
+                    Class<?> target = entityType;
+                    while (idField == null && target != Object.class) {
+                        for (Field field : target.getDeclaredFields()) {
+                            if ("id".equals(field.getName())) {
+                                idField = field;
+                            }
+                        }
+                        target = target.getSuperclass();
+                    }
+                    if (idField != null) {
+                        idField.setAccessible(true);
+                        idField.set(bean, input.getId());
+                    }
+
+                    return bean;
+                } catch (SecurityException se) {
+                    throw new MappingException("Unable to lookup id field, may be use a custom transformer ?", se);
+                } catch (IllegalAccessException e) {
+                    throw new MappingException("Unable to set id value in id field, may be use a custom transformer ?", e);
+                } catch (IOException e) {
+                    throw new MappingException("Unable to read the Elasticsearch response.", e);
+                }
+            }
+        };
+    }
+}

--- a/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/jackson/MappingException.java
+++ b/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/jackson/MappingException.java
@@ -1,0 +1,20 @@
+package com.mysema.query.elasticsearch.jackson;
+
+/**
+ * Mapping exception for factory purposes.
+ *
+ * @author kevinleturc
+ */
+public class MappingException extends RuntimeException {
+
+    /**
+     * Default constructor.
+     *
+     * @param message The message.
+     * @param cause   The cause.
+     */
+    public MappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/jackson/package-info.java
+++ b/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/jackson/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2014, Mysema Ltd
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mysema.query.elasticsearch.jackson;

--- a/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/package-info.java
+++ b/querydsl-elasticsearch/src/main/java/com/mysema/query/elasticsearch/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2011, Mysema Ltd
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mysema.query.elasticsearch;

--- a/querydsl-elasticsearch/src/test/java/com/mysema/query/PackageVerification.java
+++ b/querydsl-elasticsearch/src/test/java/com/mysema/query/PackageVerification.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014, Mysema Ltd
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mysema.query;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.mysema.codegen.CodeWriter;
+import com.mysema.query.apt.elasticsearch.ElasticsearchAnnotationProcessor;
+import com.mysema.query.codegen.CodegenModule;
+import com.mysema.query.types.Expression;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PackageVerification {
+    
+    @Test
+    public void Verify_Package() throws Exception{
+        String version = System.getProperty("version");
+        verify(new File("target/querydsl-elasticsearch-"+version+"-apt-one-jar.jar"));
+    }
+
+    private void verify(File oneJar) throws Exception {
+        assertTrue(oneJar.getPath() + " doesn't exist", oneJar.exists());
+        // verify classLoader
+        URLClassLoader oneJarClassLoader = new URLClassLoader(new URL[]{oneJar.toURI().toURL()});
+        oneJarClassLoader.loadClass(Expression.class.getName()); // querydsl-core
+        oneJarClassLoader.loadClass(CodeWriter.class.getName()); // codegen
+        oneJarClassLoader.loadClass(CodegenModule.class.getName()).newInstance();
+        oneJarClassLoader.loadClass(Entity.class.getName()); // elasticsearch
+        Class cl = oneJarClassLoader.loadClass(ElasticsearchAnnotationProcessor.class.getName()); // querydsl-apt
+        cl.newInstance();
+        String resourceKey = "META-INF/services/javax.annotation.processing.Processor";
+        assertEquals(ElasticsearchAnnotationProcessor.class.getName(), Resources.toString(oneJarClassLoader.findResource(resourceKey), Charsets.UTF_8));
+    }
+    
+}

--- a/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/ElasticsearchQueryTest.java
+++ b/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/ElasticsearchQueryTest.java
@@ -1,0 +1,303 @@
+package com.mysema.query.elasticsearch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.mysema.query.NonUniqueResultException;
+import com.mysema.query.SearchResults;
+import com.mysema.query.elasticsearch.domain.QUser;
+import com.mysema.query.elasticsearch.domain.User;
+import com.mysema.query.elasticsearch.jackson.JacksonElasticsearchQueries;
+import com.mysema.query.types.OrderSpecifier;
+import com.mysema.query.types.Predicate;
+import com.mysema.testutil.ExternalDB;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.elasticsearch.client.Requests.refreshRequest;
+import static org.junit.Assert.*;
+
+@Category(ExternalDB.class)
+public class ElasticsearchQueryTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static Client client;
+
+    private final String indexUser = "index1";
+    private final String typeUser = "user";
+
+    private final QUser user = QUser.user;
+    List<User> users = Lists.newArrayList();
+    User u1, u2, u3, u4;
+
+    public ElasticsearchQueryTest() {
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        ImmutableSettings.Builder settings = ImmutableSettings.builder().put("path.data", ElasticsearchQueryTest.class.getResource("").getPath());
+        Node node = NodeBuilder.nodeBuilder().local(true).settings(settings).node();
+        client = node.client();
+
+    }
+
+    @Before
+    public void before() {
+        deleteType(indexUser);
+        createIndex(indexUser);
+
+        u1 = addUser("Jaakko", "Jantunen", 20);
+        u2 = addUser("Jaakki", "Jantunen", 30);
+        u3 = addUser("Jaana", "Aakkonen", 40);
+        u4 = addUser("Jaana", "BeekkoNen", 50);
+
+        refresh(indexUser, false);
+    }
+
+    @Test
+    public void Count() {
+        assertEquals(4, query().count());
+    }
+
+    @Test
+    public void Count_Predicate() {
+        assertEquals(2, where(user.lastName.eq("Jantunen")).count());
+    }
+
+    @Test
+    public void SingleResult_Keys() {
+        User u = where(user.firstName.eq("Jaakko")).singleResult(user.firstName);
+        assertEquals("Jaakko", u.getFirstName());
+        assertNull(u.getLastName());
+        assertEquals(0, u.getAge());
+    }
+
+    @Test
+    public void UniqueResult_Keys() {
+        User u = where(user.firstName.eq("Jaakko")).uniqueResult(user.firstName);
+        assertEquals("Jaakko", u.getFirstName());
+        assertNull(u.getLastName());
+        assertEquals(0, u.getAge());
+    }
+
+    @Test(expected = NonUniqueResultException.class)
+    public void UniqueResult_Keys_Non_Unique() {
+        where(user.firstName.eq("Jaana")).uniqueResult(user.firstName);
+    }
+
+    @Test
+    public void Contains() {
+        //assertQuery(user.friends.contains(u1), u3, u4, u2);
+    }
+
+    @Test
+    public void Contains2() {
+        //assertQuery(user.friends.contains(u4));
+    }
+
+    @Test
+    public void NotContains() {
+        //assertQuery(user.friends.contains(u1).not(), u1);
+    }
+
+    @Test
+    public void Equals_Ignore_Case() {
+        assertTrue(where(user.firstName.equalsIgnoreCase("jAaKko")).exists());
+        assertFalse(where(user.firstName.equalsIgnoreCase("AaKk")).exists());
+    }
+
+    @Test
+    public void Starts_With_and_Between() {
+        assertQuery(user.firstName.startsWith("Jaa").and(user.age.between(20, 30)), u2, u1);
+        assertQuery(user.firstName.startsWith("Jaa").and(user.age.goe(20).and(user.age.loe(30))), u2, u1);
+    }
+
+    @Test
+    public void Exists() {
+        assertTrue(where(user.firstName.eq("Jaakko")).exists());
+        assertFalse(where(user.firstName.eq("JaakkoX")).exists());
+        assertTrue(where(user.id.eq(u1.getId())).exists());
+    }
+
+    @Test
+    public void Find_By_Id() {
+        assertNotNull(where(user.id.eq(u1.getId())).uniqueResult());
+    }
+
+    @Test
+    public void Find_By_Ids() {
+        assertQuery(user.id.in(u1.getId(), u2.getId()), u2, u1);
+    }
+
+    @Test
+    public void Order() {
+        List<User> users = query().orderBy(user.age.asc()).list();
+        assertEquals(asList(u1, u2, u3, u4), users);
+
+        users = query().orderBy(user.age.desc()).list();
+        assertEquals(asList(u4, u3, u2, u1), users);
+    }
+
+    @Test
+    public void ListResults() {
+        SearchResults<User> results = query().limit(2).orderBy(user.age.asc()).listResults();
+        assertEquals(4l, results.getTotal());
+        assertEquals(2, results.getResults().size());
+
+        results = query().offset(2).orderBy(user.age.asc()).listResults();
+        assertEquals(4l, results.getTotal());
+        assertEquals(2, results.getResults().size());
+    }
+
+    @Test
+    public void EmptyResults() {
+        SearchResults<User> results = query().where(user.firstName.eq("XXX")).listResults();
+        assertEquals(0l, results.getTotal());
+        assertEquals(Collections.<User>emptyList(), results.getResults());
+    }
+
+    @Test
+    public void EqInAndOrderByQueries() {
+        assertQuery(user.firstName.eq("Jaakko"), u1);
+        assertQuery(user.firstName.equalsIgnoreCase("jaakko"), u1);
+        assertQuery(user.lastName.eq("Aakkonen"), u3);
+
+        assertQuery(user.firstName.in("Jaakko","Teppo"), u1);
+        assertQuery(user.lastName.in("Aakkonen", "BeekkoNen"), u3, u4);
+
+        assertQuery(user.firstName.eq("Jouko"));
+
+        assertQuery(user.firstName.eq("Jaana"), user.lastName.asc(), u3, u4);
+        assertQuery(user.firstName.eq("Jaana"), user.lastName.desc(), u4, u3);
+        assertQuery(user.lastName.eq("Jantunen"), user.firstName.asc(), u2, u1);
+        assertQuery(user.lastName.eq("Jantunen"), user.firstName.desc(), u1, u2);
+
+        assertQuery(user.firstName.eq("Jaana").and(user.lastName.eq("Aakkonen")), u3);
+        //This shoud produce 'and' also
+        assertQuery(where(user.firstName.eq("Jaana"), user.lastName.eq("Aakkonen")), u3);
+
+        assertQuery(user.firstName.ne("Jaana"), u2, u1);
+        assertQuery(user.firstName.ne("Jaana").and(user.lastName.ne("Jantunen")));
+        assertQuery(user.firstName.eq("Jaana").and(user.lastName.eq("Aakkonen")).not(), u4, u2, u1);
+
+    }
+
+    @Test
+    public void Iterate() {
+        User a = addUser("A", "A", 10);
+        User b = addUser("A1", "B", 10);
+        User c = addUser("A2", "C", 10);
+
+        refresh(indexUser, false);
+
+        Iterator<User> i = where(user.firstName.startsWith("A"))
+                .orderBy(user.firstName.asc())
+                .iterate();
+
+        assertEquals(a, i.next());
+        assertEquals(b, i.next());
+        assertEquals(c, i.next());
+        assertEquals(false, i.hasNext());
+    }
+
+    @Test
+    public void Enum_Eq() {
+        assertQuery(user.gender.eq(User.Gender.MALE), u3, u4, u2, u1);
+    }
+
+    @Test
+    public void Enum_Ne() {
+        assertQuery(user.gender.ne(User.Gender.MALE));
+    }
+
+    private ElasticsearchQuery<User> query() {
+        return new JacksonElasticsearchQueries(client).query(QUser.user, indexUser, typeUser);
+    }
+
+    private ElasticsearchQuery<User> where(Predicate predicate) {
+        return query().where(predicate);
+    }
+
+    private ElasticsearchQuery<User> where(Predicate ... e) {
+        return query().where(e);
+    }
+
+    private void assertQuery(Predicate e, User ... expected) {
+        assertQuery(where(e).orderBy(user.lastName.asc(), user.firstName.asc()), expected);
+    }
+
+    private void assertQuery(Predicate e, OrderSpecifier<?> orderBy, User ... expected ) {
+        assertQuery(where(e).orderBy(orderBy), expected);
+    }
+
+    private void assertQuery(ElasticsearchQuery<User> query, User ... expected ) {
+        List<User> results = query.list();
+
+        assertNotNull(results);
+        if (expected == null ) {
+            assertEquals("Should get empty result", 0, results.size());
+            return;
+        }
+        assertEquals(expected.length, results.size());
+        int i = 0;
+        for (User u : expected) {
+            assertEquals(u, results.get(i++));
+        }
+    }
+
+    private User addUser(String first, String last, int age) {
+        User user = new User(first, last, age, new Date());
+        user.setGender(User.Gender.MALE);
+        try {
+            IndexResponse response = client.prepareIndex(indexUser, typeUser).setSource(mapper.writeValueAsString(user)).execute().actionGet();
+            user.setId(response.getId());
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        users.add(user);
+        return user;
+    }
+
+    public void deleteType(String index) {
+        if (indexExists(index)) {
+            client.admin().indices().delete(new DeleteIndexRequest(index)).actionGet();
+        }
+    }
+
+    public boolean indexExists(String index) {
+        return client.admin().indices().exists(Requests.indicesExistsRequest(index)).actionGet().isExists();
+    }
+
+    public boolean createIndex(String index) {
+        if (indexExists(index)) {
+            return true;
+        }
+
+        CreateIndexRequestBuilder createIndexRequestBuilder = client.admin().indices().prepareCreate(index);
+        return createIndexRequestBuilder.execute().actionGet().isAcknowledged();
+    }
+
+    public void refresh(String indexName, boolean waitForOperation) {
+        client.admin().indices().refresh(refreshRequest(indexName).force(waitForOperation)).actionGet();
+    }
+
+}

--- a/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/ElasticsearchSerializerTest.java
+++ b/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/ElasticsearchSerializerTest.java
@@ -1,0 +1,314 @@
+/*
+* Copyright 2011, Mysema Ltd
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.mysema.query.elasticsearch;
+
+import com.google.common.collect.Lists;
+import com.mysema.query.elasticsearch.domain.QUser;
+import com.mysema.query.types.Expression;
+import com.mysema.query.types.path.*;
+import org.apache.lucene.queryparser.flexible.core.util.StringUtils;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.junit.Assert.assertEquals;
+
+public class ElasticsearchSerializerTest {
+
+    private PathBuilder<Object> entityPath;
+    private StringPath id;
+    private StringPath title;
+    private NumberPath<Integer> year;
+    private NumberPath<Double> gross;
+
+    private NumberPath<Long> longField;
+    private NumberPath<Short> shortField;
+    private NumberPath<Byte> byteField;
+    private NumberPath<Float> floatField;
+
+    private DatePath<Date> date;
+    private final Date dateVal = new Date();
+    private DateTimePath<Timestamp> dateTime;
+    private final Timestamp dateTimeVal = new Timestamp(System.currentTimeMillis());
+
+    private ElasticsearchSerializer serializer;
+
+    @Before
+    public void before() {
+        serializer = new ElasticsearchSerializer();
+        entityPath = new PathBuilder<Object>(Object.class, "obj");
+        id = entityPath.getString("id");
+        title = entityPath.getString("title");
+        year = entityPath.getNumber("year", Integer.class);
+        gross = entityPath.getNumber("gross", Double.class);
+        longField = entityPath.getNumber("longField", Long.class);
+        shortField = entityPath.getNumber("shortField", Short.class);
+        byteField = entityPath.getNumber("byteField", Byte.class);
+        floatField = entityPath.getNumber("floatField", Float.class);
+        date = entityPath.getDate("date", Date.class);
+        dateTime = entityPath.getDateTime("dateTime", Timestamp.class);
+    }
+
+    @Test
+    public void Paths() {
+        QUser user = QUser.user;
+        assertEquals("user", serializer.visit(user, null));
+        //assertEquals("addresses", serializer.visit(user.addresses, null));
+        //assertEquals("addresses", serializer.visit(user.addresses.any(), null));
+        //assertEquals("addresses.street", serializer.visit(user.addresses.any().street, null));
+        assertEquals("firstName", serializer.visit(user.firstName, null));
+    }
+
+    @Test
+    public void PropertyAnnotation() {
+        //QDummyEntity entity = QDummyEntity.dummyEntity;
+        //assertEquals("prop", serializer.visit(entity.property, null));
+    }
+
+    @Test
+    public void IndexedAccess() {
+        QUser user = QUser.user;
+        //assertEquals("addresses.0.street", serializer.visit(user.addresses.get(0).street, null));
+    }
+
+    @Test
+    public void CollectionAny() {
+        QUser user = QUser.user;
+        //assertQuery(eq("addresses.street", "Aakatu"), user.addresses.any().street.eq("Aakatu"));
+    }
+
+    @Test
+    public void Equals() {
+        assertQuery(and(eq("title", "A")), title.eq("A"));
+        assertQuery(and(eq("year", 1)), year.eq(1));
+        assertQuery(and(eq("gross", 1.0D)), gross.eq(1.0D));
+        assertQuery(and(eq("longField", 1L)), longField.eq(1L));
+        assertQuery(and(eq("shortField", 1)), shortField.eq((short)1));
+        assertQuery(and(eq("byteField", 1L)), byteField.eq((byte)1));
+        assertQuery(and(eq("floatField", 1.0F)), floatField.eq(1.0F));
+
+        assertQuery(and(eq("date", dateVal)), date.eq(dateVal));
+        assertQuery(and(eq("dateTime", dateTimeVal)), dateTime.eq(dateTimeVal));
+
+        assertQuery(and(idsQuery().ids("id1")), id.eq("id1"));
+    }
+
+    @Test
+    public void EqAndEq() {
+        assertQuery(
+            and(eq("title", "A"), eq("year", 1)),
+            title.eq("A").and(year.eq(1))
+        );
+
+        assertQuery(
+            and(eq("year", 1), eq("gross", 1.0D), eq("title", "A")),
+            title.eq("A").and(year.eq(1).and(gross.eq(1.0D)))
+        );
+
+        assertQuery(
+                and(eq("title", "A"), eq("year", 1), eq("gross", 1.0D)),
+                title.eq("A").and(year.eq(1)).and(gross.eq(1.0D))
+        );
+    }
+
+    @Test
+    public void EqOrEq() {
+        assertQuery(
+                or(eq("title", "A"), eq("year", 1)),
+                title.eq("A").or(year.eq(1))
+        );
+
+        assertQuery(
+                or(eq("year", 1), eq("gross", 1.0D), eq("title", "A")),
+                title.eq("A").or(year.eq(1).or(gross.eq(1.0D)))
+        );
+
+        assertQuery(
+                or(eq("title", "A"), eq("year", 1), eq("gross", 1.0D)),
+                title.eq("A").or(year.eq(1)).or(gross.eq(1.0D))
+        );
+    }
+
+    @Test
+    public void In() {
+        assertQuery(
+            and(in("title", Lists.newArrayList("A", "B", "C"))),
+            title.in(Lists.newArrayList("A", "B", "C"))
+        );
+    }
+
+    @Test
+    public void Between() {
+        Date start = new Date(31L * 24L * 60L * 60L * 1000L);
+        Date end = new Date();
+        assertQuery(
+                and(between("date", start, end)),
+                date.between(start, end)
+        );
+
+        assertQuery(
+                and(between("year", 1, 2)),
+                year.between(1, 2)
+        );
+    }
+
+    @Test
+    public void InAndBetween() {
+        Date start = new Date(31L * 24L * 60L * 60L * 1000L);
+        Date end = new Date();
+        assertQuery(
+                and(in("title", Lists.newArrayList("A", "B", "C")), between("date", start, end)),
+                title.in(Lists.newArrayList("A", "B", "C")).and(date.between(start, end))
+        );
+    }
+
+    @Test
+    public void EqOrEqAndEq() {
+
+        assertQuery(
+                or(eq("title", "A"), and(eq("year", 1), eq("gross", 1.0D))),
+                title.eq("A").or(year.eq(1).and(gross.eq(1.0D)))
+        );
+
+        assertQuery(
+                and(
+                        or(eq("title", "A"), eq("year", 1)),
+                        eq("gross", 1.0D)),
+                title.eq("A").or(year.eq(1)).and(gross.eq(1.0D))
+        );
+    }
+
+    @Test
+    public void EqAndEqOrEq() {
+
+        assertQuery(
+                and(
+                        eq("title", "A"),
+                        or(eq("year", 1), eq("gross", 1.0D))),
+                title.eq("A").and(year.eq(1).or(gross.eq(1.0D)))
+        );
+
+        assertQuery(
+                or(
+                        and(eq("title", "A"), eq("year", 1)),
+                        eq("gross", 1.0D)),
+                title.eq("A").and(year.eq(1)).or(gross.eq(1.0D))
+        );
+    }
+
+    @Test
+    public void EqAndEqOrEqAndEq() {
+
+        assertQuery(
+                and(
+                        or(
+                                and(eq("title", "A"), eq("year", 1)),
+                                eq("title", "B")),
+                        eq("year", 2)
+                ),
+                title.eq("A").and(year.eq(1)).or(title.eq("B")).and(year.eq(2))
+        );
+
+        assertQuery(
+                or(
+                        and(eq("title", "A"), eq("year", 1)),
+                        and(eq("title", "B"), eq("year", 2))
+                ),
+                title.eq("A").and(year.eq(1)).or(title.eq("B").and(year.eq(2)))
+        );
+
+        assertQuery(
+                and(
+                        or(
+                                eq("year", 1),
+                                eq("title", "B")),
+                        eq("year", 2),
+                        eq("title", "A")),
+                title.eq("A").and(year.eq(1).or(title.eq("B")).and(year.eq(2)))
+        );
+
+        assertQuery(
+                and(
+                        eq("title", "A"),
+                        or(
+                                eq("year", 1),
+                                and(eq("title", "B"), eq("year", 2)))),
+                title.eq("A").and(year.eq(1).or(title.eq("B").and(year.eq(2))))
+        );
+
+    }
+
+    public static QueryBuilder eq(String key, Object value) {
+        return QueryBuilders.queryString(StringUtils.toString(value)).field(key);
+    }
+
+    public static QueryBuilder in(String key, Iterable<?> values) {
+        BoolQueryBuilder query = boolQuery();
+        for (Object value : values) {
+            query.should(eq(key, value));
+        }
+        return query;
+    }
+
+    public static QueryBuilder and(QueryBuilder... builders) {
+        BoolQueryBuilder query = boolQuery();
+        must(query, builders);
+        return query;
+    }
+
+    public static QueryBuilder or(QueryBuilder... builders) {
+        BoolQueryBuilder query = boolQuery();
+        should(query, builders);
+        return query;
+    }
+
+    public static BoolQueryBuilder must(BoolQueryBuilder query, QueryBuilder... builders) {
+        for (QueryBuilder builder : builders) {
+            query.must(builder);
+        }
+        return query;
+    }
+
+    public static BoolQueryBuilder should(BoolQueryBuilder query, QueryBuilder... builders) {
+        for (QueryBuilder builder : builders) {
+            query.should(builder);
+        }
+        return query;
+    }
+
+    public static QueryBuilder between(String key, int start, int end) {
+        return rangeQuery(key).from(start).to(end);
+    }
+
+    public static QueryBuilder between(String key, double start, double end) {
+        return rangeQuery(key).from(start).to(end);
+    }
+
+    public static QueryBuilder between(String key, Date start, Date end) {
+        return rangeQuery(key).from(start).to(end);
+    }
+
+    private void assertQuery(QueryBuilder expected, Expression<?> e) {
+        QueryBuilder result = (QueryBuilder) serializer.handle(e);
+        assertEquals(expected.toString(), result.toString());
+    }
+
+
+}

--- a/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/domain/AbstractEntity.java
+++ b/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/domain/AbstractEntity.java
@@ -1,0 +1,44 @@
+package com.mysema.query.elasticsearch.domain;
+
+import com.mysema.query.annotations.QuerySupertype;
+
+@QuerySupertype
+public abstract class AbstractEntity {
+
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AbstractEntity other = (AbstractEntity) obj;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        return true;
+    }
+
+
+}

--- a/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/domain/User.java
+++ b/querydsl-elasticsearch/src/test/java/com/mysema/query/elasticsearch/domain/User.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2011, Mysema Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mysema.query.elasticsearch.domain;
+
+import com.mysema.query.annotations.QueryEntity;
+
+import java.util.Date;
+
+@QueryEntity
+public class User extends AbstractEntity {
+
+    public enum Gender { MALE, FEMALE }
+
+    private String firstName;
+
+    private String lastName;
+
+    private Date created;
+
+    private Gender gender;
+
+    //@QueryEmbedded
+    //private final List<Address> addresses = new ArrayList<Address>();
+
+    //@QueryEmbedded
+    //private Address mainAddress;
+
+    private int age;
+
+    public User() {
+    }
+
+    public User(String firstName, String lastName) {
+        this.firstName = firstName; this.lastName = lastName;
+        this.created = new Date();
+    }
+
+    public User(String firstName, String lastName, int age, Date created) {
+        this.firstName = firstName; this.lastName = lastName; this.age = age; this.created = created;
+    }
+
+    @Override
+    public String toString() {
+        return "TestUser [id=" + getId() + ", firstName=" + firstName + ", lastName=" + lastName
+                + "]";
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public Gender getGender() {
+        return gender;
+    }
+
+    public void setGender(Gender gender) {
+        this.gender = gender;
+    }
+
+}

--- a/querydsl-root/pom.xml
+++ b/querydsl-root/pom.xml
@@ -293,7 +293,11 @@
             <group>
               <title>Mongodb</title>
               <packages>com.mysema.query.mongodb*</packages>        
-            </group>            
+            </group>
+            <group>
+              <title>Elasticsearch</title>
+              <packages>com.mysema.query.elasticsearch*</packages>
+            </group>
           </groups>
         </configuration>
       </plugin>
@@ -402,6 +406,7 @@
         
         <!-- NoSQL -->
         <module>../querydsl-mongodb</module>
+        <module>../querydsl-elasticsearch</module>
         
         <!-- Languages -->        
         <module>../querydsl-scala</module>
@@ -469,6 +474,16 @@
         <module>../querydsl-mongodb</module>        
       </modules>
     </profile>
+
+    <profile>
+      <id>elasticsearch</id>
+      <modules>
+        <module>../querydsl-core</module>
+        <module>../querydsl-codegen</module>
+        <module>../querydsl-apt</module>
+        <module>../querydsl-elasticsearch</module>
+      </modules>
+     </profile>
     
     <profile>
       <id>sql</id>


### PR DESCRIPTION
Hi,

I used `querydsl-jpa` and `querydsl-mongodb` with the Spring integration. I recently install an Elasticsearch cluster for analytics purpose with `sping-data-elasticsearch` bridge. Nevertheless the named query methods in spring is not type and name safe, which I really like in querydsl features.

So I have developed a first integration of elasticsearch in querydsl. Currently the implementation allows to run "classic" operations such as `EQ`, `BETWEEN`, `AND`, `OR`... There's a query factory _JacksonElasticsearchQueries_ to create the queries by Q-type, elasticsearch index and elasticsearch type. We could also customize serializer and/or transformer.

I didn't write documentation about it, do you have some advices to give me ?
I hope this PR will help the project.

Bye
Kevin
