### PR TITLE
Added isNull() and isNotNull() to ExtendedSubQuery

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/support/ExtendedSubQuery.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/ExtendedSubQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.core.support;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.BooleanOperation;
 
 /**
  * {@code ExtendedSubQuery} extends the {@link SubQueryExpression} interface to provide fluent
@@ -150,5 +151,19 @@ public interface ExtendedSubQuery<T> extends SubQueryExpression<T> {
      * @return this &gt;= right
      */
     BooleanExpression goe(T constant);
+
+    /**
+     * Create a {@code this is null} expression
+     *
+     * @return this is null
+     */
+     BooleanOperation isNull();
+
+    /**
+     * Create a {@code this is not null} expression
+     *
+     * @return this is not null
+     */
+     BooleanOperation isNotNull();
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/support/FetchableSubQueryBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/FetchableSubQueryBase.java
@@ -16,6 +16,7 @@ package com.querydsl.core.support;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.BooleanOperation;
 import com.querydsl.core.types.dsl.Expressions;
 
 /**
@@ -119,6 +120,16 @@ public abstract class FetchableSubQueryBase<T, Q extends FetchableSubQueryBase<T
     @Override
     public BooleanExpression goe(T constant) {
         return goe(Expressions.constant(constant));
+    }
+
+    @Override
+    public BooleanOperation isNull() {
+        return Expressions.booleanOperation(Ops.IS_NULL, mixin);
+    }
+
+    @Override
+    public BooleanOperation isNotNull() {
+        return Expressions.booleanOperation(Ops.IS_NOT_NULL, mixin);
     }
 
     @Override


### PR DESCRIPTION
#1561 Perhaps I'm missing something but having looked at usages of a few of its public methods, I could not see test coverage for `FetchableSubQueryBase`. If someone can point me in the direction for test coverage for this class, I will add coverage for these new methods.