### PR TITLE
Correct typo in README.md

### DIFF
--- a/querydsl-jpa/README.md
+++ b/querydsl-jpa/README.md
@@ -47,7 +47,7 @@ And now, configure the Maven APT plugin :
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
             <version>${querydsl.version}</version>
-          </dependency
+          </dependency>
         </dependencies>
       </plugin>
       ...


### PR DESCRIPTION
Closing </dependency> tag is incorrect (gt character missing):
...
<dependency>
  <groupId>com.querydsl</groupId>
  <artifactId>querydsl-apt</artifactId>
  <version>${querydsl.version}</version>
</dependency    <- no gt char
...