### PR TITLE
Improve SelectBase coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <!-- deps -->
     <derby.version>10.11.1.1</derby.version>
     <hsqldb.version>2.3.2</hsqldb.version>
-    <h2.version>1.4.178</h2.version>
+    <h2.version>1.4.186</h2.version>
     <postgresql.version>9.4-1200-jdbc41</postgresql.version>
     <oracle.version>11.1.0.7.0</oracle.version>
     <mysql.version>5.1.30</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <project.checkout>scm:git:git@github.com:querydsl/querydsl.git</project.checkout>
     
     <!-- deps -->
-    <derby.version>10.10.1.1</derby.version>
+    <derby.version>10.11.1.1</derby.version>
     <hsqldb.version>2.3.1</hsqldb.version>
     <h2.version>1.4.178</h2.version>
     <postgresql.version>9.3-1101-jdbc41</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     
     <!-- deps -->
     <derby.version>10.11.1.1</derby.version>
-    <hsqldb.version>2.3.1</hsqldb.version>
+    <hsqldb.version>2.3.2</hsqldb.version>
     <h2.version>1.4.178</h2.version>
     <postgresql.version>9.3-1101-jdbc41</postgresql.version>
     <oracle.version>11.1.0.7.0</oracle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <oracle.version>11.1.0.7.0</oracle.version>
     <mysql.version>5.1.30</mysql.version>
     <jtds.version>1.3.1</jtds.version>
-    <cubrid.version>8.4.0</cubrid.version>
+    <cubrid.version>9.3.1.0005</cubrid.version>
     <sqlite.version>3.7.2</sqlite.version>
     <teradata.version>13.10.00.35</teradata.version>
     <firebird.version>2.2.5</firebird.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <derby.version>10.11.1.1</derby.version>
     <hsqldb.version>2.3.2</hsqldb.version>
     <h2.version>1.4.178</h2.version>
-    <postgresql.version>9.3-1101-jdbc41</postgresql.version>
+    <postgresql.version>9.4-1200-jdbc41</postgresql.version>
     <oracle.version>11.1.0.7.0</oracle.version>
     <mysql.version>5.1.30</mysql.version>
     <jtds.version>1.3.1</jtds.version>

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SQLServerGeometryType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SQLServerGeometryType.java
@@ -13,16 +13,18 @@
  */
 package com.querydsl.sql.spatial;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import com.querydsl.sql.types.AbstractType;
