### PR TITLE
add support for mongodb $geoWithin operator and Morphia GeoJSON classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <animal-sniffer.version>1.14</animal-sniffer.version>
 
     <jdo.version>3.0.1</jdo.version>
-    <morphia.version>0.105</morphia.version>
+    <morphia.version>0.111</morphia.version>
     
     <!-- Import-Package definitions for maven-bundle-plugin -->
     <osgi.import.package.root>

--- a/querydsl-mongodb/pom.xml
+++ b/querydsl-mongodb/pom.xml
@@ -16,10 +16,10 @@
   <packaging>jar</packaging>
 
   <properties>
-    <mongodb.version>2.10.0</mongodb.version>
+    <mongodb.version>2.13.0</mongodb.version>
     <osgi.import.package>
       com.mongodb;version="0.0.0",
-      org.mongodb.morphia.*;version="0.105",
+      org.mongodb.morphia.*;version="0.111",
       org.bson.*;version="0.0.0",
       ${osgi.import.package.root}
     </osgi.import.package>

--- a/querydsl-mongodb/pom.xml
+++ b/querydsl-mongodb/pom.xml
@@ -74,6 +74,13 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.fakemongo</groupId>
+      <artifactId>fongo</artifactId>
+      <version>1.6.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbExpressions.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbExpressions.java
@@ -16,6 +16,7 @@ package com.querydsl.mongodb;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import org.mongodb.morphia.query.Shape;
 
 /**
  * Mongodb specific operations
@@ -51,4 +52,14 @@ public final class MongodbExpressions {
         return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, Expressions.constant(new Double[]{latVal, longVal}));
     }
 
+    /**
+     * Finds the all the points within the given shape
+     *
+     * @param expr expression
+     * @param shape shape
+     * @return predicate
+     */
+    public static BooleanExpression geoWithin(Expression<Double[]> expr, Shape shape) {
+        return Expressions.booleanOperation(MongodbOps.GEO_WITHIN, expr, Expressions.constant(shape));
+    }
 }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbExpressions.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbExpressions.java
@@ -13,7 +13,6 @@
  */
 package com.querydsl.mongodb;
 
-import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -37,7 +36,7 @@ public final class MongodbExpressions {
      * @return predicate
      */
     public static BooleanExpression near(Expression<Double[]> expr, double latVal, double longVal) {
-        return Expressions.booleanOperation(MongodbOps.NEAR, expr, ConstantImpl.create(new Double[]{latVal, longVal}));
+        return Expressions.booleanOperation(MongodbOps.NEAR, expr, Expressions.constant(new Double[]{latVal, longVal}));
     }
 
     /**
@@ -49,7 +48,7 @@ public final class MongodbExpressions {
      * @return predicate
      */
     public static BooleanExpression nearSphere(Expression<Double[]> expr, double latVal, double longVal) {
-        return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, ConstantImpl.create(new Double[]{latVal, longVal}));
+        return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, Expressions.constant(new Double[]{latVal, longVal}));
     }
 
 }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbOps.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbOps.java
@@ -24,7 +24,8 @@ import com.querydsl.core.types.Operator;
 public enum MongodbOps implements Operator {
     NEAR(Boolean.class),
     ELEM_MATCH(Boolean.class),
-    NEAR_SPHERE(Boolean.class);
+    NEAR_SPHERE(Boolean.class),
+    GEO_WITHIN(Boolean.class);
 
     private final Class<?> type;
 

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -13,20 +13,19 @@
  */
 package com.querydsl.mongodb;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-
-import org.bson.BSONObject;
-import org.bson.types.ObjectId;
-
 import com.google.common.collect.Sets;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
 import com.querydsl.core.types.*;
+import org.bson.BSONObject;
+import org.bson.types.ObjectId;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Serializes the given Querydsl query to a DBObject query for MongoDB
@@ -247,16 +246,27 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
             return asDBObject(visit(path, context) + "." + key.toString(), asDBObject("$exists", true));
 
         } else if (op == MongodbOps.NEAR) {
-            return asDBObject(asDBKey(expr, 0), asDBObject("$near", asDBValue(expr, 1)));
-
+            return asDBObject(asDBKey(expr, 0), asDBObject("$near", getDBValueFor$NearOp(expr)));
         } else if (op == MongodbOps.NEAR_SPHERE) {
-            return asDBObject(asDBKey(expr, 0), asDBObject("$nearSphere", asDBValue(expr, 1)));
-
+            return asDBObject(asDBKey(expr, 0), asDBObject("$nearSphere", getDBValueFor$NearOp(expr)));
         } else if (op == MongodbOps.ELEM_MATCH) {
             return asDBObject(asDBKey(expr, 0), asDBObject("$elemMatch", asDBValue(expr, 1)));
         }
 
         throw new UnsupportedOperationException("Illegal operation " + expr);
