### PR TITLE
add support for postgres specific DISTINCT ON syntax (v3)

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/postgres/PostgresQuery.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/postgres/PostgresQuery.java
@@ -25,6 +25,9 @@ import com.mysema.query.sql.RelationalPath;
 import com.mysema.query.sql.SQLOps;
 import com.mysema.query.sql.SQLQuery;
 import com.mysema.query.sql.SQLTemplates;
+import com.mysema.query.support.Expressions;
+import com.mysema.query.types.Expression;
+import com.mysema.query.types.ExpressionUtils;
 
 /**
  * PostgresQuery provides Postgres related extensions to SQLQuery
@@ -79,7 +82,18 @@ public class PostgresQuery extends AbstractSQLQuery<PostgresQuery> {
         }
         return addFlag(Position.END, builder.toString());
     }
- 
+
+    /**
+     * adds a DISTINCT ON clause
+     *
+     * @param exprs
+     * @return
+     */
+    public PostgresQuery distinct(Expression<?>... exprs) {
+        return addFlag(Position.AFTER_SELECT, Expressions
+            .template(Object.class, "distinct on({0}) ", ExpressionUtils.list(Object.class, exprs)));
+    }
+
     @Override
     public PostgresQuery clone(Connection conn) {
         PostgresQuery q = new PostgresQuery(conn, getConfiguration(), getMetadata().clone());

--- a/querydsl-sql/src/main/java/com/mysema/query/sql/postgres/PostgresQuery.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/postgres/PostgresQuery.java
@@ -89,9 +89,10 @@ public class PostgresQuery extends AbstractSQLQuery<PostgresQuery> {
      * @param exprs
      * @return
      */
-    public PostgresQuery distinct(Expression<?>... exprs) {
-        return addFlag(Position.AFTER_SELECT, Expressions
-            .template(Object.class, "distinct on({0}) ", ExpressionUtils.list(Object.class, exprs)));
+    public PostgresQuery distinctOn(Expression<?>... exprs) {
+        return addFlag(Position.AFTER_SELECT,
+            Expressions.template(Object.class, "distinct on({0}) ",
+            ExpressionUtils.list(Object.class, exprs)));
     }
 
     @Override

--- a/querydsl-sql/src/test/java/com/mysema/query/sql/postgres/PostgresQueryTest.java
+++ b/querydsl-sql/src/test/java/com/mysema/query/sql/postgres/PostgresQueryTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.mysema.query.sql.PostgresTemplates;
+import com.mysema.query.sql.domain.QEmployee;
 import com.mysema.query.sql.domain.QSurvey;
 
 public class PostgresQueryTest {
@@ -13,6 +14,8 @@ public class PostgresQueryTest {
     private PostgresQuery query;
     
     private QSurvey survey = new QSurvey("survey");
+
+    private QEmployee employee = new QEmployee("employee");
     
     @Before
     public void setUp() {
@@ -25,6 +28,7 @@ public class PostgresQueryTest {
     public void Syntax() {
 //        [ WITH [ RECURSIVE ] with_query [, ...] ]
 //        SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ]
+        query.distinct(survey.name);
 //            * | expression [ [ AS ] output_name ] [, ...]
 //            [ FROM from_item [, ...] ]
         query.from(survey);
@@ -86,6 +90,19 @@ public class PostgresQueryTest {
         query.from(survey).forUpdate().of(survey);
         assertEquals("from SURVEY survey for update of SURVEY", toString(query));
     }
+
+    @Test
+    public void Distinct_On() {
+        query.from(employee)
+            .distinct(employee.datefield, employee.timefield)
+            .orderBy(employee.datefield.asc(), employee.timefield.asc(), employee.salary.asc());
+
+        query.getMetadata().addProjection(employee.id);
+        assertEquals(
+            "select distinct on(employee.DATEFIELD, employee.TIMEFIELD) employee.ID from EMPLOYEE employee order by employee.DATEFIELD asc, employee.TIMEFIELD asc, employee.SALARY asc",
+            toString(query));
+    }
+
     
     private String toString(PostgresQuery query) {
         return query.toString().replace('\n', ' ');

--- a/querydsl-sql/src/test/java/com/mysema/query/sql/postgres/PostgresQueryTest.java
+++ b/querydsl-sql/src/test/java/com/mysema/query/sql/postgres/PostgresQueryTest.java
@@ -28,7 +28,7 @@ public class PostgresQueryTest {
     public void Syntax() {
 //        [ WITH [ RECURSIVE ] with_query [, ...] ]
 //        SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ]
-        query.distinct(survey.name);
+        query.distinctOn(survey.name);
 //            * | expression [ [ AS ] output_name ] [, ...]
 //            [ FROM from_item [, ...] ]
         query.from(survey);
@@ -94,7 +94,7 @@ public class PostgresQueryTest {
     @Test
     public void Distinct_On() {
         query.from(employee)
-            .distinct(employee.datefield, employee.timefield)
+            .distinctOn(employee.datefield, employee.timefield)
             .orderBy(employee.datefield.asc(), employee.timefield.asc(), employee.salary.asc());
 
         query.getMetadata().addProjection(employee.id);


### PR DESCRIPTION
Simple change to allow for using DISTINCT ON, a very useful postgres specific feature:
http://www.postgresql.org/docs/9.4/static/sql-select.html#SQL-DISTINCT

Another user inquired about this in #1212.

Submitting a separate PR for version 4 changes [#1490].