### PR TITLE
Fixed issue with order by expressions for non-root entity paths

### DIFF
--- a/querydsl-jpa/src/main/java/com/mysema/query/jpa/JPAQueryMixin.java
+++ b/querydsl-jpa/src/main/java/com/mysema/query/jpa/JPAQueryMixin.java
@@ -109,8 +109,6 @@ public class JPAQueryMixin<T> extends QueryMixin<T> {
         PathMetadata<?> metadata = path.getMetadata();
         if (metadata.isRoot() || paths.contains(path)) {
             return path;
-        } else if (aliases.containsKey(path)) {
-            return (Path<T>) aliases.get(path);
         } else if (metadata.getPathType() == PathType.COLLECTION_ANY) {
             return (Path<T>) shorten(metadata.getParent(), paths);
         } else if (!isEntityPath(path)) {
@@ -122,18 +120,26 @@ public class JPAQueryMixin<T> extends QueryMixin<T> {
                         new PathMetadata(parent, metadata.getElement(), metadata.getPathType()));
             }
         } else if (metadata.getParent().getMetadata().isRoot()) {
-            Class<T> type = getElementTypeOrType(path);
-            Path<T> newPath = new PathImpl<T>(type, path.toString().replace('.', '_'));
-            leftJoin(path, newPath);
-            return newPath;
+            if (aliases.containsKey(path)) {
+                return (Path<T>) aliases.get(path);
+            } else {
+                Class<T> type = getElementTypeOrType(path);
+                Path<T> newPath = new PathImpl<T>(type, path.toString().replace('.', '_'));
+                leftJoin(path, newPath);
+                return newPath;
+            }
         } else {
             Class<T> type = getElementTypeOrType(path);
             Path<?> parent = shorten(metadata.getParent(), paths);
             Path<T> oldPath = new PathImpl<T>(path.getType(),
                     new PathMetadata(parent, metadata.getElement(), metadata.getPathType()));
-            Path<T> newPath = new PathImpl<T>(type, oldPath.toString().replace('.', '_'));
-            leftJoin(oldPath, newPath);
-            return newPath;
+            if (aliases.containsKey(oldPath)) {
+                return (Path<T>) aliases.get(oldPath);
+            } else {
+                Path<T> newPath = new PathImpl<T>(type, oldPath.toString().replace('.', '_'));
+                leftJoin(oldPath, newPath);
+                return newPath;
+            }
         }
     }
 

--- a/querydsl-jpa/src/test/java/com/mysema/query/jpa/JPAQueryMixinTest.java
+++ b/querydsl-jpa/src/test/java/com/mysema/query/jpa/JPAQueryMixinTest.java
@@ -6,6 +6,9 @@ import com.mysema.query.JoinExpression;
 import com.mysema.query.JoinType;
 import com.mysema.query.QueryMetadata;
 import com.mysema.query.jpa.domain.QCat;
+import com.mysema.query.jpa.domain.QCompany;
+import com.mysema.query.jpa.domain.QDepartment;
+import com.mysema.query.jpa.domain.QEmployee;
 import com.mysema.query.jpa.domain4.QBookMark;
 import com.mysema.query.jpa.domain4.QBookVersion;
 import com.mysema.query.types.PathMetadataFactory;
@@ -36,6 +39,24 @@ public class JPAQueryMixinTest {
                 new JoinExpression(JoinType.LEFTJOIN, cat.mate.as(cat_mate))),
                 md.getJoins());
         assertEquals(Arrays.asList(cat_mate.name.asc()),
+                md.getOrderBy());
+    }
+
+    @Test
+    public void OrderBy_NonRoot_Twice() {
+        QDepartment department = QDepartment.department;
+        QCompany department_company = new QCompany("department_company");
+        QEmployee department_company_ceo = new QEmployee("department_company_ceo");
+        mixin.from(department);
+        mixin.orderBy(department.company.ceo.firstName.asc(), department.company.ceo.lastName.asc());
+
+        QueryMetadata md = mixin.getMetadata();
+        assertEquals(Arrays.asList(
+                        new JoinExpression(JoinType.DEFAULT, department),
+                        new JoinExpression(JoinType.LEFTJOIN, department.company.as(department_company)),
+                        new JoinExpression(JoinType.LEFTJOIN, department_company.ceo.as(department_company_ceo))),
+                md.getJoins());
+        assertEquals(Arrays.asList(department_company_ceo.firstName.asc(), department_company_ceo.lastName.asc()),
                 md.getOrderBy());
     }
 


### PR DESCRIPTION
The same join is added multiple times when using multiple order-by expressions for non-root entity paths. This is a possible fix.