+    }
+
+    private Object getDBValueFor$NearOp(Operation<?> expr) {
+        Object value = asDBValue(expr, 1);
+
+        if (value instanceof BSONObject && expr.getArgs().size() > 2) {
+            BSONObject geometry = (BSONObject) value;
+            Object maxDistanceMeters = asDBValue(expr, 2);
+            geometry.put("$maxDistance", maxDistanceMeters);
+            return geometry;
+        } else {
+            return value;
+        }
     }
 
     private Object negate(BasicDBObject arg) {

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -249,6 +249,8 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
             return asDBObject(asDBKey(expr, 0), asDBObject("$near", getDBValueFor$NearOp(expr)));
         } else if (op == MongodbOps.NEAR_SPHERE) {
             return asDBObject(asDBKey(expr, 0), asDBObject("$nearSphere", getDBValueFor$NearOp(expr)));
+        } else if (op == MongodbOps.GEO_WITHIN) {
+            return asDBObject(asDBKey(expr, 0), asDBObject("$geoWithin", asDBValue(expr, 1)));
         } else if (op == MongodbOps.ELEM_MATCH) {
             return asDBObject(asDBKey(expr, 0), asDBObject("$elemMatch", asDBValue(expr, 1)));
         }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/Point.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/Point.java
@@ -51,4 +51,8 @@ public class Point extends ArrayPath<Double[], Double> {
         return MongodbExpressions.near(this, latVal, longVal);
     }
 
+    public BooleanExpression nearSphere(double latVal, double longVal) {
+        return MongodbExpressions.nearSphere(this, latVal, longVal);
+    }
+
 }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/Point.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/Point.java
@@ -17,6 +17,7 @@ import com.querydsl.core.types.Path;
 import com.querydsl.core.types.PathMetadata;
 import com.querydsl.core.types.dsl.ArrayPath;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import org.mongodb.morphia.query.Shape;
 
 /**
  * {@code Point} is an adapter type for Double[] arrays to use geo spatial querying features of Mongodb
@@ -53,6 +54,10 @@ public class Point extends ArrayPath<Double[], Double> {
 
     public BooleanExpression nearSphere(double latVal, double longVal) {
         return MongodbExpressions.nearSphere(this, latVal, longVal);
+    }
+
+    public BooleanExpression geoWithin(Shape shape) {
+        return MongodbExpressions.geoWithin(this, shape);
     }
 
 }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
@@ -17,6 +17,7 @@ import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.mongodb.MongodbOps;
+import org.mongodb.morphia.geo.Geometry;
 import org.mongodb.morphia.geo.Point;
 
 /**
@@ -75,6 +76,17 @@ public final class MorphiaExpressions {
      */
     public static BooleanExpression nearSphere(Expression<Point> expr, Point point, double maxDistance) {
         return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, Expressions.constant(point), Expressions.constant(maxDistance));
+    }
+
+    /**
+     * Finds the all the points within the given geometry
+     *
+     * @param expr expression
+     * @param geometry geometry
+     * @return predicate
+     */
+    public static BooleanExpression geoWithin(Expression<Point> expr, Geometry geometry) {
+        return Expressions.booleanOperation(MongodbOps.GEO_WITHIN, expr, Expressions.constant(geometry));
     }
 
 }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