+import javax.annotation.Nullable;
+
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.codec.Wkt;
+
+import com.querydsl.sql.types.AbstractType;
 
 /**
  * @author tiwe
@@ -72,7 +74,7 @@ public class SQLServerGeometryType extends AbstractType<Geometry> {
         if (geometry.getSRID() > -1) {
             return "geometry::STGeomFromText('" + str + "', " + geometry.getSRID() + ")";
         } else {
-            return "geometry::STGeomFromText('" + str + "')";
+            return "geometry::STGeomFromText('" + str + "', 4326)";
         }
     }
 

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SQLServerGeometryType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SQLServerGeometryType.java
@@ -34,6 +34,8 @@ public class SQLServerGeometryType extends AbstractType<Geometry> {
 
     public static final SQLServerGeometryType DEFAULT = new SQLServerGeometryType();
 
+    private static final int DEFAULT_SRID = 4326;
+
     public SQLServerGeometryType() {
         super(Types.BLOB);
     }
@@ -74,7 +76,7 @@ public class SQLServerGeometryType extends AbstractType<Geometry> {
         if (geometry.getSRID() > -1) {
             return "geometry::STGeomFromText('" + str + "', " + geometry.getSRID() + ")";
         } else {
-            return "geometry::STGeomFromText('" + str + "', 4326)";
+            return "geometry::STGeomFromText('" + str + "', " + DEFAULT_SRID + ")";
         }
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/CUBRIDTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/CUBRIDTemplates.java
@@ -62,6 +62,8 @@ public class CUBRIDTemplates extends SQLTemplates {
         setDefaultValues("\ndefault values");
         setArraysSupported(false);
 
+        add(Ops.DateTimeOps.DATE, "trunc({0})");
+
         add(Ops.DateTimeOps.DAY_OF_YEAR, "dayofyear({0})");
         add(Ops.DateTimeOps.DAY_OF_WEEK, "dayofweek({0})");
         add(Ops.DateTimeOps.YEAR_WEEK, "(year({0}) * 100 + week({0}))");
@@ -73,6 +75,15 @@ public class CUBRIDTemplates extends SQLTemplates {
         add(Ops.DateTimeOps.ADD_HOURS, "date_add({0}, interval {1s} hour)");
         add(Ops.DateTimeOps.ADD_MINUTES, "date_add({0}, interval {1s} minute)");
         add(Ops.DateTimeOps.ADD_SECONDS, "date_add({0}, interval {1s} second)");
+
+        String diffSeconds = "(unix_timestamp({1}) - unix_timestamp({0}))";
+        add(Ops.DateTimeOps.DIFF_YEARS,   "(year({1}) - year({0}))");
+        add(Ops.DateTimeOps.DIFF_MONTHS,  "months_between({1}, {0})");
+        add(Ops.DateTimeOps.DIFF_WEEKS,   "ceil(({1}-{0}) / 7)");
+        add(Ops.DateTimeOps.DIFF_DAYS,    "({1}-{0})");
+        add(Ops.DateTimeOps.DIFF_HOURS,   "ceil(" + diffSeconds + " / 3600)");
+        add(Ops.DateTimeOps.DIFF_MINUTES, "ceil(" + diffSeconds + " / 60)");
+        add(Ops.DateTimeOps.DIFF_SECONDS, diffSeconds);
 
         add(Ops.DateTimeOps.TRUNC_YEAR,   "trunc({0},'yyyy')");
         add(Ops.DateTimeOps.TRUNC_MONTH,  "trunc({0},'mm')");
@@ -100,6 +111,21 @@ public class CUBRIDTemplates extends SQLTemplates {
         addTypeNameToCode("varchar", Types.LONGVARCHAR, true);
         addTypeNameToCode("double", Types.FLOAT, true);
         addTypeNameToCode("float", Types.REAL, true);
+    }
+
+
+    @Override
+    public String serialize(String literal, int jdbcType) {
+        switch (jdbcType) {
+            case Types.DATE:
+                return "date'" + literal + "'";
+            case Types.TIME:
+                return "time'" + literal + "'";
+            case Types.TIMESTAMP:
+                return "timestamp'" + literal + "'";
+            default:
+                return super.serialize(literal, jdbcType);
+        }
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/DB2Templates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/DB2Templates.java
@@ -182,18 +182,17 @@ public class DB2Templates extends SQLTemplates {
         add(Ops.DateTimeOps.ADD_MINUTES, "{0} + {1} minutes");
         add(Ops.DateTimeOps.ADD_SECONDS, "{0} + {1} seconds");
 
-        // FIXME
-        add(Ops.DateTimeOps.DIFF_YEARS, "timestampdiff(256, char({0} - {1}))");
-        add(Ops.DateTimeOps.DIFF_MONTHS, "timestampdiff(64, char({0} - {1}))");
-        add(Ops.DateTimeOps.DIFF_WEEKS, "timestampdiff(32, char({0} - {1}))");
-        add(Ops.DateTimeOps.DIFF_DAYS, "timestampdiff(16, char({0} - {1}))");
-        add(Ops.DateTimeOps.DIFF_HOURS, "timestampdiff(8, char({0} - {1}))");
-        add(Ops.DateTimeOps.DIFF_MINUTES, "timestampdiff(4, char({0} - {1}))");
-        add(Ops.DateTimeOps.DIFF_SECONDS, "timestampdiff(2, char({0} - {1}))");
+        add(Ops.DateTimeOps.DIFF_YEARS,   "timestampdiff(256, char(timestamp({1}) - timestamp({0})))");
+        add(Ops.DateTimeOps.DIFF_MONTHS,  "timestampdiff(64, char(timestamp({1}) - timestamp({0})))");
+        add(Ops.DateTimeOps.DIFF_WEEKS,   "timestampdiff(32, char(timestamp({1}) - timestamp({0})))");
+        add(Ops.DateTimeOps.DIFF_DAYS,    "timestampdiff(16, char(timestamp({1}) - timestamp({0})))");
+        add(Ops.DateTimeOps.DIFF_HOURS,   "timestampdiff(8, char(timestamp({1}) - timestamp({0})))");
+        add(Ops.DateTimeOps.DIFF_MINUTES, "timestampdiff(4, char(timestamp({1}) - timestamp({0})))");
+        add(Ops.DateTimeOps.DIFF_SECONDS, "timestampdiff(2, char(timestamp({1}) - timestamp({0})))");
 
         add(Ops.DateTimeOps.TRUNC_YEAR, "trunc_timestamp({0}, 'year')");
         add(Ops.DateTimeOps.TRUNC_MONTH, "trunc_timestamp({0}, 'month')");
-        add(Ops.DateTimeOps.TRUNC_WEEK, "trunc_timestamp({0}, 'week')");
+        add(Ops.DateTimeOps.TRUNC_WEEK, "trunc_timestamp({0}, 'ww')");
         add(Ops.DateTimeOps.TRUNC_DAY, "trunc_timestamp({0}, 'dd')");
         add(Ops.DateTimeOps.TRUNC_HOUR, "trunc_timestamp({0}, 'hh')");
         add(Ops.DateTimeOps.TRUNC_MINUTE, "trunc_timestamp({0}, 'mi')");
@@ -214,20 +213,6 @@ public class DB2Templates extends SQLTemplates {
         switch (code) {
             case Types.VARCHAR:  return "varchar(4000)";
             default: return super.getCastTypeNameForCode(code);
-        }
-    }
-
-
-    @Override
-    public String serialize(String literal, int jdbcType) {
-        if (jdbcType == Types.TIMESTAMP) {
-            return "{ts '" + literal + "'}";
-        } else if (jdbcType == Types.DATE) {
-            return "{d '" + literal + "'}";
-        } else if (jdbcType == Types.TIME) {
-            return "{t '" + literal + "'}";
-        } else {
-            return super.serialize(literal, jdbcType);
         }
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/FirebirdTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/FirebirdTemplates.java
@@ -94,6 +94,14 @@ public class FirebirdTemplates extends SQLTemplates {
         add(Ops.DateTimeOps.DIFF_MINUTES, "datediff(minute,{0},{1})");
         add(Ops.DateTimeOps.DIFF_SECONDS, "datediff(second,{0},{1})");
 
+        add(Ops.DateTimeOps.TRUNC_YEAR,   "cast(extract(year from {0}) || '-1-1' as date)");
+        add(Ops.DateTimeOps.TRUNC_MONTH,  "cast(substring(cast({0} as char(100)) from 1 for 7) || '-1' as date)");
+        // TODO weeks
+        add(Ops.DateTimeOps.TRUNC_DAY,    "cast(substring(cast({0} as char(100)) from 1 for 10) as date)");
+        add(Ops.DateTimeOps.TRUNC_HOUR,   "cast(substring(cast({0} as char(100)) from 1 for 13) || ':00:00' as timestamp)");
+        add(Ops.DateTimeOps.TRUNC_MINUTE, "cast(substring(cast({0} as char(100)) from 1 for 16) || ':00' as timestamp)");
+        add(Ops.DateTimeOps.TRUNC_SECOND, "cast(substring(cast({0} as char(100)) from 1 for 19) as timestamp)");
+
         addTypeNameToCode("smallint", Types.BOOLEAN, true);
         addTypeNameToCode("smallint", Types.BIT, true);
         addTypeNameToCode("smallint", Types.TINYINT, true);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
@@ -143,15 +143,19 @@ public class OracleTemplates extends SQLTemplates {
         addTypeNameToCode("raw", Types.VARBINARY);
         addTypeNameToCode("long", Types.LONGVARCHAR);
         addTypeNameToCode("varchar2", Types.VARCHAR);
+
+        addTypeNameToCode("number(1,0)", Types.BOOLEAN, true);
+        addTypeNameToCode("number(3,0)", Types.TINYINT, true);
+        addTypeNameToCode("number(5,0)", Types.SMALLINT, true);
+        addTypeNameToCode("number(10,0)", Types.INTEGER, true);
+        addTypeNameToCode("number(19,0)", Types.BIGINT, true);
+        addTypeNameToCode("binary_float", Types.FLOAT, true);
+        addTypeNameToCode("binary_double", Types.DOUBLE, true);
     }
 
     @Override
     public String getCastTypeNameForCode(int code) {
         switch (code) {
-            case Types.TINYINT:  return "number(3,0)";
-            case Types.SMALLINT: return "number(5,0)";
-            case Types.INTEGER:  return "number(10,0)";
-            case Types.BIGINT:   return "number(19,0)";
             case Types.DOUBLE:   return "double precision";
             case Types.VARCHAR:  return "varchar(4000 char)";
             default: return super.getCastTypeNameForCode(code);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
@@ -778,23 +778,23 @@ public class SQLTemplates extends Templates {
         return nullsLast;
     }
 
-    public boolean isCountViaAnalytics() {
+    public final boolean isCountViaAnalytics() {
         return countViaAnalytics;
     }
 
-    public boolean isWrapSelectParameters() {
+    public final boolean isWrapSelectParameters() {
         return wrapSelectParameters;
     }
 
-    public boolean isArraysSupported() {
+    public final boolean isArraysSupported() {
         return arraysSupported;
     }
 
-    public int getListMaxSize() {
+    public final int getListMaxSize() {
         return listMaxSize;
     }
 
-    public boolean isSupportsUnquotedReservedWordsAsIdentifier() {
+    public final boolean isSupportsUnquotedReservedWordsAsIdentifier() {
         return supportsUnquotedReservedWordsAsIdentifier;
     }
 
@@ -1171,7 +1171,7 @@ public class SQLTemplates extends Templates {
         listMaxSize = i;
     }
 
-    public void setSupportsUnquotedReservedWordsAsIdentifier(boolean b) {
+    protected void setSupportsUnquotedReservedWordsAsIdentifier(boolean b) {
         this.supportsUnquotedReservedWordsAsIdentifier = b;
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
@@ -378,8 +378,8 @@ public class SQLTemplates extends Templates {
         add(Ops.STRING_CONTAINS_IC, "{0l} like {%%1%%} escape '"+escape+"'", Precedence.COMPARISON);
 
         add(SQLOps.CAST, "cast({0} as {1s})");
-        add(SQLOps.UNION, "{0}\nunion\n{1}", Precedence.LIST);
-        add(SQLOps.UNION_ALL, "{0}\nunion all\n{1}", Precedence.LIST);
+        add(SQLOps.UNION, "{0}\nunion\n{1}", Precedence.OR + 1);
+        add(SQLOps.UNION_ALL, "{0}\nunion all\n{1}", Precedence.OR + 1);
         add(SQLOps.NEXTVAL, "nextval('{0s}')");
 
         // analytic functions

--- a/querydsl-sql/src/main/java/com/querydsl/sql/TeradataTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/TeradataTemplates.java
@@ -13,6 +13,8 @@
  */
 package com.querydsl.sql;
 
