### PR TITLE
Bump the `maven-plugin-plugin`

### DIFF
--- a/querydsl-maven-plugin/pom.xml
+++ b/querydsl-maven-plugin/pom.xml
@@ -28,6 +28,18 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>3.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Fixes #1788 

This fixes the parsing of plugin descriptors (the doclets) and the writing of the names of the parameters.

I also opened both the new `plugin.xml` and the one in Maven Central, and they are identical. So I hope that regarding maven this is as backwards compatible as possible.