### PR TITLE
Reorder cubrid install steps

### DIFF
--- a/travis/cubrid.sh
+++ b/travis/cubrid.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
+hostname | sed 's/^/127.0.0.1 /g' | cat - /etc/hosts > /tmp/etchoststemp && sudo mv /tmp/etchoststemp /etc/hosts --force
 echo 'yes' | sudo add-apt-repository ppa:cubrid/cubrid
 sudo apt-get update
 sudo apt-get install cubrid
 sudo apt-get install cubrid-demodb
 /etc/profile.d/cubrid.sh
-hostname | sed 's/^/127.0.0.1 /g' | cat - /etc/hosts > /tmp/etchoststemp && sudo mv /tmp/etchoststemp /etc/hosts --force
-


### PR DESCRIPTION
so that a valid hosts record is in place prior to installing cubrid.

Related to: https://github.com/travis-ci/travis-ci/issues/5254