### PR TITLE
Use the versions plugin to bump all versions

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -2,6 +2,8 @@
 rm -rf target/dist
 mkdir -p target/dist
 
+mvn versions:set -DgenerateBackupPoms=false
+
 echo "Creating javadocs"
 mvn javadoc:aggregate
 

--- a/pom.xml
+++ b/pom.xml
@@ -353,11 +353,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.mysema.maven</groupId>
-        <artifactId>maven-version-plugin</artifactId>
-        <version>0.1.0</version>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.4</version>


### PR DESCRIPTION
The person making the release will now be prompted for the new
version.

Example: Enter the new version to set 4.0.5.BUILD-SNAPSHOT: : 4.0.6

I added this because I noticed the examples weren't updated in the last release.