### PR TITLE
Join for dynamic entity path alias, querydsl-sql needs implementation

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -171,6 +171,11 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     }
 
     @Override
+    public <E> Q fullJoin(EntityPath<E> target, Path<E> alias) {
+        return queryMixin.fullJoin(target, alias);
+    }
+
+    @Override
     public <E> Q fullJoin(RelationalFunctionCall<E> target, Path<E> alias) {
         return queryMixin.fullJoin(target, alias);
     }
@@ -188,6 +193,11 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     @Override
     public Q innerJoin(EntityPath<?> target) {
         return queryMixin.innerJoin(target);
+    }
+
+    @Override
+    public <E> Q innerJoin(EntityPath<E> target, Path<E> alias) {
+        return queryMixin.innerJoin(target, alias);
     }
 
     @Override
@@ -211,6 +221,11 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     }
 
     @Override
+    public <E> Q join(EntityPath<E> target, Path<E> alias) {
+        return queryMixin.join(target, alias);
+    }
+
+    @Override
     public <E> Q join(RelationalFunctionCall<E> target, Path<E> alias) {
         return queryMixin.join(target, alias);
     }
@@ -231,6 +246,11 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     }
 
     @Override
+    public <E> Q leftJoin(EntityPath<E> target, Path<E> alias) {
+        return queryMixin.leftJoin(target, alias);
+    }
+
+    @Override
     public <E> Q leftJoin(RelationalFunctionCall<E> target, Path<E> alias) {
         return queryMixin.leftJoin(target, alias);
     }
