### PR TITLE
Add support for skipping querydsl-maven-plugin execution

### DIFF
--- a/querydsl-maven-plugin/src/main/java/com/mysema/query/maven/AbstractExporterMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/mysema/query/maven/AbstractExporterMojo.java
@@ -80,6 +80,13 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
     private boolean testClasspath;
 
     /**
+     * Whether to skip the exporting execution
+     *
+     * @parameter default-value=false property="maven.querydsl.skip"
+     */
+    private boolean skip;
+
+    /**
      * @component
      */
     private BuildContext buildContext;
@@ -92,7 +99,7 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
         } else {
             project.addCompileSourceRoot(targetFolder.getAbsolutePath());
         }
-        if (!hasSourceChanges()) {
+        if (skip || !hasSourceChanges()) {
             // Only run if something has changed on the source dirs. This will
             // avoid m2e entering on a infinite build.
             return;
@@ -192,6 +199,10 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
 
     public void setTestClasspath(boolean testClasspath) {
         this.testClasspath = testClasspath;
+    }
+
+    public void setSkip(boolean skip) {
+        this.skip = skip;
     }
 
     public void setBuildContext(BuildContext buildContext) {

--- a/querydsl-maven-plugin/src/main/java/com/mysema/query/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/mysema/query/maven/AbstractMetaDataExportMojo.java
@@ -281,6 +281,13 @@ public class AbstractMetaDataExportMojo extends AbstractMojo{
      */
     private String[] imports;
 
+    /**
+     * Whether to skip the exporting execution
+     *
+     * @parameter default-value=false property="maven.querydsl.skip"
+     */
+    private boolean skip;
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -288,6 +295,10 @@ public class AbstractMetaDataExportMojo extends AbstractMojo{
             project.addTestCompileSourceRoot(targetFolder);
         } else {
             project.addCompileSourceRoot(targetFolder);
+        }
+
+        if (skip) {
+            return;
         }
 
         try {
@@ -555,5 +566,9 @@ public class AbstractMetaDataExportMojo extends AbstractMojo{
 
     public void setImports(String[] imports) {
         this.imports = imports;
+    }
+
+    public void setSkip(boolean skip) {
+        this.skip = skip;
     }
 }


### PR DESCRIPTION
Fixes #1731 