### PR TITLE
Add QHierarchyTest_A2 to the expected 'failures'

### DIFF
--- a/querydsl-apt/src/test/java/com/querydsl/apt/GenericExporterTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/GenericExporterTest.java
@@ -78,6 +78,7 @@ public class GenericExporterTest extends AbstractProcessorTest {
         List<String> expected = new ArrayList<String>();
         // GenericExporter doesn't include field/method selection
         expected.add("QFileAttachment.java");
+        expected.add("QHierarchyTest_A2.java");
         expected.add("QJodaTest_BaseEntity.java");
         expected.add("QEnum3Test_Entity1.java");
         expected.add("QCustomCollection_MyCustomCollection.java");


### PR DESCRIPTION
Since the field and property accessor types are different,
the effective type isn't consistent so the build might fail