@@ -41,6 +41,19 @@ public final class MorphiaExpressions {
     }
 
     /**
+     * Finds the closest points relative to the given location up to a maximum distance
+     * and orders the results with decreasing proximity
+     *
+     * @param expr expression
+     * @param point location
+     * @param maxDistance max distance
+     * @return predicate
+     */
+    public static BooleanExpression near(Expression<Point> expr, Point point, double maxDistance) {
+        return Expressions.booleanOperation(MongodbOps.NEAR, expr, Expressions.constant(point), Expressions.constant(maxDistance));
+    }
+
+    /**
      * Finds the closest points relative to the given location on a sphere and orders the results with decreasing proximity
      *
      * @param expr expression
@@ -49,6 +62,19 @@ public final class MorphiaExpressions {
      */
     public static BooleanExpression nearSphere(Expression<Point> expr, Point point) {
         return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, Expressions.constant(point));
+    }
+
+    /**
+     * Finds the closest points relative to the given location on a sphere up to a maximum distance
+     * and orders the results with decreasing proximity
+     *
+     * @param expr expression
+     * @param point location
+     * @param maxDistance max distance
+     * @return predicate
+     */
+    public static BooleanExpression nearSphere(Expression<Point> expr, Point point, double maxDistance) {
+        return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, Expressions.constant(point), Expressions.constant(maxDistance));
     }
 
 }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.morphia;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.mongodb.MongodbOps;
+import org.mongodb.morphia.geo.Point;
+
+/**
+ * Morphia specific MongoDB operations
+ *
+ * @author jmoghisi
+ *
+ */
+public final class MorphiaExpressions {
+
+    private MorphiaExpressions() { }
+
+    /**
+     * Finds the closest points relative to the given location and orders the results with decreasing proximity
+     *
+     * @param expr expression
+     * @param point location
+     * @return predicate
+     */
+    public static BooleanExpression near(Expression<Point> expr, Point point) {
+        return Expressions.booleanOperation(MongodbOps.NEAR, expr, Expressions.constant(point));
+    }
+
+    /**
+     * Finds the closest points relative to the given location on a sphere and orders the results with decreasing proximity
+     *
+     * @param expr expression
+     * @param point location
+     * @return predicate
+     */
+    public static BooleanExpression nearSphere(Expression<Point> expr, Point point) {
+        return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, Expressions.constant(point));
+    }
+
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaSerializer.java
@@ -26,6 +26,7 @@ import org.mongodb.morphia.annotations.Reference;
 import org.mongodb.morphia.geo.Geometry;
 import org.mongodb.morphia.geo.GeometryQueryConverter;
 import org.mongodb.morphia.mapping.Mapper;
+import org.mongodb.morphia.query.Shape;
 
 import java.lang.reflect.AnnotatedElement;
 
@@ -49,6 +50,8 @@ public class MorphiaSerializer extends MongodbSerializer {
     public Object visit(Constant<?> expr, Void context) {
         if (Geometry.class.isAssignableFrom(expr.getType())) {
             return geometryQueryConverter.encode(expr.getConstant());
+        } else if (Shape.class.isAssignableFrom(expr.getType())) {
+            return ((Shape) expr.getConstant()).toDBObject();
         } else {
             return super.visit(expr, context);
         }

--- a/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
+++ b/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
@@ -32,7 +32,16 @@ public class QPoint extends EntityPathBase<Point> {
         return MorphiaExpressions.near(this, point);
     }
 
+    public BooleanExpression near(Point point, double maxDistance) {
+        return MorphiaExpressions.near(this, point, maxDistance);
+    }
+
     public BooleanExpression nearSphere(Point point) {
         return MorphiaExpressions.nearSphere(this, point);
     }
+
+    public BooleanExpression nearSphere(Point point, double maxDistance) {
+        return MorphiaExpressions.nearSphere(this, point, maxDistance);
+    }
+
 }

--- a/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
+++ b/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
@@ -1,0 +1,38 @@
+package org.mongodb.morphia.geo;
+
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.mongodb.morphia.MorphiaExpressions;
+
+import javax.annotation.Nullable;
+
+/**
+ * {@code QPoint} is an adapter type for Point to use geo spatial querying features of Mongodb
+ *
+ * @author jmoghisi
+ *
+ */
+public class QPoint extends EntityPathBase<Point> {
+
+    public QPoint(String variable) {
+        super(Point.class, variable);
+    }
+
+    public QPoint(PathMetadata metadata) {
+        super(Point.class, metadata);
+    }
+
+    public QPoint(PathMetadata metadata, @Nullable PathInits inits) {
+        super(Point.class, metadata, inits);
+    }
+
+    public BooleanExpression near(Point point) {
+        return MorphiaExpressions.near(this, point);
+    }
+
+    public BooleanExpression nearSphere(Point point) {
+        return MorphiaExpressions.nearSphere(this, point);
+    }
+}

--- a/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
+++ b/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
@@ -44,4 +44,8 @@ public class QPoint extends EntityPathBase<Point> {
         return MorphiaExpressions.nearSphere(this, point, maxDistance);
     }
 
+    public BooleanExpression geoWithin(Geometry geometry) {
+        return MorphiaExpressions.geoWithin(this, geometry);
+    }
+
 }

