### PR TITLE
Add a strategy to allow customize the default variable name case

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/APTOptions.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/APTOptions.java
@@ -80,6 +80,11 @@ public final class APTOptions {
      * set whether unknown non-annotated classes should be treated as embeddable (default: false)
      */
     public static final String QUERYDSL_UNKNOWN_AS_EMBEDDABLE = "querydsl.unknownAsEmbeddable";
+    
+    /**
+     * set the case transformer class
+     */
+    public static final String QUERYDSL_CASE_TRANSFORMER_CLASS = "querydsl.caseTransformerClass";
 
     private APTOptions() { }
 

--- a/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
@@ -176,6 +176,10 @@ public class DefaultConfiguration implements Configuration {
                 includedClasses.addAll(classes);
             }
         }
+        
+        if (options.containsKey(QUERYDSL_CASE_TRANSFORMER_CLASS)) {
+            module.bind(CodegenModule.CASE_TRANSFORMER_CLASS, options.get(QUERYDSL_CASE_TRANSFORMER_CLASS));
+        }
 
         try {
             // register additional mappings if querydsl-spatial is on the classpath

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/CaseTransformer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/CaseTransformer.java
@@ -1,0 +1,15 @@
+package com.querydsl.codegen;
+
+/**
+ * Transforms the case.
+ *
+ */
+public interface CaseTransformer {
+    /**
+     * Transform the case of the given {@code name}.
+     *
+     * @param name the string to transform the case of.
+     * @return the name with new case
+     */
+    String transform(String name);
+}

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/CodegenModule.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/CodegenModule.java
@@ -48,6 +48,11 @@ public class CodegenModule  extends AbstractModule {
      */
     public static final String IMPORTS = "imports";
 
+    /**
+     * key for the keywords set
+     */
+    public static final String CASE_TRANSFORMER_CLASS = "caseTransformerClass";
+
     @Override
     protected void configure() {
         bind(TypeMappings.class, JavaTypeMappings.class);
@@ -63,6 +68,7 @@ public class CodegenModule  extends AbstractModule {
         bind(PACKAGE_SUFFIX, "");
         bind(KEYWORDS, Collections.<String>emptySet());
         bind(IMPORTS, Collections.<String>emptySet());
+        bind(CASE_TRANSFORMER_CLASS, UncapitalizedCaseTransformer.class.getCanonicalName());
     }
 
 }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EmbeddableSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EmbeddableSerializer.java
@@ -45,8 +45,8 @@ public final class EmbeddableSerializer extends EntitySerializer {
      * @param keywords keywords to be used
      */
     @Inject
-    public EmbeddableSerializer(TypeMappings typeMappings, @Named("keywords") Collection<String> keywords) {
-        super(typeMappings, keywords);
+    public EmbeddableSerializer(TypeMappings typeMappings, @Named("keywords") Collection<String> keywords, @Named(CodegenModule.CASE_TRANSFORMER_CLASS) String caseTransfomerClass) {
+        super(typeMappings, keywords, caseTransfomerClass);
     }
 
     @Override

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/SupertypeSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/SupertypeSerializer.java
@@ -33,8 +33,8 @@ public final class SupertypeSerializer extends EntitySerializer {
      * @param keywords keywords to be used
      */
     @Inject
-    public SupertypeSerializer(TypeMappings typeMappings, @Named("keywords") Collection<String> keywords) {
-        super(typeMappings, keywords);
+    public SupertypeSerializer(TypeMappings typeMappings, @Named("keywords") Collection<String> keywords, @Named(CodegenModule.CASE_TRANSFORMER_CLASS) String caseTransfomerClass) {
+        super(typeMappings, keywords, caseTransfomerClass);
     }
 
 }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/UncapitalizedCaseTransformer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/UncapitalizedCaseTransformer.java
@@ -1,0 +1,19 @@
+package com.querydsl.codegen;
+
+import com.mysema.codegen.StringUtils;
+
+/**
+ * Uncapitalizes the first letter of a name.
+ *
+ */
+public class UncapitalizedCaseTransformer implements CaseTransformer {
+
+    /**
+     * @see com.querydsl.codegen.CaseTransformer#transform(java.lang.String)
+     */
+    @Override
+    public String transform(String name) {
+        return StringUtils.uncapitalize(name);
+    }
+
+}

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/CustomTypeTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/CustomTypeTest.java
@@ -32,7 +32,7 @@ public class CustomTypeTest {
 
     private final TypeMappings typeMappings = new JavaTypeMappings();
 
-    private final EntitySerializer serializer = new EntitySerializer(typeMappings, Collections.<String>emptySet());
+    private final EntitySerializer serializer = new EntitySerializer(typeMappings, Collections.<String>emptySet(), UncapitalizedCaseTransformer.class.getCanonicalName());
 
     private final StringWriter writer = new StringWriter();
 

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/EmbeddableSerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/EmbeddableSerializerTest.java
@@ -35,7 +35,7 @@ public class EmbeddableSerializerTest {
 
     private final TypeMappings typeMappings = new JavaTypeMappings();
 
-    private final EntitySerializer serializer = new EmbeddableSerializer(typeMappings, Collections.<String>emptySet());
+    private final EntitySerializer serializer = new EmbeddableSerializer(typeMappings, Collections.<String>emptySet(), UncapitalizedCaseTransformer.class.getCanonicalName());
 
     private final StringWriter writer = new StringWriter();
 

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/EntitySerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/EntitySerializerTest.java
@@ -35,7 +35,7 @@ public class EntitySerializerTest {
 
     private final TypeMappings typeMappings = new JavaTypeMappings();
 
-    private final EntitySerializer serializer = new EntitySerializer(typeMappings, Collections.<String>emptySet());
+    private final EntitySerializer serializer = new EntitySerializer(typeMappings, Collections.<String>emptySet(), UncapitalizedCaseTransformer.class.getCanonicalName());
 
     private final StringWriter writer = new StringWriter();
 

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/PackageSuffixTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/PackageSuffixTest.java
@@ -31,7 +31,7 @@ public class PackageSuffixTest {
 
     private final TypeMappings typeMappings = new JavaTypeMappings();
 
-    private final EntitySerializer serializer = new EntitySerializer(typeMappings, Collections.<String>emptySet());
+    private final EntitySerializer serializer = new EntitySerializer(typeMappings, Collections.<String>emptySet(), UncapitalizedCaseTransformer.class.getCanonicalName());
 
     private final StringWriter writer = new StringWriter();
 

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/SerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/SerializerTest.java
@@ -63,25 +63,25 @@ public class SerializerTest {
 
     @Test
     public void EntitySerializer() throws Exception {
-        new EntitySerializer(typeMappings, Collections.<String>emptyList())
+        new EntitySerializer(typeMappings, Collections.<String>emptyList(), UncapitalizedCaseTransformer.class.getCanonicalName())
             .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
     }
 
     @Test
     public void EntitySerializer2() throws Exception {
-        new EntitySerializer(typeMappings,Collections.<String>emptyList())
+        new EntitySerializer(typeMappings,Collections.<String>emptyList(), UncapitalizedCaseTransformer.class.getCanonicalName())
             .serialize(type, new SimpleSerializerConfig(true,true,true,true,""), new JavaWriter(writer));
     }
 
     @Test
     public void EmbeddableSerializer() throws Exception {
-        new EmbeddableSerializer(typeMappings,Collections.<String>emptyList())
+        new EmbeddableSerializer(typeMappings,Collections.<String>emptyList(), UncapitalizedCaseTransformer.class.getCanonicalName())
             .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
     }
 
     @Test
     public void SupertypeSerializer() throws IOException {
-        new SupertypeSerializer(typeMappings,Collections.<String>emptyList())
+        new SupertypeSerializer(typeMappings,Collections.<String>emptyList(), UncapitalizedCaseTransformer.class.getCanonicalName())
             .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
     }
 


### PR DESCRIPTION
Proposed feature: Add a strategy to allow the user customize the default variable case generation.
1. Added an interface and a default implementation with implements the current uncapSimpleName  behavior.
2. Injected a new String parameter to the EntitySerializer constructor, which defines the strategy implementation class to use.
3. Bounded the new String parameter to the Configuration.