### PR TITLE
Fix literal escaping

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLTemplates.java
@@ -504,13 +504,7 @@ public class SQLTemplates extends Templates {
     public String escapeLiteral(String str) {
         StringBuilder builder = new StringBuilder();
         for (char ch : str.toCharArray()) {
-            if (ch == '\n') {
-                builder.append("\\n");
-                continue;
-            } else if (ch == '\r') {
-                builder.append("\\r");
-                continue;
-            } else if (ch == '\'') {
+            if (ch == '\'') {
                 builder.append("''");
                 continue;
             }

--- a/querydsl-sql/src/test/java/com/mysema/query/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/mysema/query/SelectBase.java
@@ -883,12 +883,14 @@ public class SelectBase extends AbstractBaseTest {
     @Test
     @ExcludeIn(FIREBIRD)
     public void Like_Escape() {
-        List<String> strs = ImmutableList.of("%a", "a%", "%a%", "_a", "a_", "_a_", "[C-P]arsen");
+        List<String> strs = ImmutableList.of("%a", "a%", "%a%", "_a", "a_", "_a_", "[C-P]arsen", "a\nb");
 
         for (String str : strs) {
             assertTrue(str, query()
                 .from(employee)
-                .where(Expressions.stringTemplate("'" + str + "'").contains(str)).count() > 0);
+                .where(Expressions.predicate(Ops.STRING_CONTAINS,
+                       Expressions.constant(str),
+                       Expressions.constant(str))).count() > 0);
         }
     }
 
@@ -1016,6 +1018,11 @@ public class SelectBase extends AbstractBaseTest {
         assertEquals(true, singleResult(ConstantImpl.create(true)));
         assertEquals(false, singleResult(ConstantImpl.create(false)));
         assertEquals("abc", singleResult(ConstantImpl.create("abc")));
+        assertEquals("'", singleResult(ConstantImpl.create("'")));
+        assertEquals("\"", singleResult(ConstantImpl.create("\"")));
+        assertEquals("\n", singleResult(ConstantImpl.create("\n")));
+        assertEquals("\r\n", singleResult(ConstantImpl.create("\r\n")));
+        assertEquals("\t", singleResult(ConstantImpl.create("\t")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1275 
backport of https://github.com/querydsl/querydsl/pull/1297