### PR TITLE
Update unsafe class names test

### DIFF
--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/ClassPathUtils.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/ClassPathUtils.java
@@ -73,7 +73,7 @@ public final class ClassPathUtils {
      */
     public static Class<?> safeClassForName(ClassLoader classLoader, String className) {
         try {
-            if (className.startsWith("com.sun") || className.startsWith("com.apple")) {
+            if (className.startsWith("com.sun.") || className.startsWith("com.apple.")) {
                 return null;
             } else {
                 return Class.forName(className, true, classLoader);

--- a/querydsl-codegen/src/test/java/com/applejuice/ShouldBeLoaded.java
+++ b/querydsl-codegen/src/test/java/com/applejuice/ShouldBeLoaded.java
@@ -1,0 +1,4 @@
+package com.applejuice;
+
+public class ShouldBeLoaded {
+}

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/ClassPathUtilsTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/ClassPathUtilsTest.java
@@ -13,8 +13,7 @@
  */
 package com.querydsl.codegen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Set;
@@ -22,7 +21,6 @@ import java.util.Set;
 import org.junit.Test;
 
 import com.SomeClass;
-
 
 public class ClassPathUtilsTest {
 
@@ -40,4 +38,16 @@ public class ClassPathUtilsTest {
         assertFalse(classes.isEmpty());
         assertEquals("XXX", SomeOtherClass2.property);
     }
+
+    @Test
+    public void SafeClassForName() {
+        assertNull(safeForName("com.sun.nio.file.ExtendedOpenOption"));
+        assertNotNull(safeForName("com.suntanning.ShouldBeLoaded"));
+        assertNotNull(safeForName("com.applejuice.ShouldBeLoaded"));
+    }
+
+    private Class<?> safeForName(String className) {
+        return ClassPathUtils.safeClassForName(ClassPathUtilsTest.class.getClassLoader(), className);
+    }
+
 }

--- a/querydsl-codegen/src/test/java/com/suntanning/ShouldBeLoaded.java
+++ b/querydsl-codegen/src/test/java/com/suntanning/ShouldBeLoaded.java
@@ -1,0 +1,4 @@
+package com.suntanning;
+
+public class ShouldBeLoaded {
+}


### PR DESCRIPTION
This allows classes to be loaded that begin with com.sun or com.apple
which are not in those packages.