### PR TITLE
Fix Scala case class generation dropping parameters

### DIFF
--- a/querydsl-scala/src/main/scala/com/querydsl/scala/ScalaBeanSerializer.scala
+++ b/querydsl-scala/src/main/scala/com/querydsl/scala/ScalaBeanSerializer.scala
@@ -135,11 +135,10 @@ class CaseClassSerializer @Inject() (typeMappings: TypeMappings) extends Seriali
 
   def writeClass(model: EntityType, writer: ScalaWriter) = {
     model.getAnnotations foreach writer.annotation
-    val parameters = model.getProperties
-      .map(p => new Parameter(p.getEscapedName, p.getType)).toArray
+    val parameters = model.getProperties.toVector
+      .map(p => new Parameter(p.getEscapedName, p.getType))
     writer.caseClass(model.getSimpleName, parameters:_*)
   }
-
 }
 
 


### PR DESCRIPTION
Mapping on a set produced Parameters with hashCode collisions, which were then dropped from the resulting set. Converting to a Vector before mapping prevents this.