### PR TITLE
Move adding objects to MDC inside the `isDebugEnabled` block

### DIFF
--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -162,10 +162,10 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        String normalizedQuery = queryString.replace('\n', ' ');
-        MDC.put(MDC_QUERY, normalizedQuery);
-        MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
         if (logger.isDebugEnabled()) {
+            String normalizedQuery = queryString.replace('\n', ' ');
+            MDC.put(MDC_QUERY, normalizedQuery);
+            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
             logger.debug(normalizedQuery);
         }
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
@@ -198,10 +198,10 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        String normalizedQuery = queryString.replace('\n', ' ');
-        MDC.put(MDC_QUERY, normalizedQuery);
-        MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
         if (logger.isDebugEnabled()) {
+            String normalizedQuery = queryString.replace('\n', ' ');
+            MDC.put(MDC_QUERY, normalizedQuery);
+            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
             logger.debug(normalizedQuery);
         }
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
@@ -192,10 +192,10 @@ public abstract class AbstractHibernateSQLQuery<T, Q extends AbstractHibernateSQ
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        String normalizedQuery = queryString.replace('\n', ' ');
-        MDC.put(MDC_QUERY, normalizedQuery);
-        MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
         if (logger.isDebugEnabled()) {
+            String normalizedQuery = queryString.replace('\n', ' ');
+            MDC.put(MDC_QUERY, normalizedQuery);
+            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
             logger.debug(normalizedQuery);
         }
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -226,10 +226,10 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        String normalizedQuery = queryString.replace('\n', ' ');
-        MDC.put(MDC_QUERY, normalizedQuery);
-        MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
         if (logger.isDebugEnabled()) {
+            String normalizedQuery = queryString.replace('\n', ' ');
+            MDC.put(MDC_QUERY, normalizedQuery);
+            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
             logger.debug(normalizedQuery);
         }
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
@@ -273,10 +273,10 @@ public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        String normalizedQuery = queryString.replace('\n', ' ');
-        MDC.put(MDC_QUERY, normalizedQuery);
-        MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
         if (logger.isDebugEnabled()) {
+            String normalizedQuery = queryString.replace('\n', ' ');
+            MDC.put(MDC_QUERY, normalizedQuery);
+            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
             logger.debug(normalizedQuery);
         }
     }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
@@ -609,10 +609,10 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
     }
 
     protected void logQuery(String queryString, Collection<Object> parameters) {
-        String normalizedQuery = queryString.replace('\n', ' ');
-        MDC.put(MDC_QUERY, normalizedQuery);
-        MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
         if (logger.isDebugEnabled()) {
+            String normalizedQuery = queryString.replace('\n', ' ');
+            MDC.put(MDC_QUERY, normalizedQuery);
+            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
             logger.debug(normalizedQuery);
         }
     }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
@@ -203,10 +203,10 @@ public abstract class AbstractSQLClause<C extends AbstractSQLClause<C>> implemen
     }
 
     protected void logQuery(Logger logger, String queryString, Collection<Object> parameters) {
-        String normalizedQuery = queryString.replace('\n', ' ');
-        MDC.put(QueryBase.MDC_QUERY, normalizedQuery);
-        MDC.put(QueryBase.MDC_PARAMETERS, String.valueOf(parameters));
         if (logger.isDebugEnabled()) {
+            String normalizedQuery = queryString.replace('\n', ' ');
+            MDC.put(QueryBase.MDC_QUERY, normalizedQuery);
+            MDC.put(QueryBase.MDC_PARAMETERS, String.valueOf(parameters));
             logger.debug(normalizedQuery);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/querydsl/querydsl/issues/1573

Note that removing MDC parameters that are not there is okay.
It would complicate it too much anyway.