--- a/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/package-info.java
+++ b/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * MongoDB geo support
+ */
+package org.mongodb.morphia.geo;

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
+import org.mongodb.morphia.geo.GeoJson;
 
 import java.net.UnknownHostException;
 import java.util.List;
@@ -53,27 +54,37 @@ public class GeoSpatialQueryTest {
     public void before() {
         ds.delete(ds.createQuery(GeoEntity.class));
         ds.getCollection(GeoEntity.class).ensureIndex(new BasicDBObject("location","2d"));
+
+        ds.save(new GeoEntity(10.0, 50.0));
+        ds.save(new GeoEntity(20.0, 50.0));
+        ds.save(new GeoEntity(30.0, 50.0));
     }
 
     @Test
     public void near() {
-        ds.save(new GeoEntity(10.0, 50.0));
-        ds.save(new GeoEntity(20.0, 50.0));
-        ds.save(new GeoEntity(30.0, 50.0));
-
         List<GeoEntity> entities = query().where(geoEntity.location.near(50.0, 50.0)).fetch();
-        assertEquals(30.0, entities.get(0).getLocation()[0], 0.1);
-        assertEquals(20.0, entities.get(1).getLocation()[0], 0.1);
-        assertEquals(10.0, entities.get(2).getLocation()[0], 0.1);
+        assertEntities(entities);
+    }
+
+    @Test
+    public void geojson_near() {
+        List<GeoEntity> entities = query().where(geoEntity.locationAsGeoJson().near(GeoJson.point(50.0, 50.0))).fetch();
+        assertEntities(entities);
     }
 
     @Test
     public void near_sphere() {
-        ds.save(new GeoEntity(10.0, 50.0));
-        ds.save(new GeoEntity(20.0, 50.0));
-        ds.save(new GeoEntity(30.0, 50.0));
-
         List<GeoEntity> entities = query().where(geoEntity.location.nearSphere(50.0, 50.0)).fetch();
+        assertEntities(entities);
+    }
+
+    @Test
+    public void geojson_near_sphere() {
+        List<GeoEntity> entities = query().where(geoEntity.locationAsGeoJson().nearSphere(GeoJson.point(50.0, 50.0))).fetch();
+        assertEntities(entities);
+    }
+
+    private void assertEntities(List<GeoEntity> entities) {
         assertEquals(30.0, entities.get(0).getLocation()[0], 0.1);
         assertEquals(20.0, entities.get(1).getLocation()[0], 0.1);
         assertEquals(10.0, entities.get(2).getLocation()[0], 0.1);

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -13,38 +13,40 @@
  */
 package com.querydsl.mongodb;
 
-import static org.junit.Assert.assertEquals;
-
-import java.net.UnknownHostException;
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mongodb.morphia.Datastore;
-import org.mongodb.morphia.Morphia;
-
+import com.github.fakemongo.junit.FongoRule;
 import com.mongodb.BasicDBObject;
-import com.mongodb.Mongo;
 import com.mongodb.MongoException;
 import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.mongodb.domain.GeoEntity;
 import com.querydsl.mongodb.domain.QGeoEntity;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+
+import java.net.UnknownHostException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 @Category(MongoDB.class)
 public class GeoSpatialQueryTest {
 
+    @Rule
+    public final FongoRule fongoRule = new FongoRule();
+
     private final String dbname = "geodb";
-    private final Mongo mongo;
     private final Morphia morphia;
     private final Datastore ds;
     private final QGeoEntity geoEntity = new QGeoEntity("geoEntity");
 
     public GeoSpatialQueryTest() throws UnknownHostException, MongoException {
-        mongo = new Mongo();
         morphia = new Morphia().map(GeoEntity.class);
-        ds = morphia.createDatastore(mongo, dbname);
+        ds = morphia.createDatastore(fongoRule.getFongo().getMongo(), dbname);
+        ds.ensureIndexes(GeoEntity.class);
     }
 
     @Before

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -20,6 +20,7 @@ import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.mongodb.domain.GeoEntity;
 import com.querydsl.mongodb.domain.QGeoEntity;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,6 +28,8 @@ import org.junit.experimental.categories.Category;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
 import org.mongodb.morphia.geo.GeoJson;
+import org.mongodb.morphia.geo.Geometry;
+import org.mongodb.morphia.query.Shape;
 
 import java.net.UnknownHostException;
 import java.util.List;
@@ -82,6 +85,20 @@ public class GeoSpatialQueryTest {
     public void geojson_near_sphere() {
         List<GeoEntity> entities = query().where(geoEntity.locationAsGeoJson().nearSphere(GeoJson.point(50.0, 50.0))).fetch();
         assertEntities(entities);
+    }
+
+    @Test
+    public void geojson_geoWithin() {
+        Shape boundingBox = Shape.box(new Shape.Point(40, 10), new Shape.Point(60, 40));
+        List<GeoEntity> entities = query().where(geoEntity.location.geoWithin(boundingBox)).fetch();
+        Assert.assertEquals(3, entities.size());
+    }
+
+    @Test
+    public void geojson_geoWithin_geometry() {
+        Geometry geometry = GeoJson.polygon(GeoJson.point(40, 10), GeoJson.point(60, 10), GeoJson.point(60, 40), GeoJson.point(10, 40), GeoJson.point(40, 10));
+        List<GeoEntity> entities = query().where(geoEntity.locationAsGeoJson().geoWithin(geometry)).fetch();
+        Assert.assertEquals(3, entities.size());
     }
 
     private void assertEntities(List<GeoEntity> entities) {

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -73,7 +73,7 @@ public class GeoSpatialQueryTest {
         ds.save(new GeoEntity(20.0, 50.0));
         ds.save(new GeoEntity(30.0, 50.0));
 
-        List<GeoEntity> entities = query().where(MongodbExpressions.nearSphere(geoEntity.location, 50.0, 50.0)).fetch();
+        List<GeoEntity> entities = query().where(geoEntity.location.nearSphere(50.0, 50.0)).fetch();
         assertEquals(30.0, entities.get(0).getLocation()[0], 0.1);
         assertEquals(20.0, entities.get(1).getLocation()[0], 0.1);
         assertEquals(10.0, entities.get(2).getLocation()[0], 0.1);

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
@@ -1,16 +1,6 @@
 package com.querydsl.mongodb;
 
-import static org.junit.Assert.*;
-
-import java.net.UnknownHostException;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mongodb.morphia.Datastore;
-import org.mongodb.morphia.Morphia;
-
-import com.mongodb.Mongo;
+import com.github.fakemongo.junit.FongoRule;
 import com.mongodb.MongoException;
 import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.core.types.Predicate;
@@ -18,11 +8,23 @@ import com.querydsl.mongodb.domain.Item;
 import com.querydsl.mongodb.domain.QUser;
 import com.querydsl.mongodb.domain.User;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.*;
 
 @Category(MongoDB.class)
 public class JoinTest {
 
-    private final Mongo mongo;
+    @Rule
+    public final FongoRule fongoRule = new FongoRule();
+
     private final Morphia morphia;
     private final Datastore ds;
 
@@ -33,9 +35,8 @@ public class JoinTest {
     private final QUser enemy = new QUser("enemy");
 
     public JoinTest() throws UnknownHostException, MongoException {
-        mongo = new Mongo();
         morphia = new Morphia().map(User.class).map(Item.class);
-        ds = morphia.createDatastore(mongo, dbname);
+        ds = morphia.createDatastore(fongoRule.getFongo().getMongo(), dbname);
     }
 
     @Before

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
@@ -13,22 +13,9 @@
  */
 package com.querydsl.mongodb;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
-
-import java.net.UnknownHostException;
-import java.util.*;
-
-import org.bson.types.ObjectId;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mongodb.morphia.Datastore;
-import org.mongodb.morphia.Morphia;
-
+import com.github.fakemongo.junit.FongoRule;
 import com.google.common.collect.Lists;
 import com.mongodb.BasicDBObject;
-import com.mongodb.Mongo;
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.querydsl.core.NonUniqueResultException;
@@ -42,11 +29,26 @@ import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.mongodb.domain.*;
 import com.querydsl.mongodb.domain.User.Gender;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+
+import java.net.UnknownHostException;
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
 
 @Category(MongoDB.class)
 public class MongodbQueryTest {
 
-    private final Mongo mongo;
+    @Rule
+    public final FongoRule fongoRule = new FongoRule();
+
     private final Morphia morphia;
     private final Datastore ds;
 
@@ -62,9 +64,8 @@ public class MongodbQueryTest {
     City tampere, helsinki;
 
     public MongodbQueryTest() throws UnknownHostException, MongoException {
-        mongo = new Mongo();
         morphia = new Morphia().map(User.class).map(Item.class).map(MapEntity.class).map(Dates.class);
-        ds = morphia.createDatastore(mongo, dbname);
+        ds = morphia.createDatastore(fongoRule.getFongo().getMongo(), dbname);
     }
 
     @Before

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
@@ -13,17 +13,6 @@
  */
 package com.querydsl.mongodb;
 
-import static org.junit.Assert.assertEquals;
-
-import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
-import org.bson.types.ObjectId;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
@@ -34,7 +23,20 @@ import com.querydsl.mongodb.domain.QAddress;
 import com.querydsl.mongodb.domain.QDummyEntity;
 import com.querydsl.mongodb.domain.QPerson;
 import com.querydsl.mongodb.domain.QUser;
+import com.querydsl.mongodb.morphia.MorphiaExpressions;
 import com.querydsl.mongodb.morphia.MorphiaSerializer;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.mongodb.morphia.geo.GeoJson;
+import org.mongodb.morphia.geo.QPoint;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class MongodbSerializerTest {
 
@@ -242,9 +244,23 @@ public class MongodbSerializerTest {
     }
 
     @Test
+    public void near_geojson() {
+        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)));
+        BooleanExpression actualExpr = MorphiaExpressions.near(new QPoint("point"), GeoJson.point(2.0, 1.0));
+        assertQuery(actualExpr, dbo("point", dbo("$near", geoJsonPoint)));
+    }
+
+    @Test
     public void near_sphere() {
         assertQuery(MongodbExpressions.nearSphere(new Point("point"), 1.0, 2.0),
                 dbo("point", dbo("$nearSphere", dblist(1.0, 2.0))));
+    }
+
+    @Test
+    public void near_sphere_geojson() {
+        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)));
+        BooleanExpression actualExpr = MorphiaExpressions.nearSphere(new QPoint("point"), GeoJson.point(2.0, 1.0));
+        assertQuery(actualExpr, dbo("point", dbo("$nearSphere", geoJsonPoint)));
     }
 
     @Test

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
@@ -244,9 +244,10 @@ public class MongodbSerializerTest {
     }
 
     @Test
-    public void near_geojson() {
-        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)));
-        BooleanExpression actualExpr = MorphiaExpressions.near(new QPoint("point"), GeoJson.point(2.0, 1.0));
+    public void near_geojson_with_max_distance() {
+        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)))
+                .append("$maxDistance", 20.0);
+        BooleanExpression actualExpr = MorphiaExpressions.near(new QPoint("point"), GeoJson.point(2.0, 1.0), 20.0);
         assertQuery(actualExpr, dbo("point", dbo("$near", geoJsonPoint)));
     }
 
