### PR TITLE
Add the "server" parameter (alternative to jdbcUser and jdbcPassword)

### DIFF
--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
@@ -61,7 +61,7 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
      * @parameter
      */
     private String server;
-    
+
     /**
      * JDBC driver class name
      * @parameter required=true
@@ -491,20 +491,20 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
             Class.forName(jdbcDriver);
             final String user;
             final String password;
-            if (server ==null) {
+            if (server == null) {
                 user = jdbcUser;
                 password = jdbcPassword;
             } else {
                 final AuthenticationInfo info = wagonManager.getAuthenticationInfo(server);
-                if ( info == null ) {
+                if (info == null) {
                     throw new MojoExecutionException("No authentication info for server " + server);
                 }
- 
+
                 user = info.getUserName();
                 if (user == null) {
                     throw new MojoExecutionException("Missing username from server " + server);
                 }
- 
+
                 password = info.getPassword();
                 if (password == null) {
                     throw new MojoExecutionException("Missing password from server " + server);

--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
@@ -489,13 +489,13 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
             exporter.setConfiguration(configuration);
 
             Class.forName(jdbcDriver);
-            final String user;
-            final String password;
+            String user;
+            String password;
             if (server == null) {
                 user = jdbcUser;
                 password = jdbcPassword;
             } else {
-                final AuthenticationInfo info = wagonManager.getAuthenticationInfo(server);
+                AuthenticationInfo info = wagonManager.getAuthenticationInfo(server);
                 if (info == null) {
                     throw new MojoExecutionException("No authentication info for server " + server);
                 }
@@ -510,7 +510,7 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
                     throw new MojoExecutionException("Missing password from server " + server);
                 }
             }
-            final Connection conn = DriverManager.getConnection(jdbcUrl, user, password);
+            Connection conn = DriverManager.getConnection(jdbcUrl, user, password);
             try {
                 exporter.export(conn.getMetaData());
             } finally {

--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
@@ -538,6 +538,10 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
         this.project = project;
     }
 
+    public void setServer(String server) {
+        this.server = server;
+    }
+
     public void setJdbcDriver(String jdbcDriver) {
         this.jdbcDriver = jdbcDriver;
     }


### PR DESCRIPTION
Add the *server* parameter (the id of a `<server>` from settings.xml) as
an alternative to jdbcUser and jdbcPassword parameters.