### PR TITLE
Fixed map grouping by, was generating an invalid jpql query

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/support/QueryMixin.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/QueryMixin.java
@@ -204,13 +204,14 @@ public class QueryMixin<T> {
     }
 
     public final T groupBy(Expression<?> e) {
+        e = convert(e, Role.GROUP_BY);
         metadata.addGroupBy(e);
         return self;
     }
 
     public final T groupBy(Expression<?>... o) {
         for (Expression<?> e : o) {
-            metadata.addGroupBy(e);
+            groupBy(e);
         }
         return self;
     }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
@@ -1196,6 +1196,12 @@ public abstract class AbstractJPATest {
     }
 
     @Test
+    public void map_groupBy() {
+      QShow show = QShow.show;
+      assertEquals(1, query().from(show).select(show.acts.get("X")).groupBy(show.acts.get("a")).fetchCount());
+    }
+
+    @Test
     @Ignore
     public void map_join() {
         //select m.text from Show s join s.acts a where key(a) = 'B'

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/MapOperationsTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/MapOperationsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.jpa;
+
+import static com.querydsl.jpa.Constants.*;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.querydsl.jpa.impl.JPAQuery;
+
+public class MapOperationsTest extends AbstractQueryTest {
+
+    @Test
+    public void map_with_groupBy() {
+        assertEquals("select show_acts_0\nfrom Show show\n  left join show.acts as show_acts_0 on key(show_acts_0) = ?1\ngroup by show_acts_0", new JPAQuery<Void>().from(show).select(show.acts.get("A")).groupBy(show.acts.get("A")).toString());
+    }
+
+}


### PR DESCRIPTION
Query dsl was generating a query like this:
```
select show_acts_0
from Show show
  left join show.acts as show_acts_0 with key(show_acts_0) = ?1
```

So I included convert to groupBy as well, same as setProjection()