### PR TITLE
When MathUtils.cast gets a null input, return null

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/util/MathUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/MathUtils.java
@@ -60,7 +60,7 @@ public final class MathUtils {
 
     public static <D extends Number> D cast(Number num, Class<D> type) {
         D rv;
-        if (type.isInstance(num)) {
+        if (num == null || type.isInstance(num)) {
             rv = type.cast(num);
         } else if (type.equals(Byte.class)) {
             rv = type.cast(num.byteValue());

--- a/querydsl-core/src/test/java/com/querydsl/core/util/MathUtilsTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/util/MathUtilsTest.java
@@ -13,8 +13,7 @@
  */
 package com.querydsl.core.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -61,6 +60,12 @@ public class MathUtilsTest {
         checkSame((long) 1, Long.class);
         checkSame((short) 1, Short.class);
         checkSame((byte) 1, Byte.class);
+    }
+
+    @Test
+    public void cast_returns_null_when_input_is_null() {
+        Integer result = MathUtils.cast(null, Integer.class);
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
Closes #1781 

You can cast `null` to any type, so this should be the least surprising change..
What do you think?