@@ -257,9 +258,10 @@ public class MongodbSerializerTest {
     }
 
     @Test
-    public void near_sphere_geojson() {
-        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)));
-        BooleanExpression actualExpr = MorphiaExpressions.nearSphere(new QPoint("point"), GeoJson.point(2.0, 1.0));
+    public void near_sphere_geojson_with_max_distance() {
+        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)))
+                .append("$maxDistance", 20.0);
+        BooleanExpression actualExpr = MorphiaExpressions.nearSphere(new QPoint("point"), GeoJson.point(2.0, 1.0), 20);
         assertQuery(actualExpr, dbo("point", dbo("$nearSphere", geoJsonPoint)));
     }
 

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
@@ -1,21 +1,21 @@
 package com.querydsl.mongodb;
 
-import static org.junit.Assert.assertEquals;
-
-import java.net.UnknownHostException;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mongodb.morphia.Datastore;
-import org.mongodb.morphia.Morphia;
-
-import com.mongodb.Mongo;
+import com.github.fakemongo.junit.FongoRule;
 import com.mongodb.MongoException;
 import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.mongodb.domain.*;
 import com.querydsl.mongodb.morphia.MorphiaQuery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.assertEquals;
 
 @Category(MongoDB.class)
 public class PolymorphicCollectionTest {
@@ -27,10 +27,12 @@ public class PolymorphicCollectionTest {
     private final Chips c1 = new Chips("c1");
 
     public PolymorphicCollectionTest() throws UnknownHostException, MongoException {
-        final Mongo mongo = new Mongo();
         morphia = new Morphia().map(Food.class);
-        ds = morphia.createDatastore(mongo, "testdb");
+        ds = morphia.createDatastore(fongoRule.getFongo().getMongo(), "testdb");
     }
+
+    @Rule
+    public final FongoRule fongoRule = new FongoRule();
 
     @Before
     public void before() throws UnknownHostException, MongoException {

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/GeoEntity.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/GeoEntity.java
@@ -14,18 +14,23 @@
 package com.querydsl.mongodb.domain;
 
 import org.mongodb.morphia.annotations.*;
+import org.mongodb.morphia.geo.GeoJson;
+import org.mongodb.morphia.geo.Point;
 import org.mongodb.morphia.utils.IndexType;
 
 @Entity
 @Indexes({
-    @Index(options = @IndexOptions(name = "location"), fields = @Field(value = "location", type = IndexType.GEO2D))
+    @Index(options = @IndexOptions(name = "location"), fields = @Field(value = "location", type = IndexType.GEO2D)),
+    @Index(options = @IndexOptions(name = "locationAsGeoJson"), fields = @Field(value = "locationAsGeoJson", type = IndexType.GEO2DSPHERE))
 })
 public class GeoEntity extends AbstractEntity {
 
     private Double[] location;
+    private Point locationAsGeoJson;
 
     public GeoEntity(double l1, double l2) {
-        location = new Double[]{l1, l2};
+        this.location = new Double[]{l1, l2};
+        this.locationAsGeoJson = GeoJson.point(location[0], location[1]);
     }
 
     public GeoEntity() { }
@@ -34,9 +39,13 @@ public class GeoEntity extends AbstractEntity {
         return location;
     }
 
-    public void setLocation(Double[] location) {
-        this.location = location;
+    public Point getLocationAsGeoJson() {
+        return locationAsGeoJson;
     }
 
+    public void setLocation(double l1, double l2) {
+        this.location = new Double[]{l1, l2};
+        this.locationAsGeoJson = GeoJson.point(location[0], location[1]);
+    }
 
 }

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/GeoEntity.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/GeoEntity.java
@@ -13,9 +13,13 @@
  */
 package com.querydsl.mongodb.domain;
 
-import org.mongodb.morphia.annotations.Entity;
+import org.mongodb.morphia.annotations.*;
+import org.mongodb.morphia.utils.IndexType;
 
 @Entity
+@Indexes({
+    @Index(options = @IndexOptions(name = "location"), fields = @Field(value = "location", type = IndexType.GEO2D))
+})
 public class GeoEntity extends AbstractEntity {
 
     private Double[] location;


### PR DESCRIPTION
add support for mongodb [$geoWithin operator](https://docs.mongodb.com/v2.6/reference/operator/query/geoWithin/) and Morphia GeoJSON classes

extends initial work done as part of '[Support for geospatial queries in Mongodb](https://bugs.launchpad.net/querydsl/+bug/727942)'

extend $near operator to support optional [$maxDistance parameter](https://docs.mongodb.com/v2.6/reference/operator/query/maxDistance/#op._S_maxDistance)

upgrade MongoDB driver and Morphia versions

upgrade MongoDB tests to use [Fongo](https://github.com/fakemongo/fongo) in-memory test double