### PR TITLE
Remove compiler warnings

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
@@ -30,6 +30,7 @@ import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileObject;
 
+import com.google.common.collect.Iterables;
 import com.mysema.codegen.JavaWriter;
 import com.mysema.codegen.model.Parameter;
 import com.mysema.codegen.model.Type;
@@ -423,9 +424,8 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private Set<TypeElement> processDelegateMethods() {
-        Set<Element> delegateMethods = (Set) getElements(QueryDelegate.class);
+        Set<? extends Element> delegateMethods = getElements(QueryDelegate.class);
         Set<TypeElement> typeElements = new HashSet<TypeElement>();
 
         for (Element delegateMethod : delegateMethods) {
@@ -472,19 +472,18 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
         return typeElements;
     }
 
-    @SuppressWarnings("unchecked")
     private void validateMetaTypes() {
-        for (Collection<EntityType> entityTypes : Arrays.asList(
+        @SuppressWarnings("unchecked") // Only concatenated
+        Iterable<? extends EntityType> entityTypes = Iterables.concat(
                 context.supertypes.values(),
                 context.entityTypes.values(),
                 context.extensionTypes.values(),
                 context.embeddableTypes.values(),
-                context.projectionTypes.values())) {
-            for (EntityType entityType : entityTypes) {
-                for (Property property : entityType.getProperties()) {
-                    if (property.getInits() != null && property.getInits().size() > 0) {
-                        validateInits(entityType, property);
-                    }
+                context.projectionTypes.values());
+        for (EntityType entityType : entityTypes) {
+            for (Property property : entityType.getProperties()) {
+                if (property.getInits() != null && property.getInits().size() > 0) {
+                    validateInits(entityType, property);
                 }
             }
         }

--- a/querydsl-apt/src/main/java/com/querydsl/apt/SpatialSupport.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/SpatialSupport.java
@@ -63,8 +63,8 @@ final class SpatialSupport {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static void addImports(AbstractModule module, String packageName) {
+        @SuppressWarnings("unchecked")
         Set<String> imports = module.get(Set.class, CodegenModule.IMPORTS);
         if (imports.isEmpty()) {
             imports = ImmutableSet.of(packageName);

--- a/querydsl-apt/src/main/java/com/querydsl/apt/morphia/MorphiaAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/morphia/MorphiaAnnotationProcessor.java
@@ -28,6 +28,7 @@ import com.querydsl.apt.Configuration;
 import com.querydsl.apt.DefaultConfiguration;
 import com.querydsl.core.annotations.QueryEntities;
 import com.querydsl.core.annotations.QuerySupertype;
+import com.querydsl.core.types.Expression;
 
 /**
  * Annotation processor to create Querydsl query types for Morphia annotated classes
@@ -38,7 +39,6 @@ import com.querydsl.core.annotations.QuerySupertype;
 @SupportedAnnotationTypes({"com.querydsl.core.annotations.*","org.mongodb.morphia.annotations.*"})
 public class MorphiaAnnotationProcessor extends AbstractQuerydslProcessor {
 
-    @SuppressWarnings("unchecked")
     @Override
     protected Configuration createConfiguration(RoundEnvironment roundEnv) {
         Class<? extends Annotation> entities = QueryEntities.class;
@@ -50,7 +50,9 @@ public class MorphiaAnnotationProcessor extends AbstractQuerydslProcessor {
                 processingEnv.getOptions(), Collections.<String>emptySet(),
                 entities, entity, superType, null, embedded, skip);
         try {
-            Class cl = Class.forName("com.querydsl.mongodb.Point");
+            @SuppressWarnings("unchecked") // Point is an Expression<Double[]>
+            Class<? extends Expression<Double[]>> cl =
+                    (Class<? extends Expression<Double[]>>) Class.forName("com.querydsl.mongodb.Point");
             conf.addCustomType(Double[].class, cl);
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException(e);

--- a/querydsl-apt/src/test/java/com/querydsl/apt/domain/AbstractClasses2Test.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/domain/AbstractClasses2Test.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import com.querydsl.core.types.dsl.NumberPath;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({"rawtypes", "serial", "unchecked"})
 public class AbstractClasses2Test {
 
     public interface Archetype<PK extends Serializable, DO extends Serializable> extends Serializable, Comparable<DO>  {

--- a/querydsl-apt/src/test/java/com/querydsl/apt/domain/AbstractClassesTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/domain/AbstractClassesTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import com.querydsl.core.types.dsl.NumberPath;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({"rawtypes", "serial", "unchecked"})
 public class AbstractClassesTest {
 
     public interface Archetype<PK extends Serializable, DO extends Serializable> extends Serializable, Comparable<DO>  {

--- a/querydsl-apt/src/test/java/com/querydsl/apt/domain/EntityTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/domain/EntityTest.java
@@ -97,7 +97,7 @@ public class EntityTest extends AbstractTest {
 
     @Test
     public void Constructors() throws SecurityException, NoSuchMethodException {
-        Class[] types = new Class[]{Class.class, PathMetadata.class, PathInits.class};
+        Class<?>[] types = new Class<?>[]{Class.class, PathMetadata.class, PathInits.class};
         QEntityTest_Entity1.class.getConstructor(types);
         QEntityTest_Entity2.class.getConstructor(types);
         QEntityTest_Entity3.class.getConstructor(types);
@@ -108,7 +108,7 @@ public class EntityTest extends AbstractTest {
 
     @Test(expected = NoSuchMethodException.class)
     public void Constructors2() throws SecurityException, NoSuchMethodException {
-        Class[] types = new Class[]{Class.class, PathMetadata.class, PathInits.class};
+        Class<?>[] types = new Class<?>[]{Class.class, PathMetadata.class, PathInits.class};
         QEntityTest_EntityNoReferences.class.getConstructor(types);
     }
 

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EntitySerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EntitySerializer.java
@@ -89,7 +89,7 @@ public class EntitySerializer implements Serializer {
 
         // Path
         if (!localName.equals(genericName)) {
-            writer.suppressWarnings("all");
+            suppressAllWarnings(writer);
         }
         Type simpleModel = new SimpleType(model);
         if (model.isFinal()) {
@@ -119,7 +119,7 @@ public class EntitySerializer implements Serializer {
             writer.end();
         } else {
             if (!localName.equals(genericName)) {
-                writer.suppressWarnings("all");
+                suppressAllWarnings(writer);
             }
             writer.beginConstructor(PATH_METADATA);
             if (stringOrBoolean) {
@@ -134,7 +134,7 @@ public class EntitySerializer implements Serializer {
         // PathMetadata, PathInits
         if (hasEntityFields) {
             if (!localName.equals(genericName)) {
-                writer.suppressWarnings("all");
+                suppressAllWarnings(writer);
             }
             writer.beginConstructor(PATH_METADATA, PATH_INITS);
             writer.line(thisOrSuper, "(", classCast, writer.getClassConstant(localName) + COMMA + "metadata, inits" + additionalParams + ");");
@@ -175,7 +175,7 @@ public class EntitySerializer implements Serializer {
         String additionalParams = hasEntityFields ? "" : getAdditionalConstructorParameter(model);
 
         if (!localName.equals(genericName)) {
-            writer.suppressWarnings("all");
+            suppressAllWarnings(writer);
         }
         writer.beginConstructor(new Parameter("variable", Types.STRING));
         if (stringOrBoolean) {
@@ -370,7 +370,7 @@ public class EntitySerializer implements Serializer {
 //                writer.append("(Class)");
 //            }
             writer.append(writer.getClassConstant(localName));
-            writer.append(", new Class[]{");
+            writer.append(", new Class<?>[]{");
             boolean first = true;
             for (Parameter p : c.getParameters()) {
                 if (!first) {
@@ -396,7 +396,6 @@ public class EntitySerializer implements Serializer {
         }
     }
 
-    @SuppressWarnings("unchecked")
     protected void introImports(CodeWriter writer, SerializerConfig config,
             EntityType model) throws IOException {
         writer.staticimports(PathMetadataFactory.class);
@@ -421,7 +420,7 @@ public class EntitySerializer implements Serializer {
         writer.imports(SimpleExpression.class.getPackage());
 
         // other classes
-        List<Class<?>> classes = Lists.newArrayList(PathMetadata.class, Generated.class);
+        List<Class<?>> classes = Lists.<Class<?>>newArrayList(PathMetadata.class, Generated.class);
         if (!getUsedClassNames(model).contains("Path")) {
             classes.add(Path.class);
         }
@@ -445,7 +444,7 @@ public class EntitySerializer implements Serializer {
         if (inits) {
             classes.add(PathInits.class);
         }
-        writer.imports(classes.toArray(new Class[classes.size()]));
+        writer.imports(classes.toArray(new Class<?>[classes.size()]));
     }
 
     private Set<String> getUsedClassNames(EntityType model) {
@@ -824,6 +823,10 @@ public class EntitySerializer implements Serializer {
         } else {
             return new SimpleType(type, type.getParameters());
         }
+    }
+
+    private static CodeWriter suppressAllWarnings(CodeWriter writer) throws IOException {
+        return writer.suppressWarnings("all", "rawtypes", "unchecked");
     }
 
 }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
@@ -322,7 +322,6 @@ public class GenericExporter {
         return false;
     }
 
-    @SuppressWarnings("unchecked")
     private EntityType createEntityType(Class<?> cl, Map<Class<?>, EntityType> types) {
         if (types.get(cl) != null) {
             return types.get(cl);
@@ -339,10 +338,14 @@ public class GenericExporter {
 
             typeMappings.register(type, queryTypeFactory.create(type));
 
-            if (strictMode && cl.getSuperclass() != null && !containsAny(cl.getSuperclass(),
-                    entityAnnotation, supertypeAnnotation, embeddableAnnotation)) {
-                // skip supertype handling
-                return type;
+            if (strictMode && cl.getSuperclass() != null) {
+                @SuppressWarnings("unchecked")
+                Class<? extends Annotation>[] annotations =
+                        (Class<? extends Annotation>[]) new Class<?>[] {entityAnnotation, supertypeAnnotation, embeddableAnnotation};
+                if (!containsAny(cl.getSuperclass(), annotations)) {
+                    // skip supertype handling
+                    return type;
+                }
             }
 
             if (cl.getSuperclass() != null && !stopClasses.contains(cl.getSuperclass())

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/ProjectionSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/ProjectionSerializer.java
@@ -115,7 +115,7 @@ public final class ProjectionSerializer implements Serializer {
             // body
             writer.beginLine("super(" + writer.getClassConstant(localName));
             // TODO: Fix for Scala (Array[Class])
-            writer.append(", new Class[]{");
+            writer.append(", new Class<?>[]{");
             boolean first = true;
 
             for (Parameter p : c.getParameters()) {

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/TypeFactoryTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/TypeFactoryTest.java
@@ -206,10 +206,9 @@ public class TypeFactoryTest {
         assertEquals("java.lang", bo.getPackageName());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void SimpleType() {
-        for (Class<?> cl : Arrays.asList(Blob.class, Clob.class, Locale.class, Class.class, Serializable.class)) {
+        for (Class<?> cl : Arrays.<Class<?>>asList(Blob.class, Clob.class, Locale.class, Class.class, Serializable.class)) {
             assertEquals("wrong type for " + cl.getName(), TypeCategory.SIMPLE, factory.get(cl).getCategory());
         }
     }

--- a/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
@@ -40,10 +40,11 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
 
     private final QueryEngine queryEngine;
 
-    @SuppressWarnings("unchecked")
     public AbstractCollQuery(QueryMetadata metadata, QueryEngine queryEngine) {
         super(new CollQueryMixin<Q>(metadata));
-        this.queryMixin.setSelf((Q) this);
+        @SuppressWarnings("unchecked") // Q is this + subtype
+        Q self = (Q) this;
+        this.queryMixin.setSelf(self);
         this.queryEngine = queryEngine;
     }
 
@@ -72,11 +73,10 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
      * @param col content of the source
      * @return current object
      */
-    @SuppressWarnings("unchecked")
     public <A> Q from(Path<A> entity, Iterable<? extends A> col) {
         iterables.put(entity, col);
         getMetadata().addJoin(JoinType.DEFAULT, entity);
-        return (Q) this;
+        return queryMixin.getSelf();
     }
 
     /**
@@ -87,10 +87,9 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
      * @param col content of the source
      * @return current object
      */
-    @SuppressWarnings("unchecked")
     public <A> Q bind(Path<A> entity, Iterable<? extends A> col) {
         iterables.put(entity, col);
-        return (Q) this;
+        return queryMixin.getSelf();
     }
 
     @Override
@@ -125,10 +124,9 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
      * @param alias alias for the join target
      * @return current object
      */
-    @SuppressWarnings("unchecked")
     public <P> Q innerJoin(Path<? extends Collection<P>> target, Path<P> alias) {
         getMetadata().addJoin(JoinType.INNERJOIN, createAlias(target, alias));
-        return (Q) this;
+        return queryMixin.getSelf();
     }
 
     /**
@@ -139,10 +137,9 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
      * @param alias alias for the join target
      * @return current object
      */
-    @SuppressWarnings("unchecked")
     public <P> Q innerJoin(MapExpression<?,P> target, Path<P> alias) {
         getMetadata().addJoin(JoinType.INNERJOIN, createAlias(target, alias));
-        return (Q) this;
+        return queryMixin.getSelf();
     }
 
     /**
@@ -153,10 +150,9 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
      * @param alias alias for the join target
      * @return current object
      */
-    @SuppressWarnings("unchecked")
     public <P> Q leftJoin(Path<? extends Collection<P>> target, Path<P> alias) {
         getMetadata().addJoin(JoinType.LEFTJOIN, createAlias(target, alias));
-        return (Q) this;
+        return queryMixin.getSelf();
     }
 
     /**
@@ -167,29 +163,28 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
      * @param alias alias for the joint target
      * @return current object
      */
-    @SuppressWarnings("unchecked")
     public <P> Q leftJoin(MapExpression<?,P> target, Path<P> alias) {
         getMetadata().addJoin(JoinType.LEFTJOIN, createAlias(target, alias));
-        return (Q) this;
+        return queryMixin.getSelf();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public CloseableIterator<T> iterate() {
+        @SuppressWarnings("unchecked") // This is the built type
         Expression<T> projection = (Expression<T>) queryMixin.getMetadata().getProjection();
         return new IteratorAdapter<T>(queryEngine.list(getMetadata(), iterables, projection).iterator());
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public List<T> fetch() {
+        @SuppressWarnings("unchecked") // This is the built type
         Expression<T> projection = (Expression<T>) queryMixin.getMetadata().getProjection();
         return queryEngine.list(getMetadata(), iterables, projection);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public QueryResults<T> fetchResults() {
+        @SuppressWarnings("unchecked") // This is the built type
         Expression<T> projection = (Expression<T>) queryMixin.getMetadata().getProjection();
         long count = queryEngine.count(getMetadata(), iterables);
         if (count > 0L) {

--- a/querydsl-collections/src/main/java/com/querydsl/collections/CollQuery.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/CollQuery.java
@@ -81,17 +81,19 @@ public class CollQuery<T> extends AbstractCollQuery<T, CollQuery<T>> implements 
         return new CollQuery<T>(queryMixin.getMetadata().clone(), getQueryEngine());
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <E> CollQuery<E> select(Expression<E> expr) {
         queryMixin.setProjection(expr);
-        return (CollQuery<E>) this;
+        @SuppressWarnings("unchecked") // This is the new projection's type
+        CollQuery<E> newType = (CollQuery<E>) queryMixin.getSelf();
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public CollQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (CollQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new projection's type
+        CollQuery<Tuple> newType = (CollQuery<Tuple>) queryMixin.getSelf();
+        return newType;
     }
 }

--- a/querydsl-collections/src/main/java/com/querydsl/collections/DefaultEvaluatorFactory.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/DefaultEvaluatorFactory.java
@@ -128,7 +128,6 @@ public class DefaultEvaluatorFactory {
      * @param filter filter of the query
      * @return evaluator
      */
-    @SuppressWarnings("unchecked")
     public <T> Evaluator<List<T>> createEvaluator(QueryMetadata metadata,
             Expression<? extends T> source, Predicate filter) {
         String typeName = ClassUtils.getName(source.getType());
@@ -154,7 +153,7 @@ public class DefaultEvaluatorFactory {
                 sourceListType,
                 new String[]{source + "_"},
                 new Type[]{sourceListType},
-                new Class[]{Iterable.class},
+                new Class<?>[]{Iterable.class},
                 constants);
     }
 
@@ -166,7 +165,6 @@ public class DefaultEvaluatorFactory {
      * @param filter where condition
      * @return evaluator
      */
-    @SuppressWarnings("unchecked")
     public Evaluator<List<Object[]>> createEvaluator(QueryMetadata metadata,
             List<JoinExpression> joins, @Nullable Predicate filter) {
         List<String> sourceNames = new ArrayList<String>();
@@ -266,7 +264,7 @@ public class DefaultEvaluatorFactory {
                 projectionType,
                 sourceNames.toArray(new String[sourceNames.size()]),
                 sourceTypes.toArray(new Type[sourceTypes.size()]),
-                sourceClasses.toArray(new Class[sourceClasses.size()]),
+                sourceClasses.toArray(new Class<?>[sourceClasses.size()]),
                 constants);
     }
 

--- a/querydsl-collections/src/test/java/com/querydsl/collections/AbstractQueryTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/AbstractQueryTest.java
@@ -90,18 +90,20 @@ public abstract class AbstractQueryTest {
             return rv;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public <U> TestQuery<U> select(Expression<U> expr) {
             queryMixin.setProjection(expr);
-            return (TestQuery<U>) this;
+            @SuppressWarnings("unchecked") // This is the new projection's type
+            TestQuery<U> newType = (TestQuery<U>) queryMixin.getSelf();
+            return newType;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public TestQuery<Tuple> select(Expression<?>... exprs) {
             queryMixin.setProjection(exprs);
-            return (TestQuery<Tuple>) this;
+            @SuppressWarnings("unchecked") // This is the new projection's type
+            TestQuery<Tuple> newType = (TestQuery<Tuple>) queryMixin.getSelf();
+            return newType;
         }
     }
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/AggregationTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/AggregationTest.java
@@ -11,7 +11,7 @@ public class AggregationTest extends AbstractQueryTest {
 
     private static final QCat cat = QCat.cat;
 
-    private CollQuery query;
+    private CollQuery<?> query;
 
     @Override
     @Before
@@ -29,27 +29,27 @@ public class AggregationTest extends AbstractQueryTest {
 
     @Test
     public void Avg() {
-        assertEquals(3.5, query.select(cat.weight.avg()).fetchOne());
+        assertEquals(3.5, query.select(cat.weight.avg()).fetchOne(), 0.0);
     }
 
     @Test
     public void Count() {
-        assertEquals(4L, query.select(cat.count()).fetchOne());
+        assertEquals(Long.valueOf(4L), query.select(cat.count()).fetchOne());
     }
 
     @Test
     public void CountDistinct() {
-        assertEquals(4L, query.select(cat.countDistinct()).fetchOne());
+        assertEquals(Long.valueOf(4L), query.select(cat.countDistinct()).fetchOne());
     }
 
     @Test
     public void Max() {
-        assertEquals(5, query.select(cat.weight.max()).fetchOne());
+        assertEquals(Integer.valueOf(5), query.select(cat.weight.max()).fetchOne());
     }
 
     @Test
     public void Min() {
-        assertEquals(2, query.select(cat.weight.min()).fetchOne());
+        assertEquals(Integer.valueOf(2), query.select(cat.weight.min()).fetchOne());
     }
 
     @SuppressWarnings("unchecked")
@@ -60,7 +60,7 @@ public class AggregationTest extends AbstractQueryTest {
 
     @Test
     public void Sum() {
-        assertEquals(14, query.select(cat.weight.sum()).fetchOne());
+        assertEquals(Integer.valueOf(14), query.select(cat.weight.sum()).fetchOne());
     }
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/alias/AliasFactory.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/alias/AliasFactory.java
@@ -128,10 +128,10 @@ class AliasFactory {
         Enhancer enhancer = new Enhancer();
         enhancer.setClassLoader(AliasFactory.class.getClassLoader());
         if (cl.isInterface()) {
-            enhancer.setInterfaces(new Class[] {cl, ManagedObject.class});
+            enhancer.setInterfaces(new Class<?>[] {cl, ManagedObject.class});
         } else {
             enhancer.setSuperclass(cl);
-            enhancer.setInterfaces(new Class[] {ManagedObject.class});
+            enhancer.setInterfaces(new Class<?>[] {ManagedObject.class});
         }
         // creates one handler per proxy
         MethodInterceptor handler = new PropertyAccessInvocationHandler(path, this, pathFactory, typeSystem);

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
@@ -128,10 +128,11 @@ public class GroupByBuilder<K> {
         };
     }
 
-    @SuppressWarnings("unchecked")
     private <V> Expression<V> getLookup(Expression<V> expression) {
         if (expression instanceof GroupExpression) {
-            return ((GroupExpression) expression).getExpression();
+            @SuppressWarnings("unchecked") // This is the underlying type
+            GroupExpression<V, ?> groupExpression = (GroupExpression<V, ?>) expression;
+            return groupExpression.getExpression();
         } else {
             return expression;
         }
@@ -177,10 +178,9 @@ public class GroupByBuilder<K> {
      * @return new result transformer
      */
     public <V> ResultTransformer<CloseableIterator<V>> iterate(FactoryExpression<V> expression) {
-        final FactoryExpression<?> transformation = FactoryExpressionUtils.wrap(expression);
+        final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
         List<Expression<?>> args = transformation.getArgs();
         return new GroupByIterate<K, V>(key, args.toArray(new Expression<?>[args.size()])) {
-            @SuppressWarnings("unchecked")
             @Override
             protected V transform(Group group) {
                 // XXX Isn't group.toArray() suitable here?
@@ -188,7 +188,7 @@ public class GroupByBuilder<K> {
                 for (int i = 1; i < groupExpressions.size(); i++) {
                     args.add(group.getGroup(groupExpressions.get(i)));
                 }
-                return (V) transformation.newInstance(args.toArray());
+                return transformation.newInstance(args.toArray());
             }
         };
     }
@@ -200,10 +200,9 @@ public class GroupByBuilder<K> {
      * @return new result transformer
      */
     public <V> ResultTransformer<List<V>> list(FactoryExpression<V> expression) {
-        final FactoryExpression<?> transformation = FactoryExpressionUtils.wrap(expression);
+        final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
         List<Expression<?>> args = transformation.getArgs();
         return new GroupByList<K, V>(key, args.toArray(new Expression<?>[args.size()])) {
-            @SuppressWarnings("unchecked")
             @Override
             protected V transform(Group group) {
                 // XXX Isn't group.toArray() suitable here?
@@ -211,7 +210,7 @@ public class GroupByBuilder<K> {
                 for (int i = 1; i < groupExpressions.size(); i++) {
                     args.add(group.getGroup(groupExpressions.get(i)));
                 }
-                return (V) transformation.newInstance(args.toArray());
+                return transformation.newInstance(args.toArray());
             }
         };
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByIterate.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByIterate.java
@@ -62,7 +62,6 @@ public class GroupByIterate<K, V> extends AbstractGroupByTransformer<K, Closeabl
                 return group != null || iter.hasNext();
             }
 
-            @SuppressWarnings("unchecked")
             @Override
             public V next() {
                 if (!iter.hasNext()) {
@@ -76,17 +75,18 @@ public class GroupByIterate<K, V> extends AbstractGroupByTransformer<K, Closeabl
                 }
 
                 while (iter.hasNext()) {
-                    Object[] row = iter.next().toArray();
+                    @SuppressWarnings("unchecked") //This type is mandated by the key type
+                    K[] row = (K[]) iter.next().toArray();
                     if (group == null) {
                         group = new GroupImpl(groupExpressions, maps);
-                        groupId = (K) row[0];
+                        groupId = row[0];
                         group.add(row);
                     } else if (Objects.equal(groupId, row[0])) {
                         group.add(row);
                     } else {
                         Group current = group;
                         group = new GroupImpl(groupExpressions, maps);
-                        groupId = (K) row[0];
+                        groupId = row[0];
                         group.add(row);
                         return transform(current);
                     }

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByList.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByList.java
@@ -39,7 +39,6 @@ public class GroupByList<K, V> extends AbstractGroupByTransformer<K, List<V>> {
         super(key, expressions);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public List<V> transform(FetchableQuery<?,?> query) {
         // create groups
@@ -57,14 +56,15 @@ public class GroupByList<K, V> extends AbstractGroupByTransformer<K, List<V>> {
         GroupImpl group = null;
         K groupId = null;
         while (iter.hasNext()) {
-            Object[] row = iter.next().toArray();
+            @SuppressWarnings("unchecked") //This type is mandated by the key type
+            K[] row = (K[]) iter.next().toArray();
             if (group == null) {
                 group = new GroupImpl(groupExpressions, maps);
-                groupId = (K) row[0];
+                groupId = row[0];
             } else if (!Objects.equal(groupId, row[0])) {
                 list.add(transform(group));
                 group = new GroupImpl(groupExpressions, maps);
-                groupId = (K) row[0];
+                groupId = row[0];
             }
             group.add(row);
         }

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByMap.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByMap.java
@@ -38,7 +38,6 @@ public class GroupByMap<K,V> extends AbstractGroupByTransformer<K, Map<K,V>> {
         super(key, expressions);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Map<K, V> transform(FetchableQuery<?,?> query) {
         Map<K, Group> groups = new LinkedHashMap<K, Group>();
@@ -55,8 +54,9 @@ public class GroupByMap<K,V> extends AbstractGroupByTransformer<K, Map<K,V>> {
         CloseableIterator<Tuple> iter = query.select(expr).iterate();
         try {
             while (iter.hasNext()) {
-                Object[] row = iter.next().toArray();
-                K groupId = (K) row[0];
+                @SuppressWarnings("unchecked") //This type is mandated by the key type
+                K[] row = (K[]) iter.next().toArray();
+                K groupId = row[0];
                 GroupImpl group = (GroupImpl) groups.get(groupId);
                 if (group == null) {
                     group = new GroupImpl(groupExpressions, maps);

--- a/querydsl-core/src/main/java/com/querydsl/core/group/QPair.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/QPair.java
@@ -34,7 +34,7 @@ import com.querydsl.core.types.Expression;
 
     @SuppressWarnings({"unchecked" })
     public QPair(Expression<K> key, Expression<V> value) {
-        super((Class) Pair.class, new Class[]{Object.class, Object.class}, key, value);
+        super((Class) Pair.class, new Class<?>[]{Object.class, Object.class}, key, value);
     }
 
     public boolean equals(Expression<?> keyExpr, Expression<?> valueExpr) {

--- a/querydsl-core/src/main/java/com/querydsl/core/support/NumberConversion.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/NumberConversion.java
@@ -50,7 +50,6 @@ public class NumberConversion<T> extends FactoryExpressionBase<T> {
         return exprs;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public T newInstance(Object... args) {
         if (args[0] != null) {

--- a/querydsl-core/src/main/java/com/querydsl/core/support/NumberConversions.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/NumberConversions.java
@@ -54,21 +54,18 @@ public class NumberConversions<T> extends FactoryExpressionBase<T> {
         return expr.getArgs();
     }
 
-    @SuppressWarnings("unchecked")
     private <E extends Enum<E>> Enum<E>[] getValues(Class<E> enumClass) {
+        @SuppressWarnings("unchecked") // Class<E> -> E[]
         Enum<E>[] values = (Enum<E>[]) this.values.get(enumClass);
         if (values == null) {
-            try {
-                values = (Enum<E>[]) enumClass.getMethod("values").invoke(null);
-                this.values.put(enumClass, values);
-            } catch (Exception e) {
-                throw new RuntimeException(e.getMessage(), e);
-            }
+            values = enumClass.getEnumConstants();
+            this.values.put(enumClass, values);
         }
         return values;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public T newInstance(Object... args) {
         for (int i = 0; i < args.length; i++) {
             Class<?> type = expr.getArgs().get(i).getType();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionUtils.java
@@ -81,15 +81,14 @@ public final class FactoryExpressionUtils {
 
     }
 
-    @SuppressWarnings("unchecked")
     public static FactoryExpression<?> wrap(List<? extends Expression<?>> projection) {
         boolean usesFactoryExpressions = false;
         for (Expression<?> e : projection) {
             usesFactoryExpressions |= e instanceof FactoryExpression;
         }
         if (usesFactoryExpressions) {
-            return wrap(new ArrayConstructorExpression(
-                    projection.toArray(new Expression[projection.size()])));
+            return wrap(new ArrayConstructorExpression<Object>(
+                    projection.toArray(new Expression<?>[projection.size()])));
         } else {
             return null;
         }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/TemplateFactory.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/TemplateFactory.java
@@ -89,7 +89,6 @@ public class TemplateFactory {
 
     private final Function<Object,Object> toStartsWithViaLikeLower =
             new Function<Object,Object>() {
-                @SuppressWarnings("unchecked")
                 @Override
                 public Object apply(Object arg) {
                     if (arg instanceof Constant<?>) {
@@ -119,7 +118,6 @@ public class TemplateFactory {
 
     private final Function<Object,Object> toEndsWithViaLikeLower =
             new Function<Object,Object>() {
-                @SuppressWarnings("unchecked")
                 @Override
                 public Object apply(Object arg) {
                     if (arg instanceof Constant<?>) {
@@ -135,7 +133,6 @@ public class TemplateFactory {
 
     private final Function<Object,Object> toContainsViaLike =
             new Function<Object,Object>() {
-                @SuppressWarnings("unchecked")
                 @Override
                 public Object apply(Object arg) {
                     if (arg instanceof Constant<?>) {
@@ -151,7 +148,6 @@ public class TemplateFactory {
 
     private final Function<Object,Object> toContainsViaLikeLower =
             new Function<Object,Object>() {
-                @SuppressWarnings("unchecked")
                 @Override
                 public Object apply(Object arg) {
                     if (arg instanceof Constant<?>) {

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -219,10 +219,10 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
      * @param right
      * @return this / right
      */
-    @SuppressWarnings("unchecked")
     public <N extends Number & Comparable<?>> NumberExpression<T> divide(Expression<N> right) {
-        Class<?> type = getDivisionType(getType(), right.getType());
-        return Expressions.numberOperation((Class<T>) type, Ops.DIV, mixin, right);
+        @SuppressWarnings("unchecked")
+        Class<T> type = (Class<T>) getDivisionType(getType(), right.getType());
+        return Expressions.numberOperation(type, Ops.DIV, mixin, right);
     }
 
     /**
@@ -233,10 +233,10 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
      * @param right
      * @return this / right
      */
-    @SuppressWarnings("unchecked")
     public <N extends Number & Comparable<?>> NumberExpression<T> divide(N right) {
-        Class<?> type = getDivisionType(getType(), right.getClass());
-        return Expressions.numberOperation((Class<T>) type, Ops.DIV, mixin, ConstantImpl.create(right));
+        @SuppressWarnings("unchecked")
+        Class<T> type = (Class< T>) getDivisionType(getType(), right.getClass());
+        return Expressions.numberOperation(type, Ops.DIV, mixin, ConstantImpl.create(right));
     }
 
     /**

--- a/querydsl-core/src/test/java/com/querydsl/core/TemplatesTestBase.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/TemplatesTestBase.java
@@ -39,12 +39,10 @@ public class TemplatesTestBase {
 
     private final String modulePrefix = getClass().getPackage().getName();
 
-    @SuppressWarnings("unchecked")
     @Test
     public void Default_Instance() {
         Set<Class<? extends Templates>> templates = querydsl.getSubTypesOf(Templates.class);
-        Set<Class<? extends Templates>> moduleSpecific = getAll(templates, topLevelClass,
-                withPattern("class " + modulePrefix + ".*"));
+        Set<Class<? extends Templates>> moduleSpecific = getAll(templates, MODULE_SPECIFIC);
 
         for (Class<? extends Templates> template : moduleSpecific) {
             try {
@@ -55,6 +53,11 @@ public class TemplatesTestBase {
             }
         }
     }
+
+    @SuppressWarnings("unchecked")
+    private final Predicate<Class<? extends Templates>>[] MODULE_SPECIFIC =
+            (Predicate<Class<? extends Templates>>[]) new Predicate<?>[] {topLevelClass, withPattern("class " + modulePrefix + ".*") };
+
     private static final Predicate<Class<?>> topLevelClass = new Predicate<Class<?>>() {
 
         @Override

--- a/querydsl-core/src/test/java/com/querydsl/core/types/ConstructorExpressionTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/ConstructorExpressionTest.java
@@ -34,7 +34,7 @@ public class ConstructorExpressionTest {
         Expression<Long> longVal = ConstantImpl.create(1L);
         Expression<String> stringVal = ConstantImpl.create("");
         ProjectionExample instance = new ConstructorExpression<ProjectionExample>(ProjectionExample.class,
-                new Class[]{long.class, String.class}, longVal, stringVal).newInstance(0L, "");
+                new Class<?>[]{long.class, String.class}, longVal, stringVal).newInstance(0L, "");
         assertNotNull(instance);
         assertEquals((Long) 0L, instance.id);
         assertTrue(instance.text.isEmpty());

--- a/querydsl-core/src/test/java/com/querydsl/core/types/SerializationTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/SerializationTest.java
@@ -30,7 +30,7 @@ public class SerializationTest {
         args.put(Object.class, "obj");
         args.put(BeanPath.class, new EntityPathBase<Object>(Object.class, "obj"));
         args.put(Class.class, Integer.class);
-        args.put(Class[].class, new Class[]{Object.class, Object.class});
+        args.put(Class[].class, new Class<?>[]{Object.class, Object.class});
         args.put(java.util.Date.class, new java.util.Date(0));
         args.put(java.sql.Date.class, new java.sql.Date(0));
         args.put(java.sql.Time.class, new java.sql.Time(0));

--- a/querydsl-core/src/test/java/com/querydsl/core/types/StringTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/StringTest.java
@@ -78,7 +78,7 @@ public class StringTest {
         assertEquals("lower(alias.name)", $(alias.getName()).lower().toString());
 
         // ConstructorExpression
-        ConstructorExpression<SomeType> someType = new ConstructorExpression<SomeType>(SomeType.class, new Class[]{SomeType.class}, $(alias));
+        ConstructorExpression<SomeType> someType = new ConstructorExpression<SomeType>(SomeType.class, new Class<?>[]{SomeType.class}, $(alias));
         assertEquals("new SomeType(alias)", someType.toString());
 
         // ArrayConstructorExpression

--- a/querydsl-core/src/test/java/com/querydsl/core/util/MultiIteratorTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/util/MultiIteratorTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import com.mysema.commons.lang.IteratorAdapter;
 
-
+@SuppressWarnings("unchecked")
 public class MultiIteratorTest {
 
     private MultiIterator it;
@@ -33,7 +33,6 @@ public class MultiIteratorTest {
 
     private List<Integer> list3, list4;
 
-    @SuppressWarnings("unchecked")
     @Test
     public void EmptyList() {
         it = new MultiIterator(Arrays.asList(list1, list2));
@@ -43,14 +42,12 @@ public class MultiIteratorTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void OneLevel() {
         it = new MultiIterator(Arrays.asList(list1));
         assertIteratorEquals(Arrays.asList(row(1), row(2)).iterator(), it);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void TwoLevels() {
         list2 = Arrays.asList(10, 20, 30);
@@ -60,7 +57,6 @@ public class MultiIteratorTest {
         assertIteratorEquals(base, it);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ThreeLevels() {
         list1 = Arrays.asList(1, 2);
@@ -78,7 +74,6 @@ public class MultiIteratorTest {
         assertIteratorEquals(list.iterator(), it);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void FourLevels() {
         list1 = Arrays.asList(1, 2);
@@ -100,7 +95,6 @@ public class MultiIteratorTest {
         assertIteratorEquals(list.iterator(), it);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void FourLevels2() {
         list1 = new ArrayList<Integer>(100);
@@ -114,7 +108,6 @@ public class MultiIteratorTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void test() {
         List<Integer> list1 = asList(1, 2, 3, 4);

--- a/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/TweetRepository.java
+++ b/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/TweetRepository.java
@@ -43,7 +43,6 @@ public class TweetRepository extends AbstractRepository {
         return selectFrom(tweet).where(tweet.id.eq(id)).fetchOne();
     }
 
-    @SuppressWarnings("unchecked")
     @Transactional
     public List<Tweet> findOfUser(String username) {
         return select(tweet).from(user)
@@ -51,7 +50,6 @@ public class TweetRepository extends AbstractRepository {
                 .fetch();
     }
 
-    @SuppressWarnings("unchecked")
     @Transactional
     public List<Tweet> findWithMentioned(Long userId) {
         return selectFrom(tweet)
@@ -60,7 +58,6 @@ public class TweetRepository extends AbstractRepository {
                 .fetch();
     }
 
-    @SuppressWarnings("unchecked")
     @Transactional
     public List<Tweet> findOfArea(double[] pointA, double[] pointB) {
         return selectFrom(tweet)
@@ -70,7 +67,6 @@ public class TweetRepository extends AbstractRepository {
                 .fetch();
     }
 
-    @SuppressWarnings("unchecked")
     @Transactional
     public List<Tweet> findAll(Predicate expr) {
         return selectFrom(tweet).where(expr).fetch();

--- a/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/UserRepository.java
+++ b/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/UserRepository.java
@@ -34,13 +34,11 @@ public class UserRepository extends AbstractRepository {
                 .fetch();
     }
 
-    @SuppressWarnings("unchecked")
     @Transactional
     public List<User> findAll(Predicate expr) {
         return selectFrom(user).where(expr).fetch();
     }
 
-    @SuppressWarnings("unchecked")
     @Transactional
     public List<User> all() {
         return selectFrom(user).fetch();

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQuery.java
@@ -96,18 +96,20 @@ public class JDOQuery<T> extends AbstractJDOQuery<T, JDOQuery<T>> {
         return query;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> JDOQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (JDOQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new projection type
+        JDOQuery<U> newType = (JDOQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public JDOQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (JDOQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new projection type
+        JDOQuery<Tuple> newType = (JDOQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/JDOSQLQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/JDOSQLQuery.java
@@ -63,17 +63,19 @@ public final class JDOSQLQuery<T> extends AbstractSQLQuery<T, JDOSQLQuery<T>> {
         return new SQLSerializer(configuration);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> JDOSQLQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (JDOSQLQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JDOSQLQuery<U> newType = (JDOSQLQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public JDOSQLQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (JDOSQLQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JDOSQLQuery<Tuple> newType = (JDOSQLQuery<Tuple>) this;
+        return newType;
     }
 }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPASubQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPASubQuery.java
@@ -45,18 +45,20 @@ class JPASubQuery<T> extends JPAQueryBase<T, JPASubQuery<T>> {
         return new JPASubQuery<T>(getMetadata().clone());
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> JPASubQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (JPASubQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JPASubQuery<U> newType = (JPASubQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public JPASubQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (JPASubQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JPASubQuery<Tuple> newType = (JPASubQuery<Tuple>) this;
+        return newType;
     }
 
     @Override

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateQuery.java
@@ -107,18 +107,20 @@ public class HibernateQuery<T> extends AbstractHibernateQuery<T, HibernateQuery<
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> HibernateQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (HibernateQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        HibernateQuery<U> newType = (HibernateQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public HibernateQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (HibernateQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        HibernateQuery<Tuple> newType = (HibernateQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateUtil.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateUtil.java
@@ -36,8 +36,7 @@ import com.querydsl.core.types.dsl.Param;
  */
 public final class HibernateUtil {
 
-    @SuppressWarnings("unchecked")
-    private static final Set<Class<?>> BUILT_IN = ImmutableSet.of(Boolean.class, Byte.class,
+    private static final Set<Class<?>> BUILT_IN = ImmutableSet.<Class<?>>of(Boolean.class, Byte.class,
             Character.class, Double.class, Float.class, Integer.class, Long.class, Short.class,
             String.class, BigDecimal.class, byte[].class, Byte[].class, java.util.Date.class,
             java.util.Calendar.class, java.sql.Date.class, java.sql.Time.class, java.sql.Timestamp.class,

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/HibernateSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/HibernateSQLQuery.java
@@ -65,18 +65,20 @@ public class HibernateSQLQuery<T> extends AbstractHibernateSQLQuery<T, Hibernate
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> HibernateSQLQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (HibernateSQLQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        HibernateSQLQuery<U> newType = (HibernateSQLQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public HibernateSQLQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (HibernateSQLQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        HibernateSQLQuery<Tuple> newType = (HibernateSQLQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAQuery.java
@@ -91,17 +91,19 @@ public class JPAQuery<T> extends AbstractJPAQuery<T, JPAQuery<T>> {
         return clone(entityManager, JPAProvider.getTemplates(entityManager));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> JPAQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (JPAQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JPAQuery<U> newType = (JPAQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public JPAQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (JPAQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JPAQuery<Tuple> newType = (JPAQuery<Tuple>) this;
+        return newType;
     }
 }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/JPASQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/JPASQLQuery.java
@@ -64,18 +64,20 @@ public class JPASQLQuery<T> extends AbstractJPASQLQuery<T, JPASQLQuery<T>> {
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> JPASQLQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (JPASQLQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JPASQLQuery<U> newType = (JPASQLQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public JPASQLQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (JPASQLQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        JPASQLQuery<Tuple> newType = (JPASQLQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
@@ -54,7 +54,7 @@ import antlr.TokenStreamException;
  */
 public abstract class AbstractJPATest {
 
-    private static final Expression<?>[] NO_EXPRESSIONS = new Expression[0];
+    private static final Expression<?>[] NO_EXPRESSIONS = new Expression<?>[0];
 
     private static final QCompany company = QCompany.company;
 
@@ -1603,9 +1603,9 @@ public abstract class AbstractJPATest {
             }
         };
 
-        final EntityPath<?>[] sources = new EntityPath[]{cat, otherCat};
-        final Predicate[] conditions = new Predicate[]{condition};
-        final Expression<?>[] projection = new Expression[]{cat.name, otherCat.name};
+        final EntityPath<?>[] sources = {cat, otherCat};
+        final Predicate[] conditions = {condition};
+        final Expression<?>[] projection = {cat.name, otherCat.name};
 
         QueryExecution standardTest = new QueryExecution(
                 projections,
@@ -1613,13 +1613,13 @@ public abstract class AbstractJPATest {
                 new MatchingFiltersFactory(Module.JPA, getTarget())) {
 
             @Override
-            protected Fetchable createQuery() {
+            protected Fetchable<?> createQuery() {
                 // NOTE : EclipseLink needs extra conditions cond1 and code2
                 return testQuery().from(sources).where(conditions);
             }
 
             @Override
-            protected Fetchable createQuery(Predicate filter) {
+            protected Fetchable<?> createQuery(Predicate filter) {
                 // NOTE : EclipseLink needs extra conditions cond1 and code2
                 return testQuery().from(sources).where(condition, filter).select(projection);
             }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/ConstructorsTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/ConstructorsTest.java
@@ -33,7 +33,7 @@ public class ConstructorsTest extends AbstractQueryTest {
         private static final long serialVersionUID = 2664671413344744578L;
 
         public QBookmarkDTO(Expression<java.lang.String> address) {
-            super(BookmarkDTO.class, new Class[] {String.class}, address);
+            super(BookmarkDTO.class, new Class<?>[] {String.class}, address);
         }
     }
 
@@ -43,7 +43,7 @@ public class ConstructorsTest extends AbstractQueryTest {
         ConstructorExpression<com.querydsl.jpa.domain.Cat> c =
                 Projections.constructor(
                         com.querydsl.jpa.domain.Cat.class,
-                        new Class[]{String.class},
+                        new Class<?>[]{String.class},
                         cat.name);
         assertToString("new " + com.querydsl.jpa.domain.Cat.class.getName() + "(cat.name)", c);
         assertToString("new " + getClass().getName() + "$BookmarkDTO(cat.name)",new QBookmarkDTO(cat.name));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAProviderTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAProviderTest.java
@@ -53,7 +53,7 @@ public class JPAProviderTest {
         };
         EntityManager proxy = (EntityManager) Proxy.newProxyInstance(
                 Thread.currentThread().getContextClassLoader(),
-                new Class[]{EntityManager.class},
+                new Class<?>[]{EntityManager.class},
                 handler);
         assertEquals(HQLTemplates.DEFAULT, JPAProvider.getTemplates(proxy));
     }
@@ -79,7 +79,7 @@ public class JPAProviderTest {
         };
         EntityManager proxy = (EntityManager) Proxy.newProxyInstance(
                 Thread.currentThread().getContextClassLoader(),
-                new Class[]{EntityManager.class},
+                new Class<?>[]{EntityManager.class},
                 handler);
         assertEquals(EclipseLinkTemplates.DEFAULT, JPAProvider.getTemplates(proxy));
     }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/QProjection.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/QProjection.java
@@ -12,7 +12,7 @@ public class QProjection extends ConstructorExpression<Projection> {
 
     public QProjection(StringExpression str, QCat cat) {
         super(Projection.class,
-                new Class[]{String.class, Cat.class}, new Expression[]{str, cat});
+                new Class<?>[]{String.class, Cat.class}, new Expression[]{str, cat});
     }
 
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
@@ -96,18 +96,20 @@ class QueryHelper<T> extends JPAQueryBase<T, QueryHelper<T>> {
     }
 
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> QueryHelper<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (QueryHelper<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        QueryHelper<U> newType = (QueryHelper<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public QueryHelper<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (QueryHelper<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        QueryHelper<Tuple> newType = (QueryHelper<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/Domain.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/Domain.java
@@ -25,8 +25,7 @@ public final class Domain {
 
     private Domain() { }
 
-    @SuppressWarnings("unchecked")
-    public static final List<Class<?>> classes = Arrays.asList(
+    public static final List<Class<?>> classes = Arrays.<Class<?>>asList(
             Account.class,
             Animal.class,
             Author.class,

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain2/Domain2.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain2/Domain2.java
@@ -20,8 +20,7 @@ public final class Domain2 {
 
     private Domain2() { }
 
-    @SuppressWarnings("unchecked")
-    public static final List<Class<?>> classes = Arrays.asList(
+    public static final List<Class<?>> classes = Arrays.<Class<?>>asList(
             Category.class,
             CategoryProp.class,
             Contact.class,

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLQuery.java
@@ -105,17 +105,19 @@ public class SQLQuery<T> extends AbstractSQLQuery<T, SQLQuery<T>> {
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> SQLQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (SQLQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        SQLQuery<U> newType = (SQLQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public SQLQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (SQLQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        SQLQuery<Tuple> newType = (SQLQuery<Tuple>) this;
+        return newType;
     }
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/mssql/SQLServerQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/mssql/SQLServerQuery.java
@@ -75,18 +75,20 @@ public class SQLServerQuery<T> extends AbstractSQLQuery<T, SQLServerQuery<T>> {
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> SQLServerQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (SQLServerQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        SQLServerQuery<U> newType = (SQLServerQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public SQLServerQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (SQLServerQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        SQLServerQuery<Tuple> newType = (SQLServerQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/mysql/MySQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/mysql/MySQLQuery.java
@@ -249,18 +249,20 @@ public class MySQLQuery<T> extends AbstractSQLQuery<T, MySQLQuery<T>> {
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> MySQLQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (MySQLQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        MySQLQuery<U> newType = (MySQLQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public MySQLQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (MySQLQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        MySQLQuery<Tuple> newType = (MySQLQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/oracle/OracleQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/oracle/OracleQuery.java
@@ -130,18 +130,20 @@ public class OracleQuery<T> extends AbstractSQLQuery<T, OracleQuery<T>> {
 
     // TODO : sys connect path
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> OracleQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (OracleQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        OracleQuery<U> newType = (OracleQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public OracleQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (OracleQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        OracleQuery<Tuple> newType = (OracleQuery<Tuple>) this;
+        return newType;
     }
 }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/PostgreSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/PostgreSQLQuery.java
@@ -109,17 +109,19 @@ public class PostgreSQLQuery<T> extends AbstractSQLQuery<T, PostgreSQLQuery<T>> 
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> PostgreSQLQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (PostgreSQLQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        PostgreSQLQuery<U> newType = (PostgreSQLQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public PostgreSQLQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (PostgreSQLQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        PostgreSQLQuery<Tuple> newType = (PostgreSQLQuery<Tuple>) this;
+        return newType;
     }
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/teradata/TeradataQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/teradata/TeradataQuery.java
@@ -67,18 +67,20 @@ public class TeradataQuery<T> extends AbstractSQLQuery<T, TeradataQuery<T>> {
         return q;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> TeradataQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (TeradataQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        TeradataQuery<U> newType = (TeradataQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public TeradataQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (TeradataQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        TeradataQuery<Tuple> newType = (TeradataQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/ExtendedSQLQuery.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/ExtendedSQLQuery.java
@@ -74,18 +74,20 @@ public class ExtendedSQLQuery<T> extends AbstractSQLQuery<T, ExtendedSQLQuery<T>
         return query;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <U> ExtendedSQLQuery<U> select(Expression<U> expr) {
         queryMixin.setProjection(expr);
-        return (ExtendedSQLQuery<U>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        ExtendedSQLQuery<U> newType = (ExtendedSQLQuery<U>) this;
+        return newType;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public ExtendedSQLQuery<Tuple> select(Expression<?>... exprs) {
         queryMixin.setProjection(exprs);
-        return (ExtendedSQLQuery<Tuple>) this;
+        @SuppressWarnings("unchecked") // This is the new type
+        ExtendedSQLQuery<Tuple> newType = (ExtendedSQLQuery<Tuple>) this;
+        return newType;
     }
 
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/domain/QIdName.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/domain/QIdName.java
@@ -21,7 +21,7 @@ public class QIdName extends ConstructorExpression<IdName> {
     private static final long serialVersionUID = 5770565824515003611L;
 
     public QIdName(Expression<java.lang.Integer> id, Expression<java.lang.String> name) {
-        super(IdName.class, new Class[]{int.class, String.class}, id, name);
+        super(IdName.class, new Class<?>[]{int.class, String.class}, id, name);
     }
 
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/types/TypeTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/types/TypeTest.java
@@ -75,9 +75,9 @@ public class TypeTest implements InvocationHandler {
         }
     }
 
-    private final ResultSet resultSet = (ResultSet) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{ResultSet.class}, this);
+    private final ResultSet resultSet = (ResultSet) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{ResultSet.class}, this);
 
-    private final PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{PreparedStatement.class}, this);
+    private final PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{PreparedStatement.class}, this);
 
     @SuppressWarnings("unchecked")
     @Test


### PR DESCRIPTION
SuppressWarnings moved to smaller scope
Generic array creations avoided
A lot of rawtypes warnings removed
Suppress more warnings in generated code - `all` is an Eclipse extension