### PR TITLE
Remove reference to querydsl-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Free support is provided in the Querydsl Google Group https://groups.google.com/
 Querydsl provides releases via public Maven repositories, but you can build the sources also yourself like this
 
 ```BASH
-$ cd querydsl-root
 $ mvn -DskipTests=true clean install
 ```
 


### PR DESCRIPTION
The root pom is now in the root directory so developers no longer need to switch to ./querydsl-root/ to build the project.