### PR TITLE
Introduce LiteralExpression

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
@@ -24,7 +24,7 @@ import com.querydsl.core.types.*;
  * @see java.lang.Boolean
  *
  */
-public abstract class BooleanExpression extends ComparableExpression<Boolean> implements Predicate{
+public abstract class BooleanExpression extends LiteralExpression<Boolean> implements Predicate{
 
     private static final long serialVersionUID = 3797956062512074164L;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
@@ -15,9 +15,7 @@ package com.querydsl.core.types.dsl;
 
 import javax.annotation.Nullable;
 
-import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 
@@ -35,9 +33,6 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
 
     @Nullable
     private volatile OrderSpecifier<T> asc, desc;
-
-    @Nullable
-    private volatile StringExpression stringCast;
 
     public ComparableExpressionBase(Expression<T> mixin) {
         super(mixin);
@@ -72,17 +67,6 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
     }
 
     /**
-     * Create a cast expression to the given numeric type
-     *
-     * @param <A>
-     * @param type
-     * @return
-     */
-    public <A extends Number & Comparable<? super A>> NumberExpression<A> castToNum(Class<A> type) {
-        return Expressions.numberOperation(type, Ops.NUMCAST, mixin, ConstantImpl.create(type));
-    }
-
-    /**
      * Get an OrderSpecifier for descending order of this expression
      *
      * @return
@@ -92,19 +76,6 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
             desc = new OrderSpecifier<T>(Order.DESC, mixin);
         }
         return desc;
-    }
-
-    /**
-     * Get a cast to String expression
-     *
-     * @see     java.lang.Object#toString()
-     * @return
-     */
-    public StringExpression stringValue() {
-        if (stringCast == null) {
-            stringCast = Expressions.stringOperation(Ops.STRING_CAST, mixin);
-        }
-        return stringCast;
     }
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EnumExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EnumExpression.java
@@ -22,7 +22,7 @@ import com.querydsl.core.types.*;
  *
  * @param <T> expression type
  */
-public abstract class EnumExpression<T extends Enum<T>> extends ComparableExpression<T> {
+public abstract class EnumExpression<T extends Enum<T>> extends LiteralExpression<T> {
 
     private static final long serialVersionUID = 8819222316513862829L;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/LiteralExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/LiteralExpression.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015, Timo Westkämper
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.types.dsl;
+
+import javax.annotation.Nullable;
+
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Ops;
+
+/**
+ * LiteralExpression represents literal expressions
+ *
+ * @param <T>
+ */
+public abstract class LiteralExpression<T extends Comparable> extends ComparableExpression<T> {
+
+    @Nullable
+    private volatile StringExpression stringCast;
+
+    public LiteralExpression(Expression<T> mixin) {
+        super(mixin);
+    }
+
+    /**
+     * Create a cast expression to the given numeric type
+     *
+     * @param <A>
+     * @param type
+     * @return
+     */
+    public <A extends Number & Comparable<? super A>> NumberExpression<A> castToNum(Class<A> type) {
+        return Expressions.numberOperation(type, Ops.NUMCAST, mixin, ConstantImpl.create(type));
+    }
+
+    /**
+     * Get a cast to String expression
+     *
+     * @see     java.lang.Object#toString()
+     * @return
+     */
+    public StringExpression stringValue() {
+        if (stringCast == null) {
+            stringCast = Expressions.stringOperation(Ops.STRING_CAST, mixin);
+        }
+        return stringCast;
+    }
+
+}

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -72,6 +72,9 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
     @Nullable
     private volatile NumberExpression<T> negation;
 
+    @Nullable
+    private volatile StringExpression stringCast;
+
     public NumberExpression(Expression<T> mixin) {
         super(mixin);
     }
@@ -84,6 +87,19 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
     @Override
     public NumberExpression<T> as(String alias) {
         return Expressions.numberOperation(getType(), Ops.ALIAS, mixin, ExpressionUtils.path(getType(), alias));
+    }
+
+    /**
+     * Get a cast to String expression
+     *
+     * @see     java.lang.Object#toString()
+     * @return
+     */
+    public StringExpression stringValue() {
+        if (stringCast == null) {
+            stringCast = Expressions.stringOperation(Ops.STRING_CAST, mixin);
+        }
+        return stringCast;
     }
 
     /**
@@ -144,7 +160,6 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
         return MathUtils.cast(number, getType());
     }
 
-    @Override
     @SuppressWarnings("unchecked")
     public <A extends Number & Comparable<? super A>> NumberExpression<A> castToNum(Class<A> type) {
         if (type.equals(getType())) {

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
@@ -23,7 +23,7 @@ import com.querydsl.core.types.*;
  * @author tiwe
  * @see java.lang.String
  */
-public abstract class StringExpression extends ComparableExpression<String> {
+public abstract class StringExpression extends LiteralExpression<String> {
 
     private static final long serialVersionUID = 1536955079961023361L;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TemporalExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TemporalExpression.java
@@ -23,7 +23,7 @@ import com.querydsl.core.types.Expression;
  * @param <T> expression type
  */
 @SuppressWarnings({"unchecked"})
-public abstract class TemporalExpression<T extends Comparable> extends ComparableExpression<T> {
+public abstract class TemporalExpression<T extends Comparable> extends LiteralExpression<T> {
 
     private static final long serialVersionUID = 1137918766051524298L;
 


### PR DESCRIPTION
LiteralExpression extracts some cast related operations in ComparableExpressionBase to a separate class, since not all Comparable expressions are also literals.

Since most literal types are also comparable, LiteralExpression extends ComparableExpression.