### PR TITLE
Replace occurrence of java.util.Objects with com.google.common.base.Objects

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/support/ReplaceVisitor.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/ReplaceVisitor.java
@@ -15,8 +15,8 @@ package com.querydsl.core.support;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.querydsl.core.*;
 import com.querydsl.core.types.*;
@@ -71,7 +71,7 @@ public class ReplaceVisitor<C> implements Visitor<Expression<?>, C> {
             if (element instanceof Expression<?>) {
                 element = ((Expression) element).accept(this, context);
             }
-            if (parent.equals(metadata.getParent()) && Objects.equals(element, metadata.getElement())) {
+            if (parent.equals(metadata.getParent()) && Objects.equal(element, metadata.getElement())) {
                 return expr;
             } else {
                 metadata = new PathMetadata(parent, element, metadata.getPathType());


### PR DESCRIPTION
The former is not available on JDK6.
fixes #1162