### PR TITLE
Fixed 'java.lang.IllegalArgumentException: Undeclared path ...' when creating order by with subquery

### DIFF
--- a/querydsl-core/src/main/java/com/mysema/query/support/QueryMixin.java
+++ b/querydsl-core/src/main/java/com/mysema/query/support/QueryMixin.java
@@ -353,7 +353,7 @@ public class QueryMixin<T> {
     }
 
     public final T orderBy(OrderSpecifier<?> spec) {
-        Expression<?> e = convert(spec.getTarget(), true);
+        Expression<?> e = convert(spec.getTarget(), false);
         if (!spec.getTarget().equals(e)) {
             metadata.addOrderBy(new OrderSpecifier(spec.getOrder(), e));
         } else {

--- a/querydsl-jpa/src/test/java/com/mysema/query/jpa/SubQueryTest.java
+++ b/querydsl-jpa/src/test/java/com/mysema/query/jpa/SubQueryTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import com.mysema.query.domain.QCat;
 import com.mysema.query.jpa.domain.QEmployee;
 import com.mysema.query.jpa.domain.QUser;
+import com.mysema.query.types.query.NumberSubQuery;
 
 public class SubQueryTest extends AbstractQueryTest{
 
@@ -191,4 +192,14 @@ public class SubQueryTest extends AbstractQueryTest{
                         sub().from(cat).where(cat.name.indexOf("a").eq(1)).count());
     }
     
+    @Test
+    public void OrderBy() {
+        JPQLQuery query = query().from(cat1).where(cat1.alive);
+        NumberSubQuery<Double> subquery = sub().from(cat).where(cat.mate.id.eq(cat1.id)).unique(cat.floatProperty.avg());
+        query.orderBy(subquery.subtract(-1.0f).asc());
+
+        assertEquals("select cat1 from Cat cat1 where cat1.alive order by (select avg(cat.floatProperty) from Cat cat where cat.mate.id = cat1.id) - ?1 asc",
+                        query.toString().replace("\n", " "));
+    }
+
 }

--- a/querydsl-root/pom.xml
+++ b/querydsl-root/pom.xml
@@ -147,6 +147,13 @@
     </developer>
   </developers>
 
+  <contributors>
+    <contributor>
+      <name>Marvin Froeder</name>
+      <email>velo.br@gmail.com</email>
+    </contributor>
+  </contributors>
+
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>


### PR DESCRIPTION
Hi,

After migrating from  3_2_3 to 3_5_1 we begin to see the following exception:

```
java.lang.IllegalArgumentException: Undeclared path 'cat'. Add this path as a source to the query to be able to reference it.
    at com.mysema.query.types.ValidatingVisitor.visit(ValidatingVisitor.java:78)
    at com.mysema.query.types.ValidatingVisitor.visit(ValidatingVisitor.java:1)
    at com.mysema.query.types.path.BeanPath.accept(BeanPath.java:75)
    at com.mysema.query.types.ValidatingVisitor.visit(ValidatingVisitor.java:65)
    at com.mysema.query.types.ValidatingVisitor.visit(ValidatingVisitor.java:1)
    at com.mysema.query.types.OperationImpl.accept(OperationImpl.java:90)
    at com.mysema.query.DefaultQueryMetadata.validate(DefaultQueryMetadata.java:351)
    at com.mysema.query.DefaultQueryMetadata.addJoin(DefaultQueryMetadata.java:155)
    at com.mysema.query.support.QueryMixin.leftJoin(QueryMixin.java:314)
    at com.mysema.query.jpa.JPAQueryMixin.shorten(JPAQueryMixin.java:122)
    at com.mysema.query.jpa.JPAQueryMixin.convertPathForOrder(JPAQueryMixin.java:149)
    at com.mysema.query.jpa.JPAQueryMixin.access$0(JPAQueryMixin.java:135)
    at com.mysema.query.jpa.JPAQueryMixin$1.visit(JPAQueryMixin.java:171)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:1)
    at com.mysema.query.types.PathImpl.accept(PathImpl.java:94)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:162)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:49)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:1)
    at com.mysema.query.types.OperationImpl.accept(OperationImpl.java:90)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:128)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:1)
    at com.mysema.query.types.SubQueryExpressionImpl.accept(SubQueryExpressionImpl.java:57)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:162)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:49)
    at com.mysema.query.support.ReplaceVisitor.visit(ReplaceVisitor.java:1)
    at com.mysema.query.types.OperationImpl.accept(OperationImpl.java:90)
    at com.mysema.query.jpa.JPAQueryMixin.convert(JPAQueryMixin.java:175)
    at com.mysema.query.support.QueryMixin.orderBy(QueryMixin.java:356)
    at com.mysema.query.support.QueryMixin.orderBy(QueryMixin.java:367)
    at com.mysema.query.support.QueryBase.orderBy(QueryBase.java:107)
    at com.mysema.query.jpa.JPAQueryBase.orderBy(JPAQueryBase.java:1)
    at com.mysema.query.jpa.SubQueryTest.OrderBy(SubQueryTest.java:199)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:44)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:41)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:76)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:193)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:52)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:191)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:42)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:184)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:236)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
```

I investigate a little bit, and notice the 3_2_3 behaves like convert was call passing false intead
