### PR TITLE
add support for postgresql specific DISTINCT ON syntax (v4)

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/PostgreSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/PostgreSQLQuery.java
@@ -95,9 +95,10 @@ public class PostgreSQLQuery<T> extends AbstractSQLQuery<T, PostgreSQLQuery<T>> 
      * @param exprs
      * @return
      */
-    public PostgreSQLQuery<T> distinct(Expression<?>... exprs) {
-        return addFlag(Position.AFTER_SELECT, Expressions
-            .template(Object.class, "distinct on({0}) ", ExpressionUtils.list(Object.class, exprs)));
+    public PostgreSQLQuery<T> distinctOn(Expression<?>... exprs) {
+        return addFlag(Position.AFTER_SELECT,
+            Expressions.template(Object.class, "distinct on({0}) ",
+            ExpressionUtils.list(Object.class, exprs)));
     }
 
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/PostgreSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/PostgreSQLQuery.java
@@ -21,6 +21,8 @@ import com.querydsl.core.QueryFlag.Position;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.sql.*;
 
 /**
@@ -86,6 +88,18 @@ public class PostgreSQLQuery<T> extends AbstractSQLQuery<T, PostgreSQLQuery<T>> 
         }
         return addFlag(Position.END, builder.toString());
     }
+
+    /**
+     * adds a DISTINCT ON clause
+     *
+     * @param exprs
+     * @return
+     */
+    public PostgreSQLQuery<T> distinct(Expression<?>... exprs) {
+        return addFlag(Position.AFTER_SELECT, Expressions
+            .template(Object.class, "distinct on({0}) ", ExpressionUtils.list(Object.class, exprs)));
+    }
+
 
     @Override
     public PostgreSQLQuery<T> clone(Connection conn) {

--- a/querydsl-sql/src/test/java/com/querydsl/sql/postgresql/PostgreSQLQueryTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/postgresql/PostgreSQLQueryTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.querydsl.sql.PostgreSQLTemplates;
+import com.querydsl.sql.domain.QEmployee;
 import com.querydsl.sql.domain.QSurvey;
 
 public class PostgreSQLQueryTest {
@@ -13,6 +14,8 @@ public class PostgreSQLQueryTest {
     private PostgreSQLQuery<?> query;
 
     private QSurvey survey = new QSurvey("survey");
+
+    private QEmployee employee = new QEmployee("employee");
 
     @Before
     public void setUp() {
@@ -23,6 +26,7 @@ public class PostgreSQLQueryTest {
     public void Syntax() {
 //        [ WITH [ RECURSIVE ] with_query [, ...] ]
 //        SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ]
+        query.distinct(survey.name);
 //            * | expression [ [ AS ] output_name ] [, ...]
 //            [ FROM from_item [, ...] ]
         query.from(survey);
@@ -83,6 +87,18 @@ public class PostgreSQLQueryTest {
     public void ForUpdate_Of() {
         query.from(survey).forUpdate().of(survey);
         assertEquals("from SURVEY survey for update of SURVEY", toString(query));
+    }
+
+    @Test
+    public void Distinct_On() {
+        query.from(employee)
+            .distinct(employee.datefield, employee.timefield)
+            .orderBy(employee.datefield.asc(), employee.timefield.asc(), employee.salary.asc())
+            .select(employee.id);
+
+        assertEquals(
+            "select distinct on(employee.DATEFIELD, employee.TIMEFIELD) employee.ID from EMPLOYEE employee order by employee.DATEFIELD asc, employee.TIMEFIELD asc, employee.SALARY asc",
+            toString(query));
     }
 
     private String toString(PostgreSQLQuery query) {

--- a/querydsl-sql/src/test/java/com/querydsl/sql/postgresql/PostgreSQLQueryTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/postgresql/PostgreSQLQueryTest.java
@@ -26,7 +26,7 @@ public class PostgreSQLQueryTest {
     public void Syntax() {
 //        [ WITH [ RECURSIVE ] with_query [, ...] ]
 //        SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ]
-        query.distinct(survey.name);
+        query.distinctOn(survey.name);
 //            * | expression [ [ AS ] output_name ] [, ...]
 //            [ FROM from_item [, ...] ]
         query.from(survey);
@@ -92,7 +92,7 @@ public class PostgreSQLQueryTest {
     @Test
     public void Distinct_On() {
         query.from(employee)
-            .distinct(employee.datefield, employee.timefield)
+            .distinctOn(employee.datefield, employee.timefield)
             .orderBy(employee.datefield.asc(), employee.timefield.asc(), employee.salary.asc())
             .select(employee.id);
 


### PR DESCRIPTION
Simple change to allow for using DISTINCT ON, a very useful postgres specific feature:
http://www.postgresql.org/docs/9.4/static/sql-select.html#SQL-DISTINCT

Another user inquired about this in [#1212].

Also submitted a PR for v3 [#1489].