### PR TITLE
Add convert tuple to map

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
@@ -17,6 +17,8 @@ import javax.annotation.Nullable;
 
 import com.querydsl.core.types.Expression;
 
+import java.util.Map;
+
 /**
  * {@code Tuple} defines an interface for generic query result projection
  *
@@ -89,5 +91,10 @@ public interface Tuple {
     */
    int hashCode();
 
-
+    /**
+     * convert to Map
+     *
+     * @return Map
+     */
+    Map toMap();
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
@@ -92,9 +92,9 @@ public interface Tuple {
    int hashCode();
 
     /**
-     * convert to Map
+     * Get the content as an Object array
      *
-     * @return Map
+     * @return tuple in map form
      */
     Map toMap();
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
@@ -92,7 +92,7 @@ public interface Tuple {
    int hashCode();
 
     /**
-     * Get the content as an Object array
+     * Get the content as an Object map
      *
      * @return tuple in map form
      */

--- a/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
@@ -124,6 +124,15 @@ public class QTuple extends FactoryExpressionBase<Tuple> {
         public String toString() {
             return Arrays.toString(a);
         }
+
+        @Override
+        public Map toMap() {
+            Map<String, Object> map = Maps.newHashMap();
+            for (int i = 0; i < a.length; i++) {
+                map.put(QTuple.this.args.get(i).toString(), a[i]);
+            }
+            return map;
+        }
     }
 
     private static final long serialVersionUID = -2640616030595420465L;
@@ -195,5 +204,20 @@ public class QTuple extends FactoryExpressionBase<Tuple> {
     public List<Expression<?>> getArgs() {
         return args;
     }
+
+    public ImmutableMap<Expression<?>, Integer> getBindings() {
+        return bindings;
+    }
+
+    // converter map
+//    public ImmutableMap<String, Integer> createBindingsMap() {
+//        List<Expression<?>> exprs = this.args;
+//        Map<String, Integer> map = Maps.newHashMap();
+//        for (int i = 0; i < exprs.size(); i++) {
+//            Expression<?> e = exprs.get(i);
+//            map.put(e.toString(),i);
+//        }
+//        return ImmutableMap.copyOf(map);
+//    }
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
@@ -209,15 +209,4 @@ public class QTuple extends FactoryExpressionBase<Tuple> {
         return bindings;
     }
 
-    // converter map
-//    public ImmutableMap<String, Integer> createBindingsMap() {
-//        List<Expression<?>> exprs = this.args;
-//        Map<String, Integer> map = Maps.newHashMap();
-//        for (int i = 0; i < exprs.size(); i++) {
-//            Expression<?> e = exprs.get(i);
-//            map.put(e.toString(),i);
-//        }
-//        return ImmutableMap.copyOf(map);
-//    }
-
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
@@ -205,8 +205,4 @@ public class QTuple extends FactoryExpressionBase<Tuple> {
         return args;
     }
 
-    public ImmutableMap<Expression<?>, Integer> getBindings() {
-        return bindings;
-    }
-
 }

--- a/querydsl-core/src/test/java/com/querydsl/core/group/MockTuple.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/group/MockTuple.java
@@ -1,6 +1,7 @@
 package com.querydsl.core.group;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
@@ -48,6 +49,11 @@ public class MockTuple implements Tuple {
     @Override
     public int hashCode() {
         return Arrays.hashCode(a);
+    }
+
+    @Override
+    public Map toMap() {
+        return null;
     }
 
     @Override

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/QTupleTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/QTupleTest.java
@@ -42,10 +42,15 @@ public class QTupleTest {
         assertEquals(Integer.valueOf(42), tuple.get(second));
         assertEquals(Boolean.TRUE, tuple.get(third));
 
-        assertEquals("1",tuple.toMap().get("x"));
-        assertEquals(Integer.valueOf(42),tuple.toMap().get("y"));
-//        assertEquals("42",tuple.toMap().get("y"));
-        assertEquals(Boolean.TRUE,tuple.toMap().get("z"));
+    }
+
+    @Test
+    public void newInstanceObjectMap() {
+        Tuple tuple = tupleExpression.newInstance("2", 43, false);
+        assertEquals(3, tuple.size());
+        assertEquals("2",tuple.toMap().get("x"));
+        assertEquals(Integer.valueOf(43),tuple.toMap().get("y"));
+        assertEquals(Boolean.FALSE,tuple.toMap().get("z"));
 
     }
 

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/QTupleTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/QTupleTest.java
@@ -42,6 +42,11 @@ public class QTupleTest {
         assertEquals(Integer.valueOf(42), tuple.get(second));
         assertEquals(Boolean.TRUE, tuple.get(third));
 
+        assertEquals("1",tuple.toMap().get("x"));
+        assertEquals(Integer.valueOf(42),tuple.toMap().get("y"));
+//        assertEquals("42",tuple.toMap().get("y"));
+        assertEquals(Boolean.TRUE,tuple.toMap().get("z"));
+
     }
 
 }


### PR DESCRIPTION
In vtl (velocity template engine )
get (0) to get the value of this approach in arrary form as discomfort.

It adds a tuple convert map feature so that you can use the value value to the string key.