### PR TITLE
Improve test categories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,15 @@
     <project.checkout>scm:git:git@github.com:querydsl/querydsl.git</project.checkout>
 
     <!-- default groups to exclude from surefire plugin -->
-    <excludedGroups>com.querydsl.core.testutil.ExternalDatabase,
-                    com.querydsl.core.testutil.SlowTest,com.querydsl.core.testutil.Performance</excludedGroups>
+    <excludedGroups>
+      com.querydsl.core.testutil.ExternalDatabase,
+      com.querydsl.core.testutil.SlowTest,
+      com.querydsl.core.testutil.Performance,
+      com.querydsl.core.testutil.ReportingOnly
+    </excludedGroups>
+
+    <!-- groups to run with surefire plugin - intended to be overridden on the command line -->
+    <groups></groups>
     
     <!-- deps -->
     <derby.version>10.11.1.1</derby.version>
@@ -394,6 +401,7 @@
         <configuration>
           <argLine>-Xms256m -Xmx512m</argLine>
           <excludedGroups>${excludedGroups}</excludedGroups>
+          <groups>${groups}</groups>
         </configuration>
         <dependencies>
           <dependency>
@@ -603,29 +611,6 @@
         <module>querydsl-collections</module>
       </modules>
     </profile>
-    
-    <profile>
-      <id>jenkins</id>
-      <properties>
-        <excludedGroups>com.querydsl.core.testutil.Performance</excludedGroups>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>          
-              <excludes>
-                <exclude>**/*$*</exclude>
-                <exclude>**/DB2*SuiteTest.java</exclude>
-                <exclude>**/MSSQL*SuiteTest.java</exclude>
-                <exclude>**/Teradata*SuiteTest.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
     <profile>
       <id>examples</id>
@@ -668,17 +653,6 @@
             <configuration>
               <disableXmlReport>true</disableXmlReport>
               <printSummary>false</printSummary>
-              <excludes>
-                <exclude>**/*$*</exclude>
-                <exclude>**/DB2*SuiteTest.java</exclude>
-                <exclude>**/ExportMSSQLTest.java</exclude>
-                <exclude>**/ExportOracleTest.java</exclude>
-                <exclude>**/ExportTeradataTest.java</exclude>
-                <exclude>**/Oracle*SuiteTest.java</exclude>
-                <exclude>**/OracleWithQuotingTest.java</exclude> 
-                <exclude>**/MSSQL*SuiteTest.java</exclude>
-                <exclude>**/Teradata*SuiteTest.java</exclude>
-              </excludes>
               <properties>
                 <property>
                   <name>listener</name>
@@ -690,8 +664,6 @@
         </plugins>
       </build>
     </profile>
-
-
   </profiles>
   
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,8 @@
     <project.checkout>scm:git:git@github.com:querydsl/querydsl.git</project.checkout>
 
     <!-- default groups to exclude from surefire plugin -->
-    <excludedGroups>com.querydsl.core.testutil.ExternalDB,com.querydsl.core.testutil.SlowTest</excludedGroups>
+    <excludedGroups>com.querydsl.core.testutil.ExternalDatabase,
+                    com.querydsl.core.testutil.SlowTest,com.querydsl.core.testutil.Performance</excludedGroups>
     
     <!-- deps -->
     <derby.version>10.11.1.1</derby.version>
@@ -634,9 +635,30 @@
     </profile>
 
     <profile>
+      <id>jenkins</id>
+      <properties>
+        <excludedGroups>
+          com.querydsl.core.testutil.Performance,
+
+          com.querydsl.core.testutil.DB2,
+          com.querydsl.core.testutil.SQLServer,
+          com.querydsl.core.testutil.Teradata
+        </excludedGroups>
+      </properties>
+    </profile>
+
+    <profile>
       <id>travis</id>
       <properties>
