### PR TITLE
Fix alias serialization for MongoDB

### DIFF
--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -326,7 +326,8 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
         if (metadata.getParent() != null) {
             if (metadata.getPathType() == PathType.COLLECTION_ANY) {
                 return visit(metadata.getParent(), context);
-            } else if (metadata.getParent().getMetadata().getPathType() != PathType.VARIABLE) {
+            } else if (metadata.getParent().getMetadata().getPathType() != PathType.VARIABLE
+                    && metadata.getParent().getMetadata().getPathType() != PathType.DELEGATE) {
                 String rv = getKeyForPath(expr, metadata);
                 return visit(metadata.getParent(), context) + "." + rv;
             }

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
@@ -1,0 +1,89 @@
+package com.querydsl.mongodb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.UnknownHostException;
+
+import com.mongodb.Mongo;
+import com.mongodb.MongoException;
+import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.mongodb.domain.Fish;
+import com.querydsl.mongodb.domain.Food;
+import com.querydsl.mongodb.domain.Chips;
+import com.querydsl.mongodb.domain.QFish;
+import com.querydsl.mongodb.domain.QFood;
+import com.querydsl.mongodb.morphia.MorphiaQuery;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+
+@Category(ExternalDB.class)
+public class PolymorphicCollectionTest {
+
+    private final Morphia morphia;
+    private final Datastore ds;
+    private final Fish f1 = new Fish("f1");
+    private final Fish f2 = new Fish("f2");
+    private final Chips c1 = new Chips("c1");
+
+    public PolymorphicCollectionTest() throws UnknownHostException, MongoException {
+        final Mongo mongo = new Mongo();
+        morphia = new Morphia().map(Food.class);
+        ds = morphia.createDatastore(mongo, "testdb");
+    }
+
+    @Before
+    public void before() throws UnknownHostException, MongoException {
+        ds.delete(ds.createQuery(Food.class));
+        ds.save(f1, f2, c1);
+    }
+
+    @Test
+    public void basicCount() {
+        assertEquals(where().fetchCount(), 3);
+    }
+
+    @Test
+    public void countFishFromName() {
+        assertEquals(where(QFood.food.name.eq("f1")).fetchCount(), 1);
+    }
+
+    @Test
+    public void countFishFromNameAndBreed() {
+        assertEquals(where(QFood.food.name.eq("f1")
+            .and(QFish.fish.breed.eq("unknown"))).fetchCount(), 1);
+    }
+
+    @Test
+    public void countFishFromNameAndBreedWithCast() {
+        // Fails because generated query is { "name" : "f1" , "food.breed" : "unknown"}
+        // instead of { "name" : "f1" , "breed" : "unknown"}
+        assertEquals(where(QFood.food.name.eq("f1")
+                .and(QFood.food.as(QFish.class).breed.eq("unknown"))).fetchCount(), 1);
+    }
+
+    @Test
+    public void countFishes() {
+        assertEquals(where(isFish()).fetchCount(), 2);
+    }
+
+    @Test
+    public void countFishesWithInstanceOf() {
+        assertEquals(where(QFood.food.instanceOf(Fish.class)).fetchCount(), 2);
+    }
+
+    private Predicate isFish() {
+        return QFood.food.name.startsWith("f");
+    }
+
+    private MorphiaQuery<Food> query() {
+        return new MorphiaQuery<Food>(morphia, ds, QFood.food);
+    }
+
+    private MorphiaQuery<Food> where(final Predicate... e) {
+        return query().where(e);
+    }
+}

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
@@ -59,8 +59,6 @@ public class PolymorphicCollectionTest {
 
     @Test
     public void countFishFromNameAndBreedWithCast() {
-        // Fails because generated query is { "name" : "f1" , "food.breed" : "unknown"}
-        // instead of { "name" : "f1" , "breed" : "unknown"}
         assertEquals(where(QFood.food.name.eq("f1")
                 .and(QFood.food.as(QFish.class).breed.eq("unknown"))).fetchCount(), 1);
     }
@@ -68,11 +66,6 @@ public class PolymorphicCollectionTest {
     @Test
     public void countFishes() {
         assertEquals(where(isFish()).fetchCount(), 2);
-    }
-
-    @Test
-    public void countFishesWithInstanceOf() {
-        assertEquals(where(QFood.food.instanceOf(Fish.class)).fetchCount(), 2);
     }
 
     private Predicate isFish() {

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Chips.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Chips.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.domain;
+
+import org.mongodb.morphia.annotations.Entity;
+
+@Entity("food")
+public class Chips extends Food {
+
+    public Chips(final String name) {
+        super(name);
+    }
+}

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Fish.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Fish.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.domain;
+
+import org.mongodb.morphia.annotations.Entity;
+
+@Entity("food")
+public class Fish extends Food {
+
+    private final String breed;
+
+    public Fish(final String name) {
+        super(name);
+        this.breed = "unknown";
+    }
+
+    public Fish(final String name, final String breed) {
+        super(name);
+        this.breed = breed;
+    }
+
+    public String getBreed() {
+        return breed;
+    }
+}

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Food.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Food.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.domain;
+
+import org.mongodb.morphia.annotations.Entity;
+
+@Entity("food")
+public class Food extends AbstractEntity {
+    private final String name;
+
+    public Food(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
Fixes #1427 + add junit tests:

When querying for **QFood.food.as(QFish.class).breed.eq("unknown")**

I expect to see **{ "name" : "f1" , "breed" : "unknown"}**

rather than **{ "name" : "f1" , "food.breed" : "unknown"}**

Note this is my first commit on querydsl, so I hope I have a correct understanding of what "PathType.DELEGATE" is and how it should be interpreted.