### PR TITLE
Replace concrete ImmutableList with List interface in public api

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionUtils.java
@@ -144,11 +144,25 @@ public final class ExpressionUtils {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #predicateTemplate(String, List)} instead.
+     *
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static PredicateTemplate predicateTemplate(String template, ImmutableList<?> args) {
+        return predicateTemplate(TemplateFactory.DEFAULT.create(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static PredicateTemplate predicateTemplate(String template, List<?> args) {
         return predicateTemplate(TemplateFactory.DEFAULT.create(template), args);
     }
 
@@ -166,14 +180,27 @@ public final class ExpressionUtils {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #predicateTemplate(Template, List)} instead.
+     *
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static PredicateTemplate predicateTemplate(Template template, ImmutableList<?> args) {
         return new PredicateTemplate(template, args);
     }
 
+    /**
+     * Create a new Template expression
+     *
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static PredicateTemplate predicateTemplate(Template template, List<?> args) {
+        return new PredicateTemplate(template, ImmutableList.copyOf(args));
+    }
 
     /**
      * Create a new Template expression
@@ -190,12 +217,27 @@ public final class ExpressionUtils {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #template(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T> TemplateExpression<T> template(Class<? extends T> cl, String template, ImmutableList<?> args) {
+        return template(cl, TemplateFactory.DEFAULT.create(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T> TemplateExpression<T> template(Class<? extends T> cl, String template, List<?> args) {
         return template(cl, TemplateFactory.DEFAULT.create(template), args);
     }
 
@@ -214,17 +256,37 @@ public final class ExpressionUtils {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #template(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static <T> TemplateExpression<T> template(Class<? extends T> cl, Template template, ImmutableList<?> args) {
         if (cl.equals(Boolean.class)) {
             return (TemplateExpression<T>) new PredicateTemplate(template, args);
         } else {
             return new TemplateExpressionImpl<T>(cl, template, args);
+        }
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> TemplateExpression<T> template(Class<? extends T> cl, Template template, List<?> args) {
+        if (cl.equals(Boolean.class)) {
+            return (TemplateExpression<T>) new PredicateTemplate(template, ImmutableList.copyOf(args));
+        } else {
+            return new TemplateExpressionImpl<T>(cl, template, ImmutableList.copyOf(args));
         }
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Expressions.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Expressions.java
@@ -1,3 +1,4 @@
+//CHECKSTYLERULE:OFF: FileLength
 /*
  * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
  *
@@ -14,8 +15,7 @@
 package com.querydsl.core.types.dsl;
 
 import java.sql.Time;
-import java.util.Collection;
-import java.util.Date;
+import java.util.*;
 
 import com.google.common.collect.ImmutableList;
 import com.querydsl.core.Tuple;
@@ -168,12 +168,27 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #template(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T> SimpleTemplate<T> template(Class<? extends T> cl, String template, ImmutableList<?> args) {
+        return simpleTemplate(cl, template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T> SimpleTemplate<T> template(Class<? extends T> cl, String template, List<?> args) {
         return simpleTemplate(cl, template, args);
     }
 
@@ -192,12 +207,27 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #template(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T> SimpleTemplate<T> template(Class<? extends T> cl, Template template, ImmutableList<?> args) {
+        return simpleTemplate(cl, template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T> SimpleTemplate<T> template(Class<? extends T> cl, Template template, List<?> args) {
         return simpleTemplate(cl, template, args);
     }
 
@@ -216,12 +246,27 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #simpleTemplate(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T> SimpleTemplate<T> simpleTemplate(Class<? extends T> cl, String template, ImmutableList<?> args) {
+        return simpleTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T> SimpleTemplate<T> simpleTemplate(Class<? extends T> cl, String template, List<?> args) {
         return simpleTemplate(cl, createTemplate(template), args);
     }
 
@@ -240,13 +285,28 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #simpleTemplate(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T> SimpleTemplate<T> simpleTemplate(Class<? extends T> cl, Template template, ImmutableList<?> args) {
         return new SimpleTemplate<T>(cl, template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T> SimpleTemplate<T> simpleTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new SimpleTemplate<T>(cl, template, ImmutableList.copyOf(args));
     }
 
     /**
@@ -264,12 +324,27 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #dslTemplate(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T> DslTemplate<T> dslTemplate(Class<? extends T> cl, String template, ImmutableList<?> args) {
+        return dslTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T> DslTemplate<T> dslTemplate(Class<? extends T> cl, String template, List<?> args) {
         return dslTemplate(cl, createTemplate(template), args);
     }
 
@@ -288,15 +363,29 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #dslTemplate(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T> DslTemplate<T> dslTemplate(Class<? extends T> cl, Template template, ImmutableList<?> args) {
         return new DslTemplate<T>(cl, template, args);
     }
 
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T> DslTemplate<T> dslTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new DslTemplate<T>(cl, template, ImmutableList.copyOf(args));
+    }
 
     /**
      * Create a new Template expression
@@ -314,13 +403,28 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #comparableTemplate(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Comparable<?>> ComparableTemplate<T> comparableTemplate(Class<? extends T> cl,
                                                                                      String template, ImmutableList<?> args) {
+        return comparableTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Comparable<?>> ComparableTemplate<T> comparableTemplate(Class<? extends T> cl, String template, List<?> args) {
         return comparableTemplate(cl, createTemplate(template), args);
     }
 
@@ -340,14 +444,29 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #comparableTemplate(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Comparable<?>> ComparableTemplate<T> comparableTemplate(Class<? extends T> cl,
                                                                                      Template template, ImmutableList<?> args) {
         return new ComparableTemplate<T>(cl, template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Comparable<?>> ComparableTemplate<T> comparableTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new ComparableTemplate<T>(cl, template, ImmutableList.copyOf(args));
     }
 
     /**
@@ -366,13 +485,28 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #dateTemplate(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Comparable<?>> DateTemplate<T> dateTemplate(Class<? extends T> cl,
                                                                          String template, ImmutableList<?> args) {
+        return dateTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Comparable<?>> DateTemplate<T> dateTemplate(Class<? extends T> cl, String template, List<?> args) {
         return dateTemplate(cl, createTemplate(template), args);
     }
 
@@ -392,16 +526,30 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #dateTemplate(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Comparable<?>> DateTemplate<T> dateTemplate(Class<? extends T> cl,
                                                                          Template template, ImmutableList<?> args) {
         return new DateTemplate<T>(cl, template, args);
     }
 
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Comparable<?>> DateTemplate<T> dateTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new DateTemplate<T>(cl, template, ImmutableList.copyOf(args));
+    }
 
     /**
      * Create a new Template expression
@@ -419,13 +567,28 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #dateTimeTemplate(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Comparable<?>> DateTimeTemplate<T> dateTimeTemplate(Class<? extends T> cl,
                                                                                  String template, ImmutableList<?> args) {
+        return dateTimeTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Comparable<?>> DateTimeTemplate<T> dateTimeTemplate(Class<? extends T> cl, String template, List<?> args) {
         return dateTimeTemplate(cl, createTemplate(template), args);
     }
 
@@ -442,9 +605,10 @@ public final class Expressions {
         return dateTimeTemplate(cl, template, ImmutableList.copyOf(args));
     }
 
-
     /**
      * Create a new Template expression
+     *
+     * @deprecated Use {@link #dateTimeTemplate(Class, Template, List)} instead.
      *
      * @param cl type of expression
      * @param template template
@@ -464,9 +628,8 @@ public final class Expressions {
      * @param args template parameters
      * @return template expression
      */
-    public static <T extends Comparable<?>> TimeTemplate<T> timeTemplate(Class<? extends T> cl,
-                                                                           String template, Object... args) {
-        return timeTemplate(cl, createTemplate(template), ImmutableList.copyOf(args));
+    public static <T extends Comparable<?>> DateTimeTemplate<T> dateTimeTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new DateTimeTemplate<T>(cl, template, ImmutableList.copyOf(args));
     }
 
     /**
@@ -478,7 +641,35 @@ public final class Expressions {
      * @return template expression
      */
     public static <T extends Comparable<?>> TimeTemplate<T> timeTemplate(Class<? extends T> cl,
+                                                                           String template, Object... args) {
+        return timeTemplate(cl, createTemplate(template), ImmutableList.copyOf(args));
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @deprecated Use {@link #timeTemplate(Class, String, List)} instead.
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    @Deprecated
+    public static <T extends Comparable<?>> TimeTemplate<T> timeTemplate(Class<? extends T> cl,
                                                                          String template, ImmutableList<?> args) {
+        return timeTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Comparable<?>> TimeTemplate<T> timeTemplate(Class<? extends T> cl, String template, List<?> args) {
         return timeTemplate(cl, createTemplate(template), args);
     }
 
@@ -498,14 +689,29 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #timeTemplate(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Comparable<?>> TimeTemplate<T> timeTemplate(Class<? extends T> cl,
                                                                          Template template, ImmutableList<?> args) {
         return new TimeTemplate<T>(cl, template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Comparable<?>> TimeTemplate<T> timeTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new TimeTemplate<T>(cl, template, ImmutableList.copyOf(args));
     }
 
     /**
@@ -524,13 +730,28 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #enumTemplate(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Enum<T>> EnumTemplate<T> enumTemplate(Class<? extends T> cl,
                                                                      String template, ImmutableList<?> args) {
+        return enumTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Enum<T>> EnumTemplate<T> enumTemplate(Class<? extends T> cl, String template, List<?> args) {
         return enumTemplate(cl, createTemplate(template), args);
     }
 
@@ -550,14 +771,29 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #enumTemplate(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Enum<T>> EnumTemplate<T> enumTemplate(Class<? extends T> cl,
                                                                    Template template, ImmutableList<?> args) {
         return new EnumTemplate<T>(cl, template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Enum<T>> EnumTemplate<T> enumTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new EnumTemplate<T>(cl, template, ImmutableList.copyOf(args));
     }
 
     /**
@@ -576,13 +812,28 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #numberTemplate(Class, String, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Number & Comparable<?>> NumberTemplate<T> numberTemplate(Class<? extends T> cl,
                                                                                       String template, ImmutableList<?> args) {
+        return numberTemplate(cl, createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Number & Comparable<?>> NumberTemplate<T> numberTemplate(Class<? extends T> cl, String template, List<?> args) {
         return numberTemplate(cl, createTemplate(template), args);
     }
 
@@ -602,14 +853,29 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #numberTemplate(Class, Template, List)} instead.
+     *
      * @param cl type of expression
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static <T extends Number & Comparable<?>> NumberTemplate<T> numberTemplate(Class<? extends T> cl,
                                                                                       Template template, ImmutableList<?> args) {
         return new NumberTemplate<T>(cl, template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param cl type of expression
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static <T extends Number & Comparable<?>> NumberTemplate<T> numberTemplate(Class<? extends T> cl, Template template, List<?> args) {
+        return new NumberTemplate<T>(cl, template, ImmutableList.copyOf(args));
     }
 
     /**
@@ -626,14 +892,27 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #stringTemplate(String, List)} instead.
+     *
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static StringTemplate stringTemplate(String template, ImmutableList<?> args) {
         return stringTemplate(createTemplate(template), args);
     }
 
+    /**
+     * Create a new Template expression
+     *
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static StringTemplate stringTemplate(String template, List<?> args) {
+        return stringTemplate(createTemplate(template), args);
+    }
 
     /**
      * Create a new Template expression
@@ -649,14 +928,27 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #stringTemplate(Template, List)} instead.
+     *
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static StringTemplate stringTemplate(Template template, ImmutableList<?> args) {
-        return new StringTemplate(template, ImmutableList.copyOf(args));
+        return new StringTemplate(template, args);
     }
 
+    /**
+     * Create a new Template expression
+     *
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static StringTemplate stringTemplate(Template template, List<?> args) {
+        return new StringTemplate(template, ImmutableList.copyOf(args));
+    }
 
     /**
      * Create a new Template expression
@@ -672,11 +964,25 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #booleanTemplate(String, List)} instead.
+     *
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static BooleanTemplate booleanTemplate(String template, ImmutableList<?> args) {
+        return booleanTemplate(createTemplate(template), args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static BooleanTemplate booleanTemplate(String template, List<?> args) {
         return booleanTemplate(createTemplate(template), args);
     }
 
@@ -694,11 +1000,25 @@ public final class Expressions {
     /**
      * Create a new Template expression
      *
+     * @deprecated Use {@link #booleanTemplate(Template, List)} instead.
+     *
      * @param template template
      * @param args template parameters
      * @return template expression
      */
+    @Deprecated
     public static BooleanTemplate booleanTemplate(Template template, ImmutableList<?> args) {
+        return new BooleanTemplate(template, args);
+    }
+
+    /**
+     * Create a new Template expression
+     *
+     * @param template template
+     * @param args template parameters
+     * @return template expression
+     */
+    public static BooleanTemplate booleanTemplate(Template template, List<?> args) {
         return new BooleanTemplate(template, ImmutableList.copyOf(args));
     }
 
@@ -1837,3 +2157,4 @@ public final class Expressions {
     }
 
 }
+//CHECKSTYLERULE:ON: FileLength

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/ExpressionsTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/ExpressionsTest.java
@@ -64,8 +64,10 @@ public class ExpressionsTest {
                 assertReturnType(Expressions.class.getMethod(type + "Operation", Operator.class, Expression[].class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", String.class, Object[].class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", String.class, ImmutableList.class));
+                assertReturnType(Expressions.class.getMethod(type + "Template", String.class, List.class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", Template.class, Object[].class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", Template.class, ImmutableList.class));
+                assertReturnType(Expressions.class.getMethod(type + "Template", Template.class, List.class));
             } else {
                 assertReturnType(Expressions.class.getMethod(type + "Path", Class.class, String.class));
                 assertReturnType(Expressions.class.getMethod(type + "Path", Class.class, Path.class, String.class));
@@ -73,8 +75,10 @@ public class ExpressionsTest {
                 assertReturnType(Expressions.class.getMethod(type + "Operation", Class.class, Operator.class, Expression[].class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", Class.class, String.class, Object[].class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", Class.class, String.class, ImmutableList.class));
+                assertReturnType(Expressions.class.getMethod(type + "Template", Class.class, String.class, List.class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", Class.class, Template.class, Object[].class));
                 assertReturnType(Expressions.class.getMethod(type + "Template", Class.class, Template.class, ImmutableList.class));
+                assertReturnType(Expressions.class.getMethod(type + "Template", Class.class, Template.class, List.class));
             }
         }
 


### PR DESCRIPTION
Avoids mistakes with other list implementations being dispatched
to a different method overload (intended for  #varargs).
Resolves #1908