### PR TITLE
#180 added documentation regarding APT based code generation with Maven

### DIFF
--- a/querydsl-docs/src/main/docbook/en-US/content/general/codegen.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/general/codegen.xml
@@ -242,6 +242,116 @@ import com.querydsl.core.annotations.Config;
 </project>
 ]]></programlisting>
 
+    <para>Alternatively <code>maven-compiler-plugin</code> can be used as well:
+    </para>
+
+    <programlisting language="xml"><![CDATA[
+      <project>
+        <build>
+        <plugins>
+          ...
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+              <compilerArgs>
+                <arg>-Aquerydsl.entityAccessors=true</arg>
+                <arg>-Aquerydsl.useFields=false</arg>
+              </compilerArgs>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.querydsl</groupId>
+                <artifactId>querydsl-apt</artifactId>
+                <version>${querydsl.version}</version>
+                <classifier>jpa</classifier>
+              </dependency>
+              <dependency>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.1-api</artifactId>
+                <version>1.0.0.Final</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+          ...
+        </plugins>
+        </build>
+      </project>
+]]></programlisting>
+
+    <para>
+      Notice that you need to use a proper classifier when defining dependency
+      to <code>com.querydsl:querydsl-apt</code>. Those additional artifacts
+      define the annotation processor to be used in
+      <code>META-INF/services/javax.annotation.processing.Processor</code>.
+    </para>
+
+    <para>Available classifiers include:</para>
+
+    <itemizedlist>
+      <listitem>
+        <code>general</code>
+      </listitem>
+      <listitem>
+        <code>hibernate</code>
+      </listitem>
+      <listitem>
+        <code>jdo</code>
+      </listitem>
+      <listitem>
+        <code>jpa</code>
+      </listitem>
+    </itemizedlist>
+
+    <para>
+      The great advantage of this approach is that it can also handle
+      annotated Groovy classes using <code>groovy-eclipse</code> compiler:
+    </para>
+
+    <programlisting language="xml"><![CDATA[
+      <project>
+        <build>
+        <plugins>
+          ...
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerId>groovy-eclipse-compiler</compilerId>
+              <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+              <compilerArgs>
+                <arg>-Aquerydsl.entityAccessors=true</arg>
+                <arg>-Aquerydsl.useFields=false</arg>
+              </compilerArgs>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-eclipse-compiler</artifactId>
+                <version>2.9.1-01</version>
+              </dependency>
+              <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-eclipse-batch</artifactId>
+                <version>2.3.7-01</version>
+              </dependency>
+              <dependency>
+                <groupId>com.querydsl</groupId>
+                <artifactId>querydsl-apt</artifactId>
+                <version>${querydsl.version}</version>
+                <classifier>jpa</classifier>
+              </dependency>
+              <dependency>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.1-api</artifactId>
+                <version>1.0.0.Final</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+          ...
+        </plugins>
+        </build>
+      </project>
+]]></programlisting>
 
   </sect2>
 

--- a/querydsl-docs/src/main/docbook/en-US/content/general/codegen.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/general/codegen.xml
@@ -242,7 +242,9 @@ import com.querydsl.core.annotations.Config;
 </project>
 ]]></programlisting>
 
-    <para>Alternatively <code>maven-compiler-plugin</code> can be used as well:
+    <para>
+      Alternatively <code>maven-compiler-plugin</code> can be configured
+      to hook APT directly into compilation:
     </para>
 
     <programlisting language="xml"><![CDATA[
@@ -302,6 +304,13 @@ import com.querydsl.core.annotations.Config;
         <code>jpa</code>
       </listitem>
     </itemizedlist>
+
+    <para>
+      With this configuration query objects can have their sources genrated
+      and compiled during compilation of the domain objects. This will also
+      automatically add the generated sources directory to Maven project
+      source roots.
+    </para>
 
     <para>
       The great advantage of this approach is that it can also handle

--- a/querydsl-docs/src/main/docbook/en-US/content/general/codegen.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/general/codegen.xml
@@ -306,7 +306,7 @@ import com.querydsl.core.annotations.Config;
     </itemizedlist>
 
     <para>
-      With this configuration query objects can have their sources genrated
+      With this configuration query objects can have their sources generated
       and compiled during compilation of the domain objects. This will also
       automatically add the generated sources directory to Maven project
       source roots.


### PR DESCRIPTION
This provides documentation of how changes introduced in #180 can be used with `maven-compiler-plugin`. Also hints how this can be used to process annotations on Groovy sources. I've spent a whole day looking that up over the internet and some claimed it [can't be done](https://twitter.com/dkaczynski/status/667292975915859970). I think this should be documented for the ones that might follow.

A working example of this configuration can be found [here](https://github.com/kaczynskid/querydsl-groovy-maven).