-        <excludedGroups>com.querydsl.core.testutil.Performance,com.querydsl.core.testutil.ReportingOnly</excludedGroups>
+        <excludedGroups>
+          com.querydsl.core.testutil.Performance,
+          com.querydsl.core.testutil.ReportingOnly,
+
+          com.querydsl.core.testutil.DB2,
+          com.querydsl.core.testutil.SQLServer,
+          com.querydsl.core.testutil.Teradata,
+          com.querydsl.core.testutil.Oracle
+        </excludedGroups>
       </properties>
       <build>
         <plugins>

--- a/querydsl-core/src/test/java/com/querydsl/core/Target.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/Target.java
@@ -39,7 +39,7 @@ public enum Target {
      */
     H2,
     /**
-     * HSSQLDB
+     * HSQLDB
      */
     HSQLDB,
     /**

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/CUBRID.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/CUBRID.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface CUBRID extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/DB2.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/DB2.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface DB2 extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/Database.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/Database.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+/**
+ * {@code Database} is a category for tests that require a connection to a database.
+ */
+public interface Database {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/Derby.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/Derby.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface Derby extends EmbeddedDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/EmbeddedDatabase.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/EmbeddedDatabase.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+/**
+ * {@code EmbeddedDatabase} is a category for tests that require access to embeddable
+ * databases such as H2 and HSQL.
+ */
+public interface EmbeddedDatabase extends Database {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/ExternalDB.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/ExternalDB.java
@@ -1,8 +1,0 @@
-package com.querydsl.core.testutil;
-
-/**
- * ExternalDB is used as a test category
- */
-public interface ExternalDB {
-
-}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/ExternalDatabase.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/ExternalDatabase.java
@@ -1,0 +1,9 @@
+package com.querydsl.core.testutil;
+
+/**
+ * {@code ExternalDatabase} is a category for tests that require access to databases, such as MySQL or PostgreSQL, that
+ * must be externally configured.
+ */
+public interface ExternalDatabase extends Database {
+
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/Firebird.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/Firebird.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface Firebird extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/H2.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/H2.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface H2 extends EmbeddedDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/HSQLDB.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/HSQLDB.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface HSQLDB extends EmbeddedDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/MongoDB.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/MongoDB.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface MongoDB extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/MySQL.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/MySQL.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface MySQL extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/Oracle.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/Oracle.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface Oracle extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/PostgreSQL.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/PostgreSQL.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface PostgreSQL extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/SQLServer.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/SQLServer.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface SQLServer extends ExternalDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/SQLite.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/SQLite.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface SQLite extends EmbeddedDatabase {
+}

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/Teradata.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/Teradata.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.core.testutil;
+
+public interface Teradata extends ExternalDatabase {
+}

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/DerbyEclipseLinkTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/DerbyEclipseLinkTest.java
@@ -1,10 +1,13 @@
 package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.Derby;
 import com.querydsl.jpa.*;
 
+@Category(Derby.class)
 public class DerbyEclipseLinkTest extends AbstractJPASuite {
 
     public static class JPA extends JPABase {

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/DerbySuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/DerbySuiteTest.java
@@ -1,10 +1,13 @@
 package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.Derby;
 import com.querydsl.jpa.*;
 
+@Category(Derby.class)
 public class DerbySuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2BatooTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2BatooTest.java
@@ -2,11 +2,14 @@ package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.H2;
 import com.querydsl.jpa.*;
 
 @Ignore
+@Category(H2.class)
 public class H2BatooTest extends AbstractJPASuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2EclipseLinkTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2EclipseLinkTest.java
@@ -1,10 +1,13 @@
 package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.H2;
 import com.querydsl.jpa.*;
 
+@Category(H2.class)
 public class H2EclipseLinkTest extends AbstractJPASuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2OpenJPATest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2OpenJPATest.java
@@ -2,11 +2,14 @@ package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.H2;
 import com.querydsl.jpa.*;
 
 @Ignore
+@Category(H2.class)
 public class H2OpenJPATest extends AbstractJPASuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2SuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/H2SuiteTest.java
@@ -1,10 +1,13 @@
 package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.H2;
 import com.querydsl.jpa.*;
 
+@Category(H2.class)
 public class H2SuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/HSQLDBEclipseLinkTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/HSQLDBEclipseLinkTest.java
@@ -1,10 +1,13 @@
 package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.HSQLDB;
 import com.querydsl.jpa.*;
 
+@Category(HSQLDB.class)
 public class HSQLDBEclipseLinkTest extends AbstractJPASuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/HSQLDBSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/HSQLDBSuiteTest.java
@@ -1,10 +1,13 @@
 package com.querydsl.jpa.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
+import com.querydsl.core.testutil.HSQLDB;
 import com.querydsl.jpa.*;
 
+@Category(HSQLDB.class)
 public class HSQLDBSuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MSSQLSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MSSQLSuiteTest.java
@@ -4,10 +4,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.SQLServer;
 import com.querydsl.jpa.*;
 
-@Category(ExternalDB.class)
+@Category(SQLServer.class)
 public class MSSQLSuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLEclipseLinkTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLEclipseLinkTest.java
@@ -4,10 +4,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.jpa.*;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class MySQLEclipseLinkTest extends AbstractJPASuite {
 
     public static class JPA extends JPABase {

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLSuiteTest.java
@@ -4,10 +4,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.jpa.*;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class MySQLSuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase {

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/OracleSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/OracleSuiteTest.java
@@ -4,10 +4,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Oracle;
 import com.querydsl.jpa.*;
 
-@Category(ExternalDB.class)
+@Category(Oracle.class)
 public class OracleSuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLEclipseLinkSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLEclipseLinkSuiteTest.java
@@ -4,10 +4,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.jpa.*;
 
-@Category(ExternalDB.class)
+@Category(PostgreSQL.class)
 public class PostgreSQLEclipseLinkSuiteTest extends AbstractJPASuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLSuiteTest.java
@@ -4,10 +4,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.jpa.*;
 
-@Category(ExternalDB.class)
+@Category(PostgreSQL.class)
 public class PostgreSQLSuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/TeradataSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/TeradataSuiteTest.java
@@ -4,10 +4,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.Target;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Teradata;
 import com.querydsl.jpa.*;
 
-@Category(ExternalDB.class)
+@Category(Teradata.class)
 public class TeradataSuiteTest extends AbstractSuite {
 
     public static class JPA extends JPABase { }

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -27,12 +27,12 @@ import org.mongodb.morphia.Morphia;
 import com.mongodb.BasicDBObject;
 import com.mongodb.Mongo;
 import com.mongodb.MongoException;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.mongodb.domain.GeoEntity;
 import com.querydsl.mongodb.domain.QGeoEntity;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
 
-@Category(ExternalDB.class)
+@Category(MongoDB.class)
 public class GeoSpatialQueryTest {
 
     private final String dbname = "geodb";

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
@@ -12,14 +12,14 @@ import org.mongodb.morphia.Morphia;
 
 import com.mongodb.Mongo;
 import com.mongodb.MongoException;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.mongodb.domain.Item;
 import com.querydsl.mongodb.domain.QUser;
 import com.querydsl.mongodb.domain.User;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
 
-@Category(ExternalDB.class)
+@Category(MongoDB.class)
 public class JoinTest {
 
     private final Mongo mongo;

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
@@ -32,7 +32,7 @@ import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.QueryResults;
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
@@ -42,7 +42,7 @@ import com.querydsl.mongodb.domain.*;
 import com.querydsl.mongodb.domain.User.Gender;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
 
-@Category(ExternalDB.class)
+@Category(MongoDB.class)
 public class MongodbQueryTest {
 
     private final Mongo mongo;

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
@@ -4,23 +4,20 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.UnknownHostException;
 
-import com.mongodb.Mongo;
-import com.mongodb.MongoException;
-import com.querydsl.core.testutil.ExternalDB;
-import com.querydsl.core.types.Predicate;
-import com.querydsl.mongodb.domain.Fish;
-import com.querydsl.mongodb.domain.Food;
-import com.querydsl.mongodb.domain.Chips;
-import com.querydsl.mongodb.domain.QFish;
-import com.querydsl.mongodb.domain.QFood;
-import com.querydsl.mongodb.morphia.MorphiaQuery;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
 
-@Category(ExternalDB.class)
+import com.mongodb.Mongo;
+import com.mongodb.MongoException;
+import com.querydsl.core.testutil.MongoDB;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.mongodb.domain.*;
+import com.querydsl.mongodb.morphia.MorphiaQuery;
+
+@Category(MongoDB.class)
 public class PolymorphicCollectionTest {
 
     private final Morphia morphia;

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportDerbyTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportDerbyTest.java
@@ -14,9 +14,12 @@
 package com.querydsl.sql.codegen;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.Derby;
 import com.querydsl.sql.Connections;
 
+@Category(Derby.class)
 public class ExportDerbyTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportH2Test.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportH2Test.java
@@ -14,9 +14,12 @@
 package com.querydsl.sql.codegen;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.Connections;
 
+@Category(H2.class)
 public class ExportH2Test extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportH2TwoSchemasTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportH2TwoSchemasTest.java
@@ -12,11 +12,14 @@ import java.sql.Statement;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.Connections;
 
+@Category(H2.class)
 public class ExportH2TwoSchemasTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportHsqldbTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportHsqldbTest.java
@@ -14,9 +14,12 @@
 package com.querydsl.sql.codegen;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.HSQLDB;
 import com.querydsl.sql.Connections;
 
+@Category(HSQLDB.class)
 public class ExportHsqldbTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportMSSQLTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportMSSQLTest.java
@@ -16,10 +16,10 @@ package com.querydsl.sql.codegen;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.SQLServer;
 import com.querydsl.sql.Connections;
 
-@Category(ExternalDB.class)
+@Category(SQLServer.class)
 public class ExportMSSQLTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportMySQLTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportMySQLTest.java
@@ -16,10 +16,10 @@ package com.querydsl.sql.codegen;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.sql.Connections;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class ExportMySQLTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportOracleTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportOracleTest.java
@@ -16,10 +16,10 @@ package com.querydsl.sql.codegen;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Oracle;
 import com.querydsl.sql.Connections;
 
-@Category(ExternalDB.class)
+@Category(Oracle.class)
 public class ExportOracleTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportPostgreSQLTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportPostgreSQLTest.java
@@ -16,10 +16,10 @@ package com.querydsl.sql.codegen;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.sql.Connections;
 
-@Category(ExternalDB.class)
+@Category(PostgreSQL.class)
 public class ExportPostgreSQLTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportSQLiteTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportSQLiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.codegen;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.SQLite;
 import com.querydsl.sql.Connections;
 
+@Category(SQLite.class)
 public class ExportSQLiteTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportTeradataTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ExportTeradataTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.codegen;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Teradata;
 import com.querydsl.sql.Connections;
 
-@Category(ExternalDB.class)
+@Category(Teradata.class)
 public class ExportTeradataTest extends ExportBaseTest {
 
     @BeforeClass

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/H2LiteralsSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/H2LiteralsSuiteTest.java
@@ -1,12 +1,15 @@
 package com.querydsl.sql.spatial.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.GeoDBTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
+@Category(H2.class)
 public class H2LiteralsSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/H2SuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/H2SuiteTest.java
@@ -1,12 +1,15 @@
 package com.querydsl.sql.spatial.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.GeoDBTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
+@Category(H2.class)
 public class H2SuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MSSQLLiteralsSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MSSQLLiteralsSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.SQLServer;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.SQLServer2008SpatialTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(SQLServer.class)
 public class MSSQLLiteralsSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MSSQLSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MSSQLSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.SQLServer;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.SQLServer2008SpatialTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(SQLServer.class)
 public class MSSQLSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MySQLLiteralsSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MySQLLiteralsSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.MySQLSpatialTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class MySQLLiteralsSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MySQLSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/MySQLSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.MySQLSpatialTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class MySQLSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/PostgreSQLLiteralsSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/PostgreSQLLiteralsSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.PostGISTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(PostgreSQL.class)
 public class PostgreSQLLiteralsSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/PostgreSQLSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/PostgreSQLSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.PostGISTemplates;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(PostgreSQL.class)
 public class PostgreSQLSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/SpatialTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/SpatialTest.java
@@ -5,9 +5,12 @@ import java.sql.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.Connections;
 
+@Category(H2.class)
 public class SpatialTest {
 
     @Before

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/TeradataLiteralsSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/TeradataLiteralsSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Teradata;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.spatial.TeradataSpatialTemplates;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(Teradata.class)
 public class TeradataLiteralsSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/TeradataSuiteTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/TeradataSuiteTest.java
@@ -3,13 +3,13 @@ package com.querydsl.sql.spatial.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Teradata;
 import com.querydsl.sql.Connections;
 import com.querydsl.sql.spatial.SpatialBase;
 import com.querydsl.sql.spatial.TeradataSpatialTemplates;
 import com.querydsl.sql.suites.AbstractSuite;
 
-@Category(ExternalDB.class)
+@Category(Teradata.class)
 public class TeradataSuiteTest extends AbstractSuite {
 
     public static class Spatial extends SpatialBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/QueryMutabilityTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/QueryMutabilityTest.java
@@ -23,10 +23,13 @@ import java.sql.SQLException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.querydsl.core.QueryMutability;
+import com.querydsl.core.testutil.Derby;
 import com.querydsl.sql.domain.QSurvey;
 
+@Category(Derby.class)
 public class QueryMutabilityTest {
 
     private static final QSurvey survey = new QSurvey("survey");

--- a/querydsl-sql/src/test/java/com/querydsl/sql/QueryPerformanceTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/QueryPerformanceTest.java
@@ -16,8 +16,9 @@ import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.testutil.Benchmark;
 import com.querydsl.core.testutil.Performance;
 import com.querydsl.core.testutil.Runner;
+import com.querydsl.core.testutil.Derby;
 
-@Category(Performance.class)
+@Category({Derby.class, Performance.class})
 public class QueryPerformanceTest {
 
     private static final String QUERY = "select COMPANIES.NAME\n" +

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLCloseListenerTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLCloseListenerTest.java
@@ -9,10 +9,13 @@ import java.sql.SQLException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.domain.Employee;
 
+@Category(H2.class)
 public class SQLCloseListenerTest {
 
     private SQLQuery<Employee> query;

--- a/querydsl-sql/src/test/java/com/querydsl/sql/mysql/GeneratedKeysMySQLTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/mysql/GeneratedKeysMySQLTest.java
@@ -22,12 +22,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.sql.H2Templates;
 import com.querydsl.sql.QGeneratedKeysEntity;
 import com.querydsl.sql.dml.SQLInsertClause;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class GeneratedKeysMySQLTest {
 
     private Connection conn;

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDLiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.CUBRID;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(CUBRID.class)
 public class CUBRIDLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.CUBRID;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(CUBRID.class)
 public class CUBRIDSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/DB2LiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/DB2LiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.DB2;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(DB2.class)
 public class DB2LiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/DB2SuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/DB2SuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.DB2;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(DB2.class)
 public class DB2SuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/DerbyLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/DerbyLiteralsSuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.Derby;
 import com.querydsl.sql.*;
 
+@Category(Derby.class)
 public class DerbyLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/DerbySuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/DerbySuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.Derby;
 import com.querydsl.sql.*;
 
+@Category(Derby.class)
 public class DerbySuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/FirebirdLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/FirebirdLiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Firebird;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(Firebird.class)
 public class FirebirdLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/FirebirdSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/FirebirdSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Firebird;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(Firebird.class)
 public class FirebirdSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2ExceptionSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2ExceptionSuiteTest.java
@@ -8,12 +8,15 @@ import java.sql.SQLException;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.base.Throwables;
 import com.querydsl.core.JavaSpecVersion;
 import com.querydsl.core.QueryException;
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.*;
 
+@Category(H2.class)
 public class H2ExceptionSuiteTest extends AbstractBaseTest {
 
     private static final SQLExceptionTranslator exceptionTranslator = DefaultSQLExceptionTranslator.DEFAULT;

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2LiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2LiteralsSuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.*;
 
+@Category(H2.class)
 public class H2LiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2SuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2SuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.*;
 
+@Category(H2.class)
 public class H2SuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2WithQuotingTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2WithQuotingTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.*;
 
+@Category(H2.class)
 public class H2WithQuotingTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2WithSchemaTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2WithSchemaTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.*;
 
+@Category(H2.class)
 public class H2WithSchemaTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/HsqldbLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/HsqldbLiteralsSuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.*;
 
+@Category(H2.class)
 public class HsqldbLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/HsqldbSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/HsqldbSuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.H2;
 import com.querydsl.sql.*;
 
+@Category(H2.class)
 public class HsqldbSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/MSSQLLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/MSSQLLiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.SQLServer;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(SQLServer.class)
 public class MSSQLLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/MSSQLSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/MSSQLSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.SQLServer;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(SQLServer.class)
 public class MSSQLSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/MySQLLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/MySQLLiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class MySQLLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/MySQLSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/MySQLSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class MySQLSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/MySQLWithQuotingTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/MySQLWithQuotingTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.MySQL;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(MySQL.class)
 public class MySQLWithQuotingTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/OracleLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/OracleLiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Oracle;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(Oracle.class)
 public class OracleLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/OracleSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/OracleSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Oracle;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(Oracle.class)
 public class OracleSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/OracleWithQuotingTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/OracleWithQuotingTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Oracle;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(Oracle.class)
 public class OracleWithQuotingTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/PostgreSQLLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/PostgreSQLLiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(PostgreSQL.class)
 public class PostgreSQLLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/PostgreSQLSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/PostgreSQLSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(PostgreSQL.class)
 public class PostgreSQLSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/SQLiteLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/SQLiteLiteralsSuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.SQLite;
 import com.querydsl.sql.*;
 
+@Category(SQLite.class)
 public class SQLiteLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/SQLiteSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/SQLiteSuiteTest.java
@@ -1,9 +1,12 @@
 package com.querydsl.sql.suites;
 
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+import com.querydsl.core.testutil.SQLite;
 import com.querydsl.sql.*;
 
+@Category(SQLite.class)
 public class SQLiteSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/TeradataLiteralsSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/TeradataLiteralsSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Teradata;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(Teradata.class)
 public class TeradataLiteralsSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/suites/TeradataSuiteTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/suites/TeradataSuiteTest.java
@@ -3,10 +3,10 @@ package com.querydsl.sql.suites;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import com.querydsl.core.testutil.ExternalDB;
+import com.querydsl.core.testutil.Teradata;
 import com.querydsl.sql.*;
 
-@Category(ExternalDB.class)
+@Category(Teradata.class)
 public class TeradataSuiteTest extends AbstractSuite {
 
     public static class BeanPopulation extends BeanPopulationBase { }


### PR DESCRIPTION
Instead of using `ExternalDB` as a test category for all tests requiring a database, this PR adds database-specific classes so that they can be run individually.

Examples: `mvn clean test -Psql -Dgroups=com.querydsl.core.testutil.H2 -DexcludedGroups=`