### PR TITLE
 #1955 Fix foreign key generation in MetadataExp

### DIFF
--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
@@ -356,10 +356,15 @@ public class MetaDataExporter {
                 Map<String,ForeignKeyData> foreignKeyData = keyDataFactory
                         .getImportedKeys(md, catalog, schema, tableName);
                 if (!foreignKeyData.isEmpty()) {
+                    Collection<ForeignKeyData> foreignKeysToGenerate = new HashSet<ForeignKeyData>();
                     for (ForeignKeyData fkd : foreignKeyData.values()) {
                         if (namingStrategy.shouldGenerateForeignKey(schemaAndTable, fkd)) {
-                            classModel.getData().put(ForeignKeyData.class, foreignKeyData.values());
+                            foreignKeysToGenerate.add(fkd);
                         }
+                    }
+
+                    if (!foreignKeysToGenerate.isEmpty()) {
+                        classModel.getData().put(ForeignKeyData.class, foreignKeysToGenerate);
                     }
                 }
             }


### PR DESCRIPTION
I collect the foreign keys that should be generated
into a set and only add them to the classModel if
there is any foreign key.