### PR TITLE
Remove compiler warnings

### DIFF
--- a/querydsl-collections/src/main/java/com/querydsl/collections/CollQuerySerializer.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/CollQuerySerializer.java
@@ -195,7 +195,7 @@ public final class CollQuerySerializer extends SerializerBase<CollQuerySerialize
             handle(args.get(0));
             append(OPERATOR_SYMBOLS.get(operator));
             handle(args.get(1));
-            if (args.get(1) instanceof Constant) {
+            if (args.get(1) instanceof Constant<?>) {
                 append(CAST_SUFFIXES.get(args.get(1).getType()));
             }
             return;
@@ -204,7 +204,10 @@ public final class CollQuerySerializer extends SerializerBase<CollQuerySerialize
         if (operator == Ops.STRING_CAST) {
             visitCast(operator, args.get(0), String.class);
         } else if (operator == Ops.NUMCAST) {
-            visitCast(operator, args.get(0), (Class<?>) ((Constant<?>) args.get(1)).getConstant());
+            @SuppressWarnings("unchecked") //this is the second argument's type
+            Constant<Class<?>> rightArg = (Constant<Class<?>>) args.get(1);
+
+            visitCast(operator, args.get(0), rightArg.getConstant());
         } else {
             super.visitOperation(type, operator, args);
         }

--- a/querydsl-core/src/main/java/com/querydsl/core/support/PathsExtractor.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/PathsExtractor.java
@@ -72,7 +72,7 @@ public final class PathsExtractor implements Visitor<Void, List<Path<?>>> {
     public Path<?> visit(Collection<?> exprs, List<Path<?>> paths) {
         for (Object e : exprs) {
             if (e instanceof Expression) {
-                ((Expression) e).accept(this, paths);
+                ((Expression<?>) e).accept(this, paths);
             }
         }
         return null;

--- a/querydsl-core/src/main/java/com/querydsl/core/support/QueryMixin.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/QueryMixin.java
@@ -428,8 +428,8 @@ public class QueryMixin<T> {
     public final boolean equals(Object o) {
         if (o == this) {
             return true;
-        } else if (o instanceof QueryMixin) {
-            QueryMixin q = (QueryMixin)o;
+        } else if (o instanceof QueryMixin<?>) {
+            QueryMixin<?> q = (QueryMixin<?>)o;
             return q.metadata.equals(metadata);
         } else {
             return false;

--- a/querydsl-core/src/main/java/com/querydsl/core/support/ReplaceVisitor.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/ReplaceVisitor.java
@@ -69,7 +69,7 @@ public class ReplaceVisitor<C> implements Visitor<Expression<?>, C> {
             Path<?> parent = (Path)metadata.getParent().accept(this, context);
             Object element = metadata.getElement();
             if (element instanceof Expression<?>) {
-                element = ((Expression) element).accept(this, context);
+                element = ((Expression<?>) element).accept(this, context);
             }
             if (parent.equals(metadata.getParent()) && Objects.equal(element, metadata.getElement())) {
                 return expr;
@@ -138,7 +138,7 @@ public class ReplaceVisitor<C> implements Visitor<Expression<?>, C> {
         ImmutableList.Builder builder = ImmutableList.builder();
         for (Object arg : expr.getArgs()) {
             if (arg instanceof Expression) {
-                builder.add(((Expression)arg).accept(this, context));
+                builder.add(((Expression<?>)arg).accept(this, context));
             } else {
                 builder.add(arg);
             }

--- a/querydsl-core/src/main/java/com/querydsl/core/support/SerializerBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/SerializerBase.java
@@ -101,7 +101,7 @@ public abstract class SerializerBase<S extends SerializerBase<S>> implements Vis
     
     public final S handle(Object arg) {
         if (arg instanceof Expression) {
-            ((Expression)arg).accept(this, null);
+            ((Expression<?>)arg).accept(this, null);
         } else {
             visitConstant(arg);
         }
@@ -136,7 +136,7 @@ public abstract class SerializerBase<S extends SerializerBase<S>> implements Vis
         for (final Template.Element element : template.getElements()) {
             final Object rv = element.convert(args);
             if (rv instanceof Expression) {                    
-                ((Expression)rv).accept(this, null);
+                ((Expression<?>)rv).accept(this, null);
             } else if (element.isString()) {
                 builder.append(rv.toString());
             } else {

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ConstantImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ConstantImpl.java
@@ -21,21 +21,25 @@ import javax.annotation.concurrent.Immutable;
  * @author tiwe
  */
 @Immutable
-@SuppressWarnings("unchecked")
 public final class ConstantImpl<T> extends ExpressionBase<T> implements Constant<T> {
 
     private static final long serialVersionUID = -3898138057967814118L;
 
     private static final int CACHE_SIZE = 256;
 
+    @SuppressWarnings({"rawtypes", "unchecked"}) //generic array creation not possible
     private static final Constant<Character>[] CHARACTERS = new Constant[CACHE_SIZE];
 
+    @SuppressWarnings({"rawtypes", "unchecked"}) //generic array creation not possible
     private static final Constant<Byte>[] BYTES = new Constant[CACHE_SIZE];
 
+    @SuppressWarnings({"rawtypes", "unchecked"}) //generic array creation not possible
     private static final Constant<Integer>[] INTEGERS = new Constant[CACHE_SIZE];
 
+    @SuppressWarnings({"rawtypes", "unchecked"}) //generic array creation not possible
     private static final Constant<Long>[] LONGS = new Constant[CACHE_SIZE];
 
+    @SuppressWarnings({"rawtypes", "unchecked"}) //generic array creation not possible
     private static final Constant<Short>[] SHORTS = new Constant[CACHE_SIZE];
 
     private static final Constant<Boolean> FALSE = new ConstantImpl<Boolean>(Boolean.FALSE);
@@ -107,6 +111,7 @@ public final class ConstantImpl<T> extends ExpressionBase<T> implements Constant
      *
      * @param constant
      */
+    @SuppressWarnings("unchecked") //The class of the constant will mandate the type
     public ConstantImpl(T constant) {
         this((Class)constant.getClass(), constant);
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/Template.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/Template.java
@@ -59,7 +59,7 @@ public final class Template implements Serializable {
         @Override
         public Object convert(final List<?> args) {
             final Object arg = args.get(index);
-            return arg instanceof Constant ? arg.toString() : arg;
+            return arg instanceof Constant<?> ? arg.toString() : arg;
         }
 
         @Override

--- a/querydsl-core/src/main/java/com/querydsl/core/types/TemplateFactory.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/TemplateFactory.java
@@ -49,7 +49,7 @@ public class TemplateFactory {
             new Function<Object,Object>() {
                 @Override
                 public Object apply(Object arg) {
-                    if (arg instanceof Constant) {
+                    if (arg instanceof Constant<?>) {
                         return ConstantImpl.create(apply(arg.toString()).toString());
                     } else if (arg instanceof Expression) {
                         return OperationImpl.create(String.class, Ops.LOWER, (Expression)arg);
@@ -63,7 +63,7 @@ public class TemplateFactory {
             new Function<Object,Object>() {
                 @Override
                 public Object apply(Object arg) {
-                    if (arg instanceof Constant) {
+                    if (arg instanceof Constant<?>) {
                         return ConstantImpl.create(apply(arg.toString()).toString());
                     } else if (arg instanceof Expression) {
                         return OperationImpl.create(String.class, Ops.UPPER, (Expression)arg);
@@ -77,7 +77,7 @@ public class TemplateFactory {
             new Function<Object,Object>() {
                 @Override
                 public Object apply(Object arg) {
-                    if (arg instanceof Constant) {
+                    if (arg instanceof Constant<?>) {
                         return ConstantImpl.create(apply(arg.toString()).toString());
                     } else if (arg instanceof Expression) {
                         return OperationImpl.create(String.class, Ops.CONCAT, (Expression)arg, PERCENT);
@@ -91,7 +91,7 @@ public class TemplateFactory {
             new Function<Object,Object>() {
                 @Override
                 public Object apply(Object arg) {
-                    if (arg instanceof Constant) {
+                    if (arg instanceof Constant<?>) {
                         return ConstantImpl.create(apply(arg.toString()).toString());
                     } else if (arg instanceof Expression) {
                         Expression<String> concatenated = OperationImpl.create(String.class, Ops.CONCAT, (Expression)arg, PERCENT);
@@ -120,7 +120,7 @@ public class TemplateFactory {
             new Function<Object,Object>() {
                 @Override
                 public Object apply(Object arg) {
-                    if (arg instanceof Constant) {
+                    if (arg instanceof Constant<?>) {
                         return ConstantImpl.create(apply(arg.toString()).toString());
                     } else if (arg instanceof Expression) {
                         Expression<String> concatenated = OperationImpl.create(String.class, Ops.CONCAT, PERCENT, (Expression)arg);
@@ -135,7 +135,7 @@ public class TemplateFactory {
             new Function<Object,Object>() {
                 @Override
                 public Object apply(Object arg) {
-                    if (arg instanceof Constant) {
+                    if (arg instanceof Constant<?>) {
                         return ConstantImpl.create(apply(arg.toString()).toString());
                     } else if (arg instanceof Expression) {
                         Expression<String> concatenated = OperationImpl.create(String.class, Ops.CONCAT, PERCENT, (Expression)arg);
@@ -150,7 +150,7 @@ public class TemplateFactory {
             new Function<Object,Object>() {
                 @Override
                 public Object apply(Object arg) {
-                    if (arg instanceof Constant) {
+                    if (arg instanceof Constant<?>) {
                         return ConstantImpl.create(apply(arg.toString()).toString());
                     } else if (arg instanceof Expression) {
                         Expression<String> concatenated = OperationImpl.create(String.class, Ops.CONCAT, PERCENT, (Expression)arg);

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ToStringVisitor.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ToStringVisitor.java
@@ -60,12 +60,12 @@ public final class ToStringVisitor implements Visitor<String,Templates> {
                     if (precedence > -1 && rv instanceof Operation) {
                         if (precedence < templates.getPrecedence(((Operation<?>)rv).getOperator())) {
                             builder.append("(");
-                            builder.append(((Expression)rv).accept(this, templates));
+                            builder.append(((Expression<?>)rv).accept(this, templates));
                             builder.append(")");
                             continue;
                         }
                     }
-                    builder.append(((Expression)rv).accept(this, templates));
+                    builder.append(((Expression<?>)rv).accept(this, templates));
                 } else {
                     builder.append(rv.toString());
                 }
@@ -93,7 +93,7 @@ public final class ToStringVisitor implements Visitor<String,Templates> {
                 for (Template.Element element : pattern.getElements()) {
                     Object rv = element.convert(args);
                     if (rv instanceof Expression) {
-                        builder.append(((Expression)rv).accept(this, templates));
+                        builder.append(((Expression<?>)rv).accept(this, templates));
                     } else {
                         builder.append(rv.toString());
                     }
@@ -118,7 +118,7 @@ public final class ToStringVisitor implements Visitor<String,Templates> {
         for (Template.Element element : expr.getTemplate().getElements()) {
             Object rv = element.convert(expr.getArgs());
             if (rv instanceof Expression) {
-                builder.append(((Expression)rv).accept(this, templates));
+                builder.append(((Expression<?>)rv).accept(this, templates));
             } else {
                 builder.append(rv.toString());
             }

--- a/querydsl-core/src/test/java/com/querydsl/core/ProjectionsFactory.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/ProjectionsFactory.java
@@ -149,7 +149,7 @@ public class ProjectionsFactory {
             rv.add(expr.countDistinct());
         }
 
-        if (!(other instanceof Constant || module == Module.JDO || module == Module.RDFBEAN)) {
+        if (!(other instanceof Constant<?> || module == Module.JDO || module == Module.RDFBEAN)) {
             CaseBuilder cases = new CaseBuilder();
             rv.add(NumberConstant.create(1).add(cases
                 .when(expr.gt(10)).then(expr)
@@ -206,7 +206,7 @@ public class ProjectionsFactory {
         rv.add(expr.substring(1));
         rv.add(expr.substring(0, 1));
 
-        if (!(other instanceof Constant || module == Module.JDO || module == Module.RDFBEAN)) {
+        if (!(other instanceof Constant<?> || module == Module.JDO || module == Module.RDFBEAN)) {
             CaseBuilder cases = new CaseBuilder();
             rv.add(cases.when(expr.eq("A")).then(other)
                         .when(expr.eq("B")).then(expr)

--- a/querydsl-core/src/test/java/com/querydsl/core/StringConstant.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/StringConstant.java
@@ -58,10 +58,9 @@ public final class StringConstant extends StringExpression implements Constant<S
         return v.visit(this, context);
     }
     
-    @SuppressWarnings("unchecked")
     @Override
     public StringExpression append(Expression<String> s) {
-        if (s instanceof Constant) {
+        if (s instanceof Constant<?>) {
             return append(((Constant<String>)s).getConstant());
         } else {
             return super.append(s);
@@ -134,10 +133,9 @@ public final class StringConstant extends StringExpression implements Constant<S
         return BooleanConstant.create(!constant.equals(s));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public StringExpression prepend(Expression<String> s) {
-        if (s instanceof Constant) {
+        if (s instanceof Constant<?>) {
             return prepend(((Constant<String>)s).getConstant());
         } else {
             return super.prepend(s);

--- a/querydsl-core/src/test/java/com/querydsl/core/support/DetachableAdapterTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/DetachableAdapterTest.java
@@ -23,17 +23,15 @@ import com.querydsl.core.Detachable;
 import com.querydsl.core.alias.Alias;
 import com.querydsl.core.types.EntityPath;
 
-
-@SuppressWarnings("unchecked")
 public class DetachableAdapterTest {
     
-    private QueryMixin queryMixin;
+    private QueryMixin<?> queryMixin;
     
     private Detachable detachable;
     
     @Before
     public void setUp() {
-        queryMixin = new QueryMixin();
+        queryMixin = new QueryMixin<Void>();
         detachable = new DetachableAdapter(new DetachableMixin(queryMixin));
     }
     

--- a/querydsl-core/src/test/java/com/querydsl/core/support/DetachableMixinTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/DetachableMixinTest.java
@@ -27,17 +27,15 @@ import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.ListSubQuery;
 
-
-@SuppressWarnings("unchecked")
 public class DetachableMixinTest {
 
-    private QueryMixin query;
+    private QueryMixin<?> query;
 
     private DetachableMixin detachable;
 
     @Before
     public void setUp() {
-        query = new QueryMixin();
+        query = new QueryMixin<Void>();
         detachable = new DetachableMixin(query);
     }
 

--- a/querydsl-core/src/test/java/com/querydsl/core/support/DetachableQueryTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/DetachableQueryTest.java
@@ -22,14 +22,14 @@ import org.junit.Test;
 import com.querydsl.core.alias.Alias;
 import com.querydsl.core.types.EntityPath;
 
-@SuppressWarnings("unchecked")
 public class DetachableQueryTest {
     
-    private QueryMixin query;
+    private QueryMixin<?> query;
     
-    private DetachableQuery detachable;
+    private DetachableQuery<?> detachable;
     
     @Before
+    @SuppressWarnings({"rawtypes", "unchecked"}) //not interested for testing purposes
     public void setUp() {
         query = new QueryMixin();
         detachable = new DetachableQuery(query);

--- a/querydsl-core/src/test/java/com/querydsl/core/support/ProjectableQueryTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/ProjectableQueryTest.java
@@ -20,12 +20,11 @@ import org.junit.Test;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 
-@SuppressWarnings("unchecked")
 public class ProjectableQueryTest {
         
     @Test
     public void UniqueResult_Of_Array() {
-       QueryMixin queryMixin = new QueryMixin();
+       QueryMixin<DummyProjectable> queryMixin = new QueryMixin<DummyProjectable>();
        DummyProjectable projectable = new DummyProjectable(queryMixin);
        projectable.uniqueResult(new Expression[0]);
        assertEquals(Long.valueOf(2), queryMixin.getMetadata().getModifiers().getLimit());
@@ -33,7 +32,7 @@ public class ProjectableQueryTest {
     
     @Test
     public void UniqueResult() {
-       QueryMixin queryMixin = new QueryMixin();
+       QueryMixin<DummyProjectable> queryMixin = new QueryMixin<DummyProjectable>();
        DummyProjectable projectable = new DummyProjectable(queryMixin);
        projectable.uniqueResult(Projections.bean(Object.class));
        assertEquals(Long.valueOf(2), queryMixin.getMetadata().getModifiers().getLimit());

--- a/querydsl-core/src/test/java/com/querydsl/core/support/QueryMixinPerformanceTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/QueryMixinPerformanceTest.java
@@ -20,7 +20,7 @@ public class QueryMixinPerformanceTest {
         
         long start = System.currentTimeMillis();
         for (int i = 0; i < iterations; i++) {
-            QueryMixin mixin = new QueryMixin();
+            QueryMixin<?> mixin = new QueryMixin<Void>();
             mixin.from(entity);
             mixin.where(other.eq(new DummyEntity()));
             mixin.setProjection(entity);
@@ -37,7 +37,7 @@ public class QueryMixinPerformanceTest {
         
         long start = System.currentTimeMillis();
         for (int i = 0; i < iterations; i++) {
-            QueryMixin mixin = new QueryMixin();
+            QueryMixin<?> mixin = new QueryMixin<Void>();
             mixin.from(entities);
             mixin.where(other.eq(new DummyEntity()));
             mixin.setProjection(entity);

--- a/querydsl-core/src/test/java/com/querydsl/core/support/QueryMixinTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/QueryMixinTest.java
@@ -28,8 +28,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 
 public class QueryMixinTest {
 
-    @SuppressWarnings("unchecked")
-    private QueryMixin<?> mixin = new QueryMixin();
+    private QueryMixin<?> mixin = new QueryMixin<Void>();
 
     private QCommonPersistence entity = new QCommonPersistence(PathMetadataFactory.forVariable("entity"));
 

--- a/querydsl-core/src/test/java/com/querydsl/core/types/ExpressivityTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/ExpressivityTest.java
@@ -20,13 +20,12 @@ public class ExpressivityTest {
     
     private DetachableMixin sub;
     
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Before
     public void setUp() {
         num = Expressions.numberPath(Integer.class, "num");
         str = Expressions.stringPath("str");
         date = Expressions.datePath(Date.class, "date");
-        QueryMixin query = new QueryMixin();
+        QueryMixin<?> query = new QueryMixin<Void>();
         query.from(num, str);
         sub = new DetachableMixin(query);
     }

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/NumberPathTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/NumberPathTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import com.querydsl.core.types.Constant;
 import com.querydsl.core.types.Operation;
-import com.querydsl.core.types.dsl.NumberPath;
 
 public class NumberPathTest {
 
@@ -31,8 +30,8 @@ public class NumberPathTest {
     @Test
     public void BytePath_in() {
         Operation<?> operation = (Operation<?>) bytePath.in(1, 2, 3);
-
-        List<Byte> numbers = (List<Byte>) ((Constant)operation.getArg(1)).getConstant();
+        Constant<List<Byte>> rightArg = (Constant<List<Byte>>) operation.getArg(1);
+        List<Byte> numbers = rightArg.getConstant();
         assertEquals(Byte.valueOf((byte)1), numbers.get(0));
         assertEquals(Byte.valueOf((byte)2), numbers.get(1));
         assertEquals(Byte.valueOf((byte)3), numbers.get(2));
@@ -42,8 +41,8 @@ public class NumberPathTest {
     @Test
     public void BytePath_notIn() {
         Operation<?> operation = (Operation<?>) bytePath.notIn(1, 2, 3);
-
-        List<Byte> numbers = (List<Byte>) ((Constant)operation.getArg(1)).getConstant();
+        Constant<List<Byte>> rightArg = (Constant<List<Byte>>) operation.getArg(1);
+        List<Byte> numbers = rightArg.getConstant();
         assertEquals(Byte.valueOf((byte)1), numbers.get(0));
         assertEquals(Byte.valueOf((byte)2), numbers.get(1));
         assertEquals(Byte.valueOf((byte)3), numbers.get(2));

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQLSerializer.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQLSerializer.java
@@ -273,16 +273,20 @@ public final class JDOQLSerializer extends SerializerBase<JDOQLSerializer> {
         return null;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+//    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     protected void visitOperation(Class<?> type, Operator operator, List<? extends Expression<?>> args) {
         if (operator == Ops.INSTANCE_OF) {
             handle(args.get(0)).append(" instanceof ");
-            append(((Constant<Class<?>>) args.get(1)).getConstant().getName());
+            @SuppressWarnings("unchecked") //This is the expected type for instanceOf
+            Constant<Class<?>> rightArg = (Constant<Class<?>>) args.get(1);
+            append(rightArg.getConstant().getName());
 
         } else if (operator == Ops.LIKE || operator == Ops.LIKE_ESCAPE) {
+            @SuppressWarnings("unchecked") //This is the expected type for like
+            Expression<String> rightArg = (Expression<String>) args.get(1);
             super.visitOperation(type, Ops.MATCHES, 
-                ImmutableList.of(args.get(0), ExpressionUtils.likeToRegex((Expression<String>) args.get(1), false)));
+                ImmutableList.of(args.get(0), ExpressionUtils.likeToRegex(rightArg, false)));
             
         // exists    
         } else if (operator == Ops.EXISTS && args.get(0) instanceof SubQueryExpression) {
@@ -300,7 +304,9 @@ public final class JDOQLSerializer extends SerializerBase<JDOQLSerializer> {
             append(") == 0");
                 
         } else if (operator == Ops.NUMCAST) {
-            Class<?> clazz = ((Constant<Class<?>>)args.get(1)).getConstant();
+            @SuppressWarnings("unchecked") //This is the expected type for castToNum
+            Constant<Class<?>> rightArg = (Constant<Class<?>>)args.get(1);
+            Class<?> clazz = rightArg.getConstant();
             if (Number.class.isAssignableFrom(clazz) && Primitives.isWrapperType(clazz)) {
                 clazz = Primitives.unwrap(clazz);
             }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateDeleteClause.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateDeleteClause.java
@@ -39,7 +39,7 @@ import org.hibernate.StatelessSession;
  */
 public class HibernateDeleteClause implements DeleteClause<HibernateDeleteClause> {
 
-    private final QueryMixin queryMixin = new JPAQueryMixin();
+    private final QueryMixin<?> queryMixin = new JPAQueryMixin<Void>();
 
     private final SessionHolder session;
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateUpdateClause.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateUpdateClause.java
@@ -42,7 +42,7 @@ import com.querydsl.jpa.JPQLTemplates;
 public class HibernateUpdateClause implements
         UpdateClause<HibernateUpdateClause> {
 
-    private final QueryMixin queryMixin = new JPAQueryMixin();
+    private final QueryMixin<?> queryMixin = new JPAQueryMixin<Void>();
 
     private final Map<Path<?>, Expression<?>> updates = Maps.newLinkedHashMap();
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPADeleteClause.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPADeleteClause.java
@@ -36,7 +36,7 @@ import com.querydsl.core.types.Predicate;
  */
 public class JPADeleteClause implements DeleteClause<JPADeleteClause> {
 
-    private final QueryMixin queryMixin = new JPAQueryMixin();
+    private final QueryMixin<?> queryMixin = new JPAQueryMixin<Void>();
 
     private final EntityManager entityManager;
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAUpdateClause.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAUpdateClause.java
@@ -39,7 +39,7 @@ import com.querydsl.jpa.JPQLTemplates;
  */
 public class JPAUpdateClause implements UpdateClause<JPAUpdateClause> {
 
-    private final QueryMixin queryMixin = new JPAQueryMixin();
+    private final QueryMixin<?> queryMixin = new JPAQueryMixin<Void>();
 
     private final Map<Path<?>, Expression<?>> updates = Maps.newLinkedHashMap();
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryMixinTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryMixinTest.java
@@ -18,7 +18,7 @@ import com.querydsl.jpa.domain4.QBookVersion;
 
 public class JPAQueryMixinTest {
 
-    private JPAQueryMixin mixin = new JPAQueryMixin();
+    private JPAQueryMixin<?> mixin = new JPAQueryMixin<Object>();
 
     @Test
     public void Where_Null() {

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/LuceneSerializer.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/LuceneSerializer.java
@@ -116,7 +116,9 @@ public class LuceneSerializer {
         } else if (op == Ops.GOE) {
             return ge(operation, metadata);
         } else if (op == LuceneOps.LUCENE_QUERY) {
-            return ((Constant<Query>)operation.getArg(0)).getConstant();
+            @SuppressWarnings("unchecked") //this is the expected type
+            Constant<Query> expectedConstant = (Constant<Query>)operation.getArg(0);
+            return expectedConstant.getConstant();
         }
         throw new UnsupportedOperationException("Illegal operation " + operation);
     }
@@ -160,15 +162,15 @@ public class LuceneSerializer {
         return new WildcardQuery(new Term(field, terms[0]));
     }
 
-    @SuppressWarnings("unchecked")
     protected Query eq(Operation<?> operation, QueryMetadata metadata, boolean ignoreCase) {
         verifyArguments(operation);
         Path<?> path = getPath(operation.getArg(0));
         String field = toField(path);
 
         if (Number.class.isAssignableFrom(operation.getArg(1).getType())) {
-            return new TermQuery(new Term(field, convertNumber(((Constant<Number>) operation
-                    .getArg(1)).getConstant())));
+            @SuppressWarnings("unchecked") //guarded by previous check
+            Constant<? extends Number> rightArg = (Constant<? extends Number>) operation.getArg(1);
+            return new TermQuery(new Term(field, convertNumber(rightArg.getConstant())));
         }
 
         return eq(field, convert(path, operation.getArg(1), metadata), ignoreCase);
@@ -214,7 +216,9 @@ public class LuceneSerializer {
     protected Query in(Operation<?> operation, QueryMetadata metadata, boolean ignoreCase) {
         Path<?> path = getPath(operation.getArg(0));
         String field = toField(path);
-        Collection<?> values = (Collection<?>) ((Constant<?>) operation.getArg(1)).getConstant();
+        @SuppressWarnings("unchecked") //this is the expected type
+        Constant<Collection<?>> expectedConstant = (Constant<Collection<?>>) operation.getArg(1);
+        Collection<?> values = expectedConstant.getConstant();
         BooleanQuery bq = new BooleanQuery();
         for (Object value : values) {
             String[] str = convert(path, value);
@@ -352,15 +356,23 @@ public class LuceneSerializer {
                 metadata);
     }
 
-    @SuppressWarnings({"unchecked"})
     protected Query range(Path<?> leftHandSide, String field, @Nullable Expression<?> min,
             @Nullable Expression<?> max, boolean minInc, boolean maxInc, QueryMetadata metadata) {
         if (min != null && Number.class.isAssignableFrom(min.getType()) || max != null
                 && Number.class.isAssignableFrom(max.getType())) {
-            Class<? extends Number> numType = (Class) (min != null ? min.getType() : max.getType());
-            return numericRange((Class) numType, field, (Number) (min == null ? null
-                    : ((Constant) min).getConstant()), (Number) (max == null ? null
-                    : ((Constant) max).getConstant()), minInc, maxInc);
+            @SuppressWarnings("unchecked") //guarded by previous check
+            Constant<? extends Number> minConstant = (Constant<? extends Number>) min;
+            @SuppressWarnings("unchecked") //guarded by previous check
+            Constant<? extends Number> maxConstant = (Constant<? extends Number>) max;
+
+            Class<? extends Number> numType = minConstant != null ? minConstant.getType() : maxConstant.getType();
+            //this is not necessarily safe, but compile time checking
+            //on the user side mandates these types to be interchangeable
+            @SuppressWarnings("unchecked")
+            Class<Number> unboundedNumType = (Class<Number>)numType;
+            return numericRange(unboundedNumType, field, minConstant == null ? null
+                    : minConstant.getConstant(), maxConstant == null ? null
+                            : maxConstant.getConstant(), minInc, maxInc);
         }
         return stringRange(leftHandSide, field, min, max, minInc, maxInc, metadata);
     }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -51,7 +51,9 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
     @Override
     public Object visit(Constant<?> expr, Void context) {
         if (Enum.class.isAssignableFrom(expr.getType())) {
-            return ((Enum<?>)expr.getConstant()).name();
+            @SuppressWarnings("unchecked") //Guarded by previous check
+            Constant<? extends Enum<?>> expectedExpr = (Constant<? extends Enum<?>>)expr;
+            return expectedExpr.getConstant().name();
         } else {
             return expr.getConstant();
         }
@@ -190,7 +192,8 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
                 exprIndex = 0;
             }
             if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
-                Collection<?> values = (Collection<?>) ((Constant<?>) expr.getArg(constIndex)).getConstant();
+                @SuppressWarnings("unchecked") //guarded by previous check
+                Collection<?> values = ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
                 return asDBObject(asDBKey(expr, exprIndex), asDBObject("$in", values.toArray()));
             } else {
                 if (isReference(expr, exprIndex)) {
@@ -208,7 +211,8 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
                 exprIndex = 0;
             }
             if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
-                Collection<?> values = (Collection<?>) ((Constant<?>) expr.getArg(constIndex)).getConstant();
+                @SuppressWarnings("unchecked") //guarded by previous check
+                Collection<?> values = ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
                 return asDBObject(asDBKey(expr, exprIndex), asDBObject("$nin", values.toArray()));
             } else {
                 if (isReference(expr, exprIndex)) {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -475,7 +475,7 @@ public abstract class ProjectableSQLQuery<Q extends ProjectableSQLQuery<Q> & Que
                 .equals(expandProjection(firstUnionSubQuery.getMetadata().getProjection()))) {
                 serializer.serializeUnion(union, queryMixin.getMetadata(), unionAll);
             } else {
-                QueryMixin mixin2 = new QueryMixin(queryMixin.getMetadata().clone());
+                QueryMixin<Q> mixin2 = new QueryMixin<Q>(queryMixin.getMetadata().clone());
                 Set<Path<?>> paths = getRootPaths(expandProjection(mixin2.getMetadata().getProjection()));
                 if (paths.isEmpty()) {
                     mixin2.from(ExpressionUtils.as((Expression) union, defaultQueryAlias));

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLExpressions.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLExpressions.java
@@ -85,7 +85,7 @@ public final class SQLExpressions {
             if (args[i] instanceof Expression) {
                 exprs[i] = (Expression)args[i];
             } else {
-                exprs[i] = new ConstantImpl(args[i]);
+                exprs[i] = ConstantImpl.create(args[i]);
             }
         }
         return exprs;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
@@ -852,7 +852,7 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
          && args.get(0) instanceof Path<?>
          && args.get(1) instanceof Constant<?>
          && operator != Ops.NUMCAST) {
-            Object constant = ((Constant)args.get(1)).getConstant();
+            Object constant = ((Constant<?>)args.get(1)).getConstant();
             if (!Collection.class.isInstance(constant) || !((Collection)constant).isEmpty()) {
                 for (Element element : templates.getTemplate(operator).getElements()) {
                     if (element instanceof Template.ByIndex && ((Template.ByIndex)element).getIndex() == 1) {
@@ -870,7 +870,7 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
             super.visitOperation(type, operator, args);
             inUnion = oldUnion;
 
-        } else if (operator == Ops.LIKE && args.get(1) instanceof Constant) {
+        } else if (operator == Ops.LIKE && args.get(1) instanceof Constant<?>) {
             final String escape = String.valueOf(templates.getEscapeChar());
             final String escaped = args.get(1).toString().replace(escape, escape + escape);
             super.visitOperation(String.class, Ops.LIKE,
@@ -882,7 +882,10 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
                     ImmutableList.of(args.get(0), ConstantImpl.create(typeName)));
 
         } else if (operator == Ops.NUMCAST) {
-            final Class<?> targetType = (Class<?>) ((Constant<?>) args.get(1)).getConstant();
+            @SuppressWarnings("unchecked") //this is the second argument's type
+            Constant<Class<?>> expectedConstant = (Constant<Class<?>>) args.get(1);
+
+            final Class<?> targetType = expectedConstant.getConstant();
             final String typeName = configuration.getTypeNameForCast(targetType);
             super.visitOperation(targetType, SQLOps.CAST,
                     ImmutableList.of(args.get(0), ConstantImpl.create(typeName)));

--- a/querydsl-sql/src/test/java/com/querydsl/sql/PaginationTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/PaginationTest.java
@@ -39,7 +39,7 @@ public class PaginationTest {
 
         for (SQLTemplates templates : list) {
             QEmployee employee = QEmployee.employee;
-            QueryMixin query = new QueryMixin();
+            QueryMixin<?> query = new QueryMixin<Void>();
             query.from(employee);
             query.orderBy(employee.firstname.asc());
             query.setProjection(employee.id);

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -432,7 +432,7 @@ public class SelectBase extends AbstractBaseTest {
 
         Map<Object, Object> failures = Maps.newIdentityHashMap();
         for (Object dt : data) {
-            Object dt2 = query().singleResult(new ConstantImpl(dt));
+            Object dt2 = query().singleResult(ConstantImpl.create(dt));
             if (!dt.equals(dt2)) {
                 failures.put(dt, dt2);
             }


### PR DESCRIPTION
Related to #1191 

Since a lot of rawtypes compiler warnings cause unchecked compiler warnings, it is useful to weed those out first.