### PR TITLE
Fixed detach for Collections.

### DIFF
--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -177,7 +177,7 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
     @SuppressWarnings("unchecked")
     private <T> T detach(T results) {
         if (results instanceof Collection) {
-            return (T) persistenceManager.detachCopyAll(results);
+            return (T) persistenceManager.detachCopyAll((Collection<?>) results);
         } else {
             return persistenceManager.detachCopy(results);
         }

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOQueryStandardTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOQueryStandardTest.java
@@ -30,7 +30,9 @@ import com.querydsl.core.types.ParamNotSetException;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Param;
+import com.querydsl.jdo.test.domain.Book;
 import com.querydsl.jdo.test.domain.Product;
+import com.querydsl.jdo.test.domain.QBook;
 import com.querydsl.jdo.test.domain.QProduct;
 import com.querydsl.jdo.test.domain.QStore;
 import com.querydsl.jdo.test.domain.Store;
@@ -185,4 +187,10 @@ public class JDOQueryStandardTest extends AbstractJDOTest {
                 .select(product.name).fetchFirst());
     }
 
+    @Test
+    public void DetatchCollection() {
+        new JDOQuery<Book>(pm, true)
+                .select(QBook.book).from(QBook.book)
+                .fetch();
+    }
 }


### PR DESCRIPTION
When automatically detaching results, if the result is a Collection, PersistenceManager.detachCopyAll(T...) was called instead of PersistenceManager.detachCopyAll(Collection) causing a ClassNotPersistableException. See unit test.