### PR TITLE
Add support for skipping querydsl-maven-plugin execution

### DIFF
--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractExporterMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractExporterMojo.java
@@ -106,6 +106,13 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
     private boolean testClasspath;
 
     /**
+     * Whether to skip the exporting execution
+     *
+     * @parameter default-value=false property="maven.querydsl.skip"
+     */
+    private boolean skip;
+
+    /**
      * build context
      *
      * @component
@@ -120,7 +127,7 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
         } else {
             project.addCompileSourceRoot(targetFolder.getAbsolutePath());
         }
-        if (!hasSourceChanges()) {
+        if (skip || !hasSourceChanges()) {
             // Only run if something has changed in the source directories. This will
             // prevent m2e from entering an infinite build cycle.
             return;
@@ -221,6 +228,10 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
 
     public void setTestClasspath(boolean testClasspath) {
         this.testClasspath = testClasspath;
+    }
+
+    public void setSkip(boolean skip) {
+        this.skip = skip;
     }
 
     public void setBuildContext(BuildContext buildContext) {

--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
@@ -354,6 +354,13 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
      */
     private String[] imports;
 
+    /**
+     * Whether to skip the exporting execution
+     *
+     * @parameter default-value=false property="maven.querydsl.skip"
+     */
+    private boolean skip;
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -361,6 +368,10 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
             project.addTestCompileSourceRoot(targetFolder);
         } else {
             project.addCompileSourceRoot(targetFolder);
+        }
+
+        if (skip) {
+            return;
         }
 
         try {
@@ -659,5 +670,9 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
 
     public void setImports(String[] imports) {
         this.imports = imports;
+    }
+
+    public void setSkip(boolean skip) {
+        this.skip = skip;
     }
 }


### PR DESCRIPTION
Fixes #1731 