+import java.sql.Types;
+
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.QueryModifiers;
 import com.querydsl.core.types.Ops;
@@ -110,6 +112,19 @@ public class TeradataTemplates extends SQLTemplates {
         add(Ops.DateTimeOps.TRUNC_HOUR, "trunc({0}, 'hh24')");
         add(Ops.DateTimeOps.TRUNC_MINUTE, "trunc({0}, 'mi')");
         add(Ops.DateTimeOps.TRUNC_SECOND, "{0}"); // not truncated
+
+        addTypeNameToCode("byteint", Types.BIT, true);
+        addTypeNameToCode("byteint", Types.BOOLEAN, true);
+        addTypeNameToCode("byteint", Types.TINYINT, true);
+        addTypeNameToCode("float", Types.DOUBLE, true);
+    }
+
+    @Override
+    public String getCastTypeNameForCode(int code) {
+        switch (code) {
+            case Types.VARCHAR:  return "varchar(4000)";
+            default: return super.getCastTypeNameForCode(code);
+        }
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/AbstractNumberType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/AbstractNumberType.java
@@ -13,11 +13,6 @@
  */
 package com.querydsl.sql.types;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
-import com.querydsl.core.util.MathUtils;
-
 /**
  * @author tiwe
  *
@@ -29,18 +24,4 @@ public abstract class AbstractNumberType<T extends Number & Comparable<T>> exten
         super(type);
     }
 
-    @Override
-    public T getValue(ResultSet rs, int startIndex) throws SQLException {
-        Object obj = rs.getObject(startIndex);
-        if (obj instanceof Number) {
-            return MathUtils.cast((Number) obj, getReturnedClass());
-        } else if (obj instanceof Boolean) {
-            return MathUtils.cast(Boolean.TRUE.equals(obj) ? 1 : 0, getReturnedClass());
-        } else if (obj != null) {
-            throw new IllegalArgumentException(obj.toString());
-        } else {
-            return null;
-        }
-    }
-    
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/BigDecimalAsDoubleType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/BigDecimalAsDoubleType.java
@@ -39,8 +39,8 @@ public class BigDecimalAsDoubleType extends AbstractType<BigDecimal> {
 
     @Override
     public BigDecimal getValue(ResultSet rs, int startIndex) throws SQLException {
-        Number num = (Number)rs.getObject(startIndex);
-        return num != null ? BigDecimal.valueOf(num.doubleValue()) : null;
+        double val = rs.getDouble(startIndex);
+        return rs.wasNull() ? null : BigDecimal.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/BigIntegerAsLongType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/BigIntegerAsLongType.java
@@ -39,8 +39,8 @@ public class BigIntegerAsLongType extends AbstractType<BigInteger> {
 
     @Override
     public BigInteger getValue(ResultSet rs, int startIndex) throws SQLException {
-        Number num = (Number) rs.getObject(startIndex);
-        return num != null ? BigInteger.valueOf(num.longValue()) : null;
+        long val = rs.getLong(startIndex);
+        return rs.wasNull() ? null : BigInteger.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/BooleanType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/BooleanType.java
@@ -36,8 +36,8 @@ public class BooleanType extends AbstractType<Boolean> {
 
     @Override
     public Boolean getValue(ResultSet rs, int startIndex) throws SQLException {
-        final boolean value = rs.getBoolean(startIndex);
-        return rs.wasNull() ? null : value;
+        boolean val = rs.getBoolean(startIndex);
+        return rs.wasNull() ? null : val;
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/ByteType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/ByteType.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql.types;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -36,6 +37,12 @@ public class ByteType extends AbstractNumberType<Byte> {
     @Override
     public Class<Byte> getReturnedClass() {
         return Byte.class;
+    }
+
+    @Override
+    public Byte getValue(ResultSet rs, int startIndex) throws SQLException {
+        byte val = rs.getByte(startIndex);
+        return rs.wasNull() ? null : Byte.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/DoubleType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/DoubleType.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql.types;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -36,6 +37,12 @@ public class DoubleType extends AbstractNumberType<Double> {
     @Override
     public Class<Double> getReturnedClass() {
         return Double.class;
+    }
+
+    @Override
+    public Double getValue(ResultSet rs, int startIndex) throws SQLException {
+        double val = rs.getDouble(startIndex);
+        return rs.wasNull() ? null : Double.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/FloatType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/FloatType.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql.types;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -36,6 +37,12 @@ public class FloatType extends AbstractNumberType<Float> {
     @Override
     public Class<Float> getReturnedClass() {
         return Float.class;
+    }
+
+    @Override
+    public Float getValue(ResultSet rs, int startIndex) throws SQLException {
+        float val = rs.getFloat(startIndex);
+        return rs.wasNull() ? null : Float.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/IntegerType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/IntegerType.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql.types;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -36,6 +37,12 @@ public class IntegerType extends AbstractNumberType<Integer> {
     @Override
     public Class<Integer> getReturnedClass() {
         return Integer.class;
+    }
+
+    @Override
+    public Integer getValue(ResultSet rs, int startIndex) throws SQLException {
+        int val = rs.getInt(startIndex);
+        return rs.wasNull() ? null : Integer.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/LongType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/LongType.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql.types;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -36,6 +37,12 @@ public class LongType extends AbstractNumberType<Long> {
     @Override
     public Class<Long> getReturnedClass() {
         return Long.class;
+    }
+
+    @Override
+    public Long getValue(ResultSet rs, int startIndex) throws SQLException {
+        long val = rs.getLong(startIndex);
+        return rs.wasNull() ? null : Long.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/ShortType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/ShortType.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql.types;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -36,6 +37,12 @@ public class ShortType extends AbstractNumberType<Short> {
     @Override
     public Class<Short> getReturnedClass() {
         return Short.class;
+    }
+
+    @Override
+    public Short getValue(ResultSet rs, int startIndex) throws SQLException {
+        short val = rs.getShort(startIndex);
+        return rs.wasNull() ? null : Short.valueOf(val);
     }
 
     @Override

--- a/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
@@ -119,7 +119,7 @@ public final class Connections {
 
     private static Connection getMySQL() throws SQLException, ClassNotFoundException {
         Class.forName("com.mysql.jdbc.Driver");
-        String url = "jdbc:mysql://localhost:3306/querydsl"; // ?useLegacyDatetimeCode=false
+        String url = "jdbc:mysql://localhost:3306/querydsl?useLegacyDatetimeCode=false";
         return DriverManager.getConnection(url, "querydsl", "querydsl");
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
@@ -1100,7 +1100,7 @@ public final class Connections {
 
         // qtest
         dropTable(templates, "QTEST");
-        stmt.execute("create table QTEST (ID int " + identity + " NOT NULL,  C1 int NULL)");
+        stmt.execute("create table QTEST (ID int " + identity + " NOT NULL, C1 int NULL)");
 
         // survey
         dropTable(templates, "SURVEY");
@@ -1142,11 +1142,11 @@ public final class Connections {
 
         // numbers
         dropTable(templates, "NUMBER_TEST");
-        stmt.execute("create table NUMBER_TEST(col1 int)");
+        stmt.execute("create table NUMBER_TEST(ID int " + identity + " NOT NULL, col1 int)");
 
         // xml
         dropTable(templates, "XML_TEST");
-        stmt.execute("create table XML_TEST(COL varchar(128))");
+        stmt.execute("create table XML_TEST(ID int " + identity + " NOT NULL, COL varchar(128))");
 
         teradataInited = true;
     }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
@@ -89,7 +89,7 @@ public final class Connections {
 
     private static Connection getDB2() throws SQLException, ClassNotFoundException {
         Class.forName("com.ibm.db2.jcc.DB2Driver");
-        String url = "jdbc:db2://192.168.0.24:50001/SAMPLE";
+        String url = "jdbc:db2://db2host:50001/SAMPLE";
         return DriverManager.getConnection(url, "db2inst1", "a3sd!fDj");
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/InsertBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/InsertBase.java
@@ -434,6 +434,7 @@ public class InsertBase extends AbstractBaseTest {
     }
 
     @Test
+    @ExcludeIn({ORACLE})
     public void XML() {
         delete(QXmlTest.xmlTest).execute();
         QXmlTest xmlTest = QXmlTest.xmlTest;

--- a/querydsl-sql/src/test/java/com/querydsl/sql/MergeBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/MergeBase.java
@@ -98,7 +98,7 @@ public class MergeBase extends AbstractBaseTest{
     }
 
     @Test
-    @ExcludeIn({CUBRID, DB2, DERBY, POSTGRESQL, SQLSERVER})
+    @ExcludeIn({CUBRID, DB2, DERBY, POSTGRESQL, SQLSERVER, TERADATA})
     public void Merge_With_Keys_Null_Id() throws SQLException{
         ResultSet rs = merge(survey).keys(survey.id)
                 .setNull(survey.id)

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -395,7 +395,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({CUBRID, DB2, DERBY, HSQLDB, POSTGRESQL, SQLITE})
+    @ExcludeIn({CUBRID, DB2, DERBY, HSQLDB, POSTGRESQL, SQLITE, TERADATA})
     public void Dates() {
         long ts = ((long)Math.floor(System.currentTimeMillis() / 1000)) * 1000;
         long tsDate = new org.joda.time.LocalDate(ts).toDateMidnight().getMillis();
@@ -447,7 +447,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({CUBRID, SQLITE})
+    @ExcludeIn({CUBRID, SQLITE, TERADATA})
     public void Dates_Literals() {
         if (configuration.getUseLiterals()) {
             Dates();
@@ -477,9 +477,9 @@ public class SelectBase extends AbstractBaseTest {
         add(exprs, SQLExpressions.addYears(dt, 1));
         add(exprs, SQLExpressions.addMonths(dt, 1));
         add(exprs, SQLExpressions.addDays(dt, 1));
-        add(exprs, SQLExpressions.addHours(dt, 1));
-        add(exprs, SQLExpressions.addMinutes(dt, 1));
-        add(exprs, SQLExpressions.addSeconds(dt, 1));
+        add(exprs, SQLExpressions.addHours(dt, 1), TERADATA);
+        add(exprs, SQLExpressions.addMinutes(dt, 1), TERADATA);
+        add(exprs, SQLExpressions.addSeconds(dt, 1), TERADATA);
 
         for (Expression<?> expr : exprs) {
             assertNotNull(query().singleResult(expr));
@@ -560,7 +560,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({SQLITE}) // FIXME
+    @ExcludeIn({SQLITE, TERADATA}) // FIXME
     public void Date_Trunc2() {
         DateTimeExpression<DateTime> expr = DateTimeExpression.currentTimestamp(DateTime.class);
 
@@ -762,7 +762,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({FIREBIRD, SQLSERVER})
+    @ExcludeIn({FIREBIRD, SQLSERVER, TERADATA})
     public void GroupBy_Distinct_Count() {
         List<Integer> ids = query().from(employee).groupBy(employee.id).distinct().list(Expressions.ONE);
         SearchResults<Integer> results = query().from(employee).groupBy(employee.id)
@@ -798,7 +798,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({DERBY, FIREBIRD, SQLITE, SQLSERVER})
+    @ExcludeIn({DERBY, FIREBIRD, SQLITE, SQLSERVER, TERADATA})
     public void In_Long_List() {
         List<Integer> ids = Lists.newArrayList();
         for (int i = 0; i < 20000; i++) {
@@ -810,7 +810,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({DERBY, FIREBIRD, SQLITE, SQLSERVER})
+    @ExcludeIn({DERBY, FIREBIRD, SQLITE, SQLSERVER, TERADATA})
     public void NotIn_Long_List() {
         List<Integer> ids = Lists.newArrayList();
         for (int i = 0; i < 20000; i++) {

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -395,7 +395,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({CUBRID, DB2, DERBY, HSQLDB, POSTGRESQL, SQLSERVER, SQLITE})
+    @ExcludeIn({CUBRID, DB2, DERBY, HSQLDB, POSTGRESQL, SQLITE})
     public void Dates() {
         long ts = ((long)Math.floor(System.currentTimeMillis() / 1000)) * 1000;
         long tsDate = new org.joda.time.LocalDate(ts).toDateMidnight().getMillis();
@@ -447,7 +447,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({CUBRID, SQLSERVER, SQLITE})
+    @ExcludeIn({CUBRID, SQLITE})
     public void Dates_Literals() {
         if (configuration.getUseLiterals()) {
             Dates();
@@ -548,7 +548,7 @@ public class SelectBase extends AbstractBaseTest {
         List<DatePart> dps = Lists.newArrayList();
         add(dps, DatePart.year);
         add(dps, DatePart.month);
-        add(dps, DatePart.week, DERBY, FIREBIRD);
+        add(dps, DatePart.week, DERBY, FIREBIRD, SQLSERVER);
         add(dps, DatePart.day);
         add(dps, DatePart.hour);
         add(dps, DatePart.minute);

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -447,7 +447,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({CUBRID, POSTGRESQL, SQLSERVER, SQLITE})
+    @ExcludeIn({CUBRID, SQLSERVER, SQLITE})
     public void Dates_Literals() {
         if (configuration.getUseLiterals()) {
             Dates();

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -1844,4 +1844,12 @@ public class SelectBase extends AbstractBaseTest {
         assertEquals(Integer.valueOf(200006), query.singleResult(employee.datefield.yearWeek()));
     }
 
+    @Test
+    @IncludeIn({H2})
+    public void YearWeek_H2() {
+        TestQuery query = query().from(employee).orderBy(employee.id.asc());
+        assertEquals(Integer.valueOf(200007), query.singleResult(employee.datefield.yearWeek()));
+    }
+
+
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -541,14 +541,14 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({FIREBIRD, SQLITE}) // FIXME
+    @ExcludeIn({SQLITE}) // FIXME
     public void Date_Trunc() {
         DateTimeExpression<java.util.Date> expr = DateTimeExpression.currentTimestamp();
 
         List<DatePart> dps = Lists.newArrayList();
         add(dps, DatePart.year);
         add(dps, DatePart.month);
-        add(dps, DatePart.week, DERBY);
+        add(dps, DatePart.week, DERBY, FIREBIRD);
         add(dps, DatePart.day);
         add(dps, DatePart.hour);
         add(dps, DatePart.minute);
@@ -560,7 +560,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({FIREBIRD, SQLITE}) // FIXME
+    @ExcludeIn({SQLITE}) // FIXME
     public void Date_Trunc2() {
         DateTimeExpression<DateTime> expr = DateTimeExpression.currentTimestamp(DateTime.class);
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -447,7 +447,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({CUBRID, HSQLDB, POSTGRESQL, SQLSERVER, SQLITE})
+    @ExcludeIn({CUBRID, POSTGRESQL, SQLSERVER, SQLITE})
     public void Dates_Literals() {
         if (configuration.getUseLiterals()) {
             Dates();
@@ -1003,7 +1003,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({DB2, DERBY, HSQLDB})
+    @ExcludeIn({DB2, DERBY})
     public void Literals() {
         assertEquals(1, singleResult(ConstantImpl.create(1)).intValue());
         assertEquals(2l, singleResult(ConstantImpl.create(2l)).longValue());
@@ -1015,7 +1015,6 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({HSQLDB})
     public void Literals_Literals() {
         if (configuration.getUseLiterals()) {
             Literals();

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -395,7 +395,7 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({CUBRID, DB2, HSQLDB, POSTGRESQL, SQLSERVER, SQLITE})
+    @ExcludeIn({CUBRID, DB2, DERBY, HSQLDB, POSTGRESQL, SQLSERVER, SQLITE})
     public void Dates() {
         long ts = ((long)Math.floor(System.currentTimeMillis() / 1000)) * 1000;
         long tsDate = new org.joda.time.LocalDate(ts).toDateMidnight().getMillis();
@@ -517,7 +517,7 @@ public class SelectBase extends AbstractBaseTest {
     // TDO Date_Diff with timestamps
 
     @Test
-    @ExcludeIn({DB2, DERBY, HSQLDB, SQLITE, TERADATA})
+    @ExcludeIn({DB2, HSQLDB, SQLITE, TERADATA})
     public void Date_Diff2() {
         TestQuery query = query().from(employee).orderBy(employee.id.asc());
 
@@ -541,14 +541,14 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({DERBY, FIREBIRD, SQLITE, SQLSERVER}) // FIXME
+    @ExcludeIn({FIREBIRD, SQLITE}) // FIXME
     public void Date_Trunc() {
         DateTimeExpression<java.util.Date> expr = DateTimeExpression.currentTimestamp();
 
         List<DatePart> dps = Lists.newArrayList();
         add(dps, DatePart.year);
         add(dps, DatePart.month);
-        add(dps, DatePart.week);
+        add(dps, DatePart.week, DERBY);
         add(dps, DatePart.day);
         add(dps, DatePart.hour);
         add(dps, DatePart.minute);
@@ -1012,6 +1012,14 @@ public class SelectBase extends AbstractBaseTest {
         assertEquals(true, singleResult(ConstantImpl.create(true)));
         assertEquals(false, singleResult(ConstantImpl.create(false)));
         assertEquals("abc", singleResult(ConstantImpl.create("abc")));
+    }
+
+    @Test
+    @ExcludeIn({HSQLDB})
+    public void Literals_Literals() {
+        if (configuration.getUseLiterals()) {
+            Literals();
+        }
     }
 
     private double log(double x, int y) {

--- a/querydsl-sql/src/test/java/com/querydsl/sql/UpdateBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/UpdateBase.java
@@ -13,23 +13,26 @@
  */
 package com.querydsl.sql;
 
+import static com.querydsl.core.Target.*;
+import static com.querydsl.sql.Constants.survey;
+import static org.junit.Assert.assertEquals;
+
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 
-import com.querydsl.sql.dml.SQLUpdateClause;
-import com.querydsl.sql.domain.QEmployee;
-import com.querydsl.sql.domain.QSurvey;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.Path;
-import com.querydsl.core.types.dsl.Param;
-import com.querydsl.core.testutil.IncludeIn;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import static com.querydsl.sql.Constants.survey;
-import static com.querydsl.core.Target.*;
-import static org.junit.Assert.assertEquals;
+
+import com.querydsl.core.testutil.ExcludeIn;
+import com.querydsl.core.testutil.IncludeIn;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.Param;
+import com.querydsl.sql.dml.SQLUpdateClause;
+import com.querydsl.sql.domain.QEmployee;
+import com.querydsl.sql.domain.QSurvey;
 
 public class UpdateBase extends AbstractBaseTest {
 
@@ -190,6 +193,7 @@ public class UpdateBase extends AbstractBaseTest {
     }
 
     @Test
+    @ExcludeIn(TERADATA)
     public void Update_With_TemplateExpression_In_Batch() {
         update(survey)
             .set(survey.id, 3)

--- a/querydsl-sql/src/test/java/com/querydsl/sql/types/TypeTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/types/TypeTest.java
@@ -45,7 +45,29 @@ public class TypeTest implements InvocationHandler{
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        if (method.getName().startsWith("get")) {
+        if (method.getName().equals("wasNull")) {
+            return value == null;
+        } else if (method.getName().startsWith("get")) {
+            if (method.getReturnType().isPrimitive() && value == null) {
+                Class<?> rt = method.getReturnType();
+                if (rt == Byte.TYPE) {
+                    return Byte.valueOf((byte)0);
+                } else if (rt == Short.TYPE) {
+                    return Short.valueOf((short)0);
+                } else if (rt == Integer.TYPE) {
+                    return Integer.valueOf(0);
+                } else if (rt == Long.TYPE) {
+                    return Long.valueOf(0);
+                } else if (rt == Float.TYPE) {
+                    return Float.valueOf(0);
+                } else if (rt == Double.TYPE) {
+                    return Double.valueOf(0);
+                } else if (rt == Boolean.TYPE) {
+                    return Boolean.FALSE;
+                } else if (rt == Character.TYPE) {
+                    return Character.valueOf((char)0);
+                }
+            }
             return value;
         } else {
             value = args[1];
@@ -104,7 +126,7 @@ public class TypeTest implements InvocationHandler{
         for (Pair pair : valueAndType) {
             value = null;
             Type type = (Type) pair.getSecond();
-            assertNull(type.getValue(resultSet, 0));
+            assertNull(type.toString(),   type.getValue(resultSet, 0));
             type.setValue(statement, 0, pair.getFirst());
             assertEquals(type.toString(), pair.getFirst(), type.getValue(resultSet, 0));
         }


### PR DESCRIPTION
Fixes https://github.com/querydsl/querydsl/issues/1204

Databases to go through

* [x] CUBRID 9.2.0
* [x] DB2 10.1.2
* [x] Derby 10.11.1.1
* [x] Firebird 2.5.2
* [x] H2 1.4.178
* [x] HSQLDB 2.3.2
* [x] MSSQL 2008
* [x] MySQL 5.5
* [x] Oracle 11.2.0
* [x] PostgreSQL 9.3
* [X] SQLite
* [x] Teradata 14.0.3

DB2, MSSQL, Oracle and Teradata tests are not run in travis

backport https://github.com/querydsl/querydsl/pull/1269