### PR TITLE
Fixing squid:S2178 - Short-circuit logic should be used in boolean contexts

### DIFF
--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataExporterAllTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataExporterAllTest.java
@@ -77,7 +77,7 @@ public class MetaDataExporterAllTest {
                                             for (boolean exportColumns : booleans) {
                                                 for (boolean schemaToPackage : booleans) {
                                                     if (withBeans) {
-                                                        if (!beanPrefix.isEmpty() | !beanSuffix.isEmpty() |
+                                                        if (!beanPrefix.isEmpty() || !beanSuffix.isEmpty() ||
                                                             beanPackageName != null) {
                                                             continue;
                                                         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1764 - Identical expressions should not be used on both sides of a binary operator, squid:S2178 - Short-circuit logic should be used in boolean contexts

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1764
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2178
Please let me know if you have any questions.
Kirill Vlasov