### PR TITLE
Sync surefire dependencies

### DIFF
--- a/querydsl-root/pom.xml
+++ b/querydsl-root/pom.xml
@@ -45,6 +45,7 @@
     <cglib.version>2.2.2</cglib.version>    
     <findbugs.version>1.3.2</findbugs.version>
     <slf4j.version>1.6.1</slf4j.version>
+    <surefire.version>2.18</surefire.version>
     
     <!-- Import-Package definitions for maven-bundle-plugin -->
     <osgi.import.package.root>
@@ -53,7 +54,7 @@
     </osgi.import.package.root>
     <osgi.import.package>${osgi.import.package.root}</osgi.import.package>
   </properties>
-     
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -67,7 +68,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
+
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
@@ -109,7 +110,7 @@
     <developerConnection>${project.checkout}</developerConnection>
     <url>${project.githubpage}</url>
   </scm>
-  
+
   <developers>
     <developer>
       <id>timowest</id>
@@ -159,7 +160,7 @@
       <url>LICENSE.txt</url>
     </license>
   </licenses>
-  
+
   <build>
     <pluginManagement>
       <plugins>
@@ -181,7 +182,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.18.1</version>
+          <version>${surefire.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -366,7 +367,7 @@
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit47</artifactId>
-            <version>2.16</version>
+            <version>${surefire.version}</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
The surefire artifact's versions were mismatched.
For some reason surefire 2.18.1 still caused issues, so I went for 2.18 instead.