### PR TITLE
Use yaml list notation in pullapprove config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,8 +4,10 @@ approve_regex: '(?i)^(approved|looks good|:shipit:|:\+1:)'
 reject_regex: '(?i)^Rejected'
 reset_on_push: false
 always_pending:
-  labels: progress
+  labels:
+  - progress
 reviewers:
-  name: querydsl team
-  teams: developers
-  required: 1
+  - name: querydsl team
+    teams:
+    -  developers
+    required: 1


### PR DESCRIPTION
![YAML parse error][]
I noticed that the configuration wasn't quite right.

Let's see if this one is better.

[YAML parse error]: https://cloud.githubusercontent.com/assets/4105066/16568314/01600faa-4229-11e6-9e4a-19c8a5ef0793.png