### PR TITLE
Enable dynamic exclusion of test categories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
     <project.homepage>http://www.querydsl.com</project.homepage>
     <project.githubpage>http://github.com/querydsl/querydsl</project.githubpage>
     <project.checkout>scm:git:git@github.com:querydsl/querydsl.git</project.checkout>
+
+    <!-- default groups to exclude from surefire plugin -->
+    <excludedGroups>com.querydsl.core.testutil.ExternalDB,com.querydsl.core.testutil.SlowTest</excludedGroups>
     
     <!-- deps -->
     <derby.version>10.11.1.1</derby.version>
@@ -388,7 +391,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>-Xms256m -Xmx512m</argLine>
-          <excludedGroups>com.querydsl.core.testutil.ExternalDB,com.querydsl.core.testutil.SlowTest</excludedGroups>
+          <excludedGroups>${excludedGroups}</excludedGroups>
         </configuration>
         <dependencies>
           <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -603,14 +603,16 @@
     </profile>
     
     <profile>
-      <id>jenkins</id>      
+      <id>jenkins</id>
+      <properties>
+        <excludedGroups>com.querydsl.core.testutil.Performance</excludedGroups>
+      </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>          
-              <excludedGroups>com.querydsl.core.testutil.Performance</excludedGroups>
               <excludes>
                 <exclude>**/*$*</exclude>
                 <exclude>**/DB2*SuiteTest.java</exclude>
@@ -632,13 +634,15 @@
 
     <profile>
       <id>travis</id>
+      <properties>
+        <excludedGroups>com.querydsl.core.testutil.Performance,com.querydsl.core.testutil.ReportingOnly</excludedGroups>
+      </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <excludedGroups>com.querydsl.core.testutil.Performance,com.querydsl.core.testutil.ReportingOnly</excludedGroups>
               <disableXmlReport>true</disableXmlReport>
               <printSummary>false</printSummary>
               <excludes>


### PR DESCRIPTION
Using a property to set excludedGroups enables developers to dynamically configure the groups of tests run by the surefire plugin.

I added this because I often want to turn off reporting and performance to speed up tests and I want to be able to easily enable the external database tests.

`mvn clean test -DexcludedGroups=com.querydsl.core.testutil.ExternalDB,com.querydsl.core.testutil.Performance,com.querydsl.core.testutil.ReportingOnly`

or `mvn clean test -DexcludedGroups=` to run all tests.