### PR TITLE
Add javadoc `{@link }`s to hyperlink the original source

### DIFF
--- a/querydsl-codegen/src/main/java/com/mysema/query/codegen/EntitySerializer.java
+++ b/querydsl-codegen/src/main/java/com/mysema/query/codegen/EntitySerializer.java
@@ -688,6 +688,10 @@ public class EntitySerializer implements Serializer {
     protected void serializeProperties(EntityType model,  SerializerConfig config,
             CodeWriter writer) throws IOException {
         for (Property property : model.getProperties()) {
+
+            //Add a navigational javadoc comment
+            writer.javadoc("{@link "+ property.getDeclaringType().getFullName() + "#" + property.getName() + "}");
+
             // FIXME : the custom types should have the custom type category
             if (typeMappings.isRegistered(property.getType())
                     && property.getType().getCategory() != TypeCategory.CUSTOM


### PR DESCRIPTION
When coding, I often see myself having to click on a property to get to a QObject, and then click through to get to the original model object, but then having to look up the property.
This hyperlinks the original source.
Backport of 7e15b1e88be5eade9cbbebf4f9c103994421295a