### PR TITLE
querydsl.variableNameFunctionClass swallows ClassNotFoundExceptions

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ * Copyright 2016, The Querydsl Team (http://www.querydsl.com/team)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,8 +195,10 @@ public class DefaultConfiguration implements Configuration {
                 variableNameFunction = variableNameFunctionClass.newInstance();
             } catch (RuntimeException e) {
                 throw e;
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
             } catch (Exception e) {
-               variableNameFunction = DefaultVariableNameFunction.INSTANCE;
+                variableNameFunction = DefaultVariableNameFunction.INSTANCE;
             }
         } else {
             variableNameFunction = DefaultVariableNameFunction.INSTANCE;

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/NamingFunction.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/NamingFunction.java
@@ -15,24 +15,12 @@
  */
 package com.querydsl.codegen;
 
-import javax.lang.model.SourceVersion;
-
-import com.mysema.codegen.StringUtils;
+import com.google.common.base.Function;
 
 /**
- * Default variable name generation strategy which un-capitalizes the first letter of the class name.
+ * The {@link Function} signature to convert {@link EntityType} to {@link String}.
  *
+ * @author Shredder121
  */
-public final class DefaultVariableNameFunction implements NamingFunction {
-
-    public static final DefaultVariableNameFunction INSTANCE = new DefaultVariableNameFunction();
-
-    @Override
-    public String apply(EntityType entity) {
-        String uncapSimpleName = StringUtils.uncapitalize(entity.getInnerType().getSimpleName());
-        if (SourceVersion.isKeyword(uncapSimpleName)) {
-            uncapSimpleName = uncapSimpleName + "$";
-        }
-        return uncapSimpleName;
-    }
+public interface NamingFunction extends Function<EntityType, String> {
 }


### PR DESCRIPTION
I was either going to introduce a new try-catch around the `Class.forName` or adding a catch clause to the existing try-catch.
Which one do you prefer?