### PR TITLE
Adjust the prompt at release to remind releasing querydsl-contrib

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -20,4 +20,4 @@ mvn -Dxslthl.config=http://docbook.sourceforge.net/release/xsl/current/highlight
 cp -R target/docbook/publish/en-US/* ../target/dist/reference/
 cd ..
 
-echo "done."
+echo "done with querydsl."

--- a/release.sh
+++ b/release.sh
@@ -4,3 +4,5 @@ git pull
 mvn versions:set -DgenerateBackupPoms=false
 mvn clean deploy -DskipTests -Dgpg.skip=false
 ./dist.sh
+echo -e "Don't forget \x1b[33mquerydsl-contrib\x1b[m."
+echo -e "After deploying the \x1b[33mreference documentation\x1b[m, update the \x1b[33mcurrent symlink\x1b[m"


### PR DESCRIPTION
I don't think a backport is necessary for this one.
One reminder sounds okay I think.