### PR TITLE
Bypassing NPE in multithreaded environment

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/ConstructorExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ConstructorExpression.java
@@ -128,9 +128,11 @@ public class ConstructorExpression<T> extends FactoryExpressionBase<T> {
     @SuppressWarnings("unchecked")
     public T newInstance(Object... args) {
         try {
-            if (constructor == null) {
-                constructor = getConstructor(getType(), parameterTypes);
-                transformers = getTransformers(constructor);
+            synchronized(this){
+                if (constructor == null) {
+                    constructor = getConstructor(getType(), parameterTypes);
+                    transformers = getTransformers(constructor);
+                }
             }
             for (Function<Object[], Object[]> transformer : transformers) {
                 args = transformer.apply(args);


### PR DESCRIPTION
This PR avoids NPEs thrown by ConstructorExpression in multithreaded environment. This PR solves this related issue: https://github.com/querydsl/querydsl/issues/1958