### PR TITLE
Generate constructor with variable and schema parameters.

### DIFF
--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
@@ -25,6 +25,7 @@ import javax.inject.Named;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import com.mysema.codegen.CodeWriter;
 import com.mysema.codegen.model.*;
 import com.querydsl.codegen.*;
@@ -108,6 +109,13 @@ public class MetaDataSerializer extends EntitySerializer {
                                 new Parameter("table", Types.STRING));
         writer.line(SUPER,"(", writer.getClassConstant(localName) + COMMA
                 + "forVariable(variable), schema, table);");
+        constructorContent(writer, model);
+        writer.end();
+
+        writer.beginConstructor(new Parameter("variable", Types.STRING),
+                                new Parameter("schema", Types.STRING));
+        writer.line(SUPER, "(", writer.getClassConstant(localName) + COMMA
+                + "forVariable(variable), schema, \"", model.getData().get("table") + "\");");
         constructorContent(writer, model);
         writer.end();
     }


### PR DESCRIPTION
This is for the case where each customer has its own database with the same strucure using a single connection.

Fixes #1877