### PR TITLE
Ensure all date operations actually resolve to integer

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/PostgreSQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/PostgreSQLTemplates.java
@@ -107,9 +107,17 @@ public class PostgreSQLTemplates extends SQLTemplates {
         add(Ops.MathOps.TANH, "(exp({0*'2'}) - 1) / (exp({0*'2'}) + 1)");
 
         // Date / time
-        add(Ops.DateTimeOps.DAY_OF_WEEK, "extract(dow from {0}) + 1");
-        add(Ops.DateTimeOps.DAY_OF_YEAR, "extract(doy from {0})");
-        add(Ops.DateTimeOps.YEAR_WEEK, "(extract(isoyear from {0}) * 100 + extract(week from {0}))");
+        add(Ops.DateTimeOps.DAY_OF_MONTH, "cast(extract(day from {0}) as integer)");
+        add(Ops.DateTimeOps.DAY_OF_WEEK, "cast(extract(dow from {0}) + 1 as integer)");
+        add(Ops.DateTimeOps.DAY_OF_YEAR, "cast(extract(doy from {0}) as integer)");
+        add(Ops.DateTimeOps.HOUR, "cast(extract(hour from {0}) as integer)");
+        add(Ops.DateTimeOps.MINUTE, "cast(extract(minute from {0}) as integer)");
+        add(Ops.DateTimeOps.MONTH, "cast(extract(month from {0}) as integer)");
+        add(Ops.DateTimeOps.SECOND, "cast(extract(second from {0}) as integer)");
+        add(Ops.DateTimeOps.WEEK, "cast(extract(week from {0}) as integer)");
+        add(Ops.DateTimeOps.YEAR, "cast(extract(year from {0}) as integer)");
+        add(Ops.DateTimeOps.YEAR_MONTH, "cast(extract(year from {0}) * 100 + extract(month from {0}) as integer)");
+        add(Ops.DateTimeOps.YEAR_WEEK, "cast(extract(isoyear from {0}) * 100 + extract(week from {0}) as integer)");
 
         add(Ops.AggOps.BOOLEAN_ANY, "bool_or({0})", 0);
         add(Ops.AggOps.BOOLEAN_ALL, "bool_and({0})", 0);

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -1265,6 +1265,15 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
+    public void num_date_operation() {
+        long result = query()
+                .select(employee.datefield.year().mod(1))
+                .from(employee)
+                .fetchFirst();
+        assertEquals(0, result);
+    }
+
+    @Test
     @ExcludeIn({DERBY, FIREBIRD, POSTGRESQL})
     public void number_as_boolean() {
         QNumberTest numberTest = QNumberTest.numberTest;


### PR DESCRIPTION
Databases like [Postgresql](http://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT) return double precision numbers with `extract(...)`.
We need to update the templates to include the cast.

Oh, fixes #1876 