@@ -248,6 +268,11 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     @Override
     public Q rightJoin(EntityPath<?> target) {
         return queryMixin.rightJoin(target);
+    }
+
+    @Override
+    public <E> Q rightJoin(EntityPath<E> target, Path<E> alias) {
+        return queryMixin.rightJoin(target, alias);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLCommonQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLCommonQuery.java
@@ -106,6 +106,16 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @param alias alias
      * @return the current object
      */
+    <E> Q fullJoin(EntityPath<E> o, Path<E> alias);
+
+    /**
+     * Adds a full join to the given target
+     *
+     * @param <E>
+     * @param o full join target
+     * @param alias alias
+     * @return the current object
+     */
     <E> Q fullJoin(RelationalFunctionCall<E> o, Path<E> alias);
 
     /**
@@ -134,6 +144,16 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @return the current object
      */
     Q innerJoin(EntityPath<?> o);
+
+    /**
+     * Adds an inner join to the given target
+     *
+     * @param <E>
+     * @param o
+     * @param alias alias
+     * @return the current object
+     */
+    <E> Q innerJoin(EntityPath<E> o, Path<E> alias);
 
     /**
      * Adds a full join to the given target
@@ -180,6 +200,16 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @param alias alias
      * @return the current object
      */
+    <E> Q join(EntityPath<E> o, Path<E> alias);
+
+    /**
+     * Adds a full join to the given target
+     *
+     * @param <E>
+     * @param o join target
+     * @param alias alias
+     * @return the current object
+     */
     <E> Q join(RelationalFunctionCall<E> o, Path<E> alias);
 
     /**
@@ -208,6 +238,16 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @return the current object
      */
     Q leftJoin(EntityPath<?> o);
+
+    /**
+     * Adds a full join to the given target
+     *
+     * @param <E>
+     * @param o relational function call
+     * @param alias alias
+     * @return the current object
+     */
+    <E> Q leftJoin(EntityPath<E> o, Path<E> alias);
 
     /**
      * Adds a full join to the given target
@@ -253,6 +293,16 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * @return the current object
      */
     Q rightJoin(EntityPath<?> o);
+
+    /**
+     * Adds a full join to the given target
+     *
+     * @param <E>
+     * @param o relational function call
+     * @param alias alias
+     * @return the current object
+     */
+    <E> Q rightJoin(EntityPath<E> o, Path<E> alias);
 
     /**
      * Adds a full join to the given target

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLCommonQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLCommonQuery.java
@@ -156,7 +156,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
     <E> Q innerJoin(EntityPath<E> o, Path<E> alias);
 
     /**
-     * Adds a full join to the given target
+     * Adds a inner join to the given target
      *
      * @param <E>
      * @param o relational function call
@@ -193,7 +193,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
     Q join(EntityPath<?> o);
 
     /**
-     * Adds a full join to the given target
+     * Adds a join to the given target
      *
      * @param <E>
      * @param o join target
@@ -203,7 +203,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
     <E> Q join(EntityPath<E> o, Path<E> alias);
 
     /**
-     * Adds a full join to the given target
+     * Adds a join to the given target
      *
      * @param <E>
      * @param o join target
@@ -240,7 +240,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
     Q leftJoin(EntityPath<?> o);
 
     /**
-     * Adds a full join to the given target
+     * Adds a left join to the given target
      *
      * @param <E>
      * @param o left join target
@@ -250,7 +250,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
     <E> Q leftJoin(EntityPath<E> o, Path<E> alias);
 
     /**
-     * Adds a full join to the given target
+     * Adds a left join to the given target
      *
      * @param <E>
      * @param o relational function call
@@ -295,7 +295,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
     Q rightJoin(EntityPath<?> o);
 
     /**
-     * Adds a full join to the given target
+     * Adds a right join to the given target
      *
      * @param <E>
      * @param o right join target

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLCommonQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLCommonQuery.java
@@ -149,7 +149,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * Adds an inner join to the given target
      *
      * @param <E>
-     * @param o
+     * @param o inner join target
      * @param alias alias
      * @return the current object
      */
@@ -243,7 +243,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * Adds a full join to the given target
      *
      * @param <E>
-     * @param o relational function call
+     * @param o left join target
      * @param alias alias
      * @return the current object
      */
@@ -298,7 +298,7 @@ public interface SQLCommonQuery<Q extends SQLCommonQuery<Q>> extends Query<Q> {
      * Adds a full join to the given target
      *
      * @param <E>
-     * @param o relational function call
+     * @param o right join target
      * @param alias alias
      * @return the current object
      */

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLSerializerTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLSerializerTest.java
@@ -120,6 +120,66 @@ public class SQLSerializerTest {
     }
 
     @Test
+    public void fullJoinWithoutCodeGeneration() {
+        SQLQuery<?> sqlQuery = queryForMYSQLTemplate();
+
+        PathBuilder<Object> customerPath = new PathBuilder<Object>(Object.class, "customer");
+        PathBuilder<Object> deptPath = new PathBuilder<Object>(Object.class, "department");
+        Path<Object> deptAliasPath = new PathBuilder<Object>(Object.class, "d");
+        sqlQuery = sqlQuery.from(customerPath.as("c"));
+        NumberPath<Long> idPath = Expressions.numberPath(Long.class, deptAliasPath, "id");
+
+        sqlQuery = sqlQuery.fullJoin(deptPath, deptAliasPath).select(idPath);
+
+        assertEquals("select d.id from customer as c full join department as d", sqlQuery.toString());
+    }
+
+    @Test
+    public void innerJoinWithoutCodeGeneration() {
+        SQLQuery<?> sqlQuery = queryForMYSQLTemplate();
+
+        PathBuilder<Object> customerPath = new PathBuilder<Object>(Object.class, "customer");
+        PathBuilder<Object> deptPath = new PathBuilder<Object>(Object.class, "department");
+        Path<Object> deptAliasPath = new PathBuilder<Object>(Object.class, "d");
+        sqlQuery = sqlQuery.from(customerPath.as("c"));
+        NumberPath<Long> idPath = Expressions.numberPath(Long.class, deptAliasPath, "id");
+
+        sqlQuery = sqlQuery.innerJoin(deptPath, deptAliasPath).select(idPath);
+
+        assertEquals("select d.id from customer as c inner join department as d", sqlQuery.toString());
+    }
+
+    @Test
+    public void joinWithoutCodeGeneration() {
+        SQLQuery<?> sqlQuery = queryForMYSQLTemplate();
+
+        PathBuilder<Object> customerPath = new PathBuilder<Object>(Object.class, "customer");
+        PathBuilder<Object> deptPath = new PathBuilder<Object>(Object.class, "department");
+        Path<Object> deptAliasPath = new PathBuilder<Object>(Object.class, "d");
+        sqlQuery = sqlQuery.from(customerPath.as("c"));
+        NumberPath<Long> idPath = Expressions.numberPath(Long.class, deptAliasPath, "id");
+
+        sqlQuery = sqlQuery.join(deptPath, deptAliasPath).select(idPath);
+
+        assertEquals("select d.id from customer as c join department as d", sqlQuery.toString());
+    }
+
+    @Test
+    public void leftJoinWithoutCodeGeneration() {
+        SQLQuery<?> sqlQuery = queryForMYSQLTemplate();
+
+        PathBuilder<Object> customerPath = new PathBuilder<Object>(Object.class, "customer");
+        PathBuilder<Object> deptPath = new PathBuilder<Object>(Object.class, "department");
+        Path<Object> deptAliasPath = new PathBuilder<Object>(Object.class, "d");
+        sqlQuery = sqlQuery.from(customerPath.as("c"));
+        NumberPath<Long> idPath = Expressions.numberPath(Long.class, deptAliasPath, "id");
+
+        sqlQuery = sqlQuery.leftJoin(deptPath, deptAliasPath).select(idPath);
+
+        assertEquals("select d.id from customer as c left join department as d", sqlQuery.toString());
+    }
+
+    @Test
     public void or_in() {
         StringPath path = Expressions.stringPath("str");
         Expression<?> expr = ExpressionUtils.anyOf(
@@ -356,6 +416,10 @@ public class SQLSerializerTest {
 
     private SQLQuery<?> query() {
         return new SQLQuery<Void>();
+    }
+
+    private SQLQuery<?> queryForMYSQLTemplate() {
+        return new SQLQuery<Void>(MySQLTemplates.builder().printSchema().newLineToSingleSpace().build());
     }
 
 }


### PR DESCRIPTION
Closes #1936 
1. Added 4 join related method implementations: join, innerJoin, fullJoin and rightJoin for dynamic query building, which would be without code generation.
2. The fix will solve the implementation required to build a join clause

What it solves:

```java
SQLTemplates templates = MySQLTemplates.builder().printSchema().build();
Configuration configuration = new Configuration(templates);
configuration.setUseLiterals(true);
SQLQueryFactory queryFactory = new SQLQueryFactory(configuration, sqlDataSource); //DataSource sqlDataSource

Path<Object> customerPath = new PathBuilder<Object>(Object.class, "customer");
SQLQuery<?> sqlQuery = queryFactory.from(customerPath.as("c"));

PathBuilder<Object> orderPath = new PathBuilder<Object>(Object.class, "order");
Path<Object> aliasPath = new PathBuilder<Object>(Object.class, "o");

sqlQuery = sqlQuery.innerJoin(orderPath, aliasPath); // new innerJoin method implemented

sqlQuery = sqlQuery.select(SQLExpressions.all);
System.out.println(sqlQuery.getSQL().getSQL());
```

Will print: `select * from customer as c inner join order as o`