### PR TITLE
add support for MongoDB GeoJSON Points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <animal-sniffer.version>1.14</animal-sniffer.version>
 
     <jdo.version>3.0.1</jdo.version>
-    <morphia.version>0.105</morphia.version>
+    <morphia.version>0.111</morphia.version>
     
     <!-- Import-Package definitions for maven-bundle-plugin -->
     <osgi.import.package.root>

--- a/querydsl-mongodb/pom.xml
+++ b/querydsl-mongodb/pom.xml
@@ -16,10 +16,10 @@
   <packaging>jar</packaging>
 
   <properties>
-    <mongodb.version>2.10.0</mongodb.version>
+    <mongodb.version>2.13.0</mongodb.version>
     <osgi.import.package>
       com.mongodb;version="0.0.0",
-      org.mongodb.morphia.*;version="0.105",
+      org.mongodb.morphia.*;version="0.111",
       org.bson.*;version="0.0.0",
       ${osgi.import.package.root}
     </osgi.import.package>

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/Point.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/Point.java
@@ -51,4 +51,8 @@ public class Point extends ArrayPath<Double[], Double> {
         return MongodbExpressions.near(this, latVal, longVal);
     }
 
+    public BooleanExpression nearSphere(double latVal, double longVal) {
+        return MongodbExpressions.nearSphere(this, latVal, longVal);
+    }
+
 }

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaExpressions.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.morphia;
+
+import org.mongodb.morphia.geo.Point;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.mongodb.MongodbOps;
+
+/**
+ * Morphia specific MongoDB operations
+ *
+ * @author jmoghisi
+ *
+ */
+public final class MorphiaExpressions {
+
+    private MorphiaExpressions() { }
+
+    /**
+     * Finds the closest points relative to the given location and orders the results with decreasing proximity
+     *
+     * @param expr expression
+     * @param point location
+     * @return predicate
+     */
+    public static BooleanExpression near(Expression<Point> expr, Point point) {
+        return Expressions.booleanOperation(MongodbOps.NEAR, expr, Expressions.constant(point));
+    }
+
+    /**
+     * Finds the closest points relative to the given location on a sphere and orders the results with decreasing proximity
+     *
+     * @param expr expression
+     * @param point location
+     * @return predicate
+     */
+    public static BooleanExpression nearSphere(Expression<Point> expr, Point point) {
+        return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, Expressions.constant(point));
+    }
+
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaSerializer.java
@@ -24,6 +24,7 @@ import org.mongodb.morphia.geo.Geometry;
 import org.mongodb.morphia.geo.GeometryQueryConverter;
 import org.mongodb.morphia.mapping.Mapper;
 
+import com.google.common.base.Preconditions;
 import com.mongodb.DBRef;
 import com.querydsl.core.types.Constant;
 import com.querydsl.core.types.Path;
@@ -42,8 +43,9 @@ public class MorphiaSerializer extends MongodbSerializer {
     private final GeometryQueryConverter geometryQueryConverter;
 
     public MorphiaSerializer(Morphia morphia) {
-        this.morphia = morphia == null ? new Morphia() : morphia;
-        this.geometryQueryConverter = new GeometryQueryConverter(this.morphia.getMapper());
+        Preconditions.checkNotNull(morphia);
+        this.morphia = morphia;
+        this.geometryQueryConverter = new GeometryQueryConverter(morphia.getMapper());
     }
 
     @Override

--- a/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
+++ b/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
@@ -1,0 +1,38 @@
+package org.mongodb.morphia.geo;
+
+import javax.annotation.Nullable;
+
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.mongodb.morphia.MorphiaExpressions;
+
+/**
+ * {@code QPoint} is an adapter type for Point to use geo spatial querying features of Mongodb
+ *
+ * @author jmoghisi
+ *
+ */
+public class QPoint extends EntityPathBase<Point> {
+
+    public QPoint(String variable) {
+        super(Point.class, variable);
+    }
+
+    public QPoint(PathMetadata metadata) {
+        super(Point.class, metadata);
+    }
+
+    public QPoint(PathMetadata metadata, @Nullable PathInits inits) {
+        super(Point.class, metadata, inits);
+    }
+
+    public BooleanExpression near(Point point) {
+        return MorphiaExpressions.near(this, point);
+    }
+
+    public BooleanExpression nearSphere(Point point) {
+        return MorphiaExpressions.nearSphere(this, point);
+    }
+}

--- a/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
+++ b/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/QPoint.java
@@ -1,31 +1,55 @@
 package org.mongodb.morphia.geo;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.AnnotatedElement;
 
-import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.EntityPathBase;
-import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.mongodb.morphia.MorphiaExpressions;
 
 /**
- * {@code QPoint} is an adapter type for Point to use geo spatial querying features of Mongodb
+ * {@code QPoint} represents Point paths, needed to support geo spatial querying features of Mongodb
  *
  * @author jmoghisi
  *
  */
-public class QPoint extends EntityPathBase<Point> {
+public class QPoint extends SimpleExpression<Point> implements Path<Point> {
 
-    public QPoint(String variable) {
-        super(Point.class, variable);
+    private final PathImpl<Point> pathMixin;
+
+    public QPoint(String var) {
+        this(PathMetadataFactory.forVariable(var));
+    }
+
+    public QPoint(Path<?> parent, String property) {
+        this(PathMetadataFactory.forProperty(parent, property));
     }
 
     public QPoint(PathMetadata metadata) {
-        super(Point.class, metadata);
+        super(ExpressionUtils.path(Point.class, metadata));
+        this.pathMixin = (PathImpl<Point>) mixin;
     }
 
-    public QPoint(PathMetadata metadata, @Nullable PathInits inits) {
-        super(Point.class, metadata, inits);
+    @Override
+    public PathMetadata getMetadata() {
+        return pathMixin.getMetadata();
+    }
+
+    @Override
+    public Path<?> getRoot() {
+        return pathMixin.getRoot();
+    }
+
+    @Override
+    public AnnotatedElement getAnnotatedElement() {
+        return pathMixin.getAnnotatedElement();
+    }
+
+    @Nullable
+    @Override
+    public <R, C> R accept(Visitor<R, C> v, @Nullable C context) {
+        return v.visit(pathMixin, context);
     }
 
     public BooleanExpression near(Point point) {
@@ -35,4 +59,5 @@ public class QPoint extends EntityPathBase<Point> {
     public BooleanExpression nearSphere(Point point) {
         return MorphiaExpressions.nearSphere(this, point);
     }
+
 }

--- a/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/package-info.java
+++ b/querydsl-mongodb/src/main/java/org/mongodb/morphia/geo/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * MongoDB geo support
+ */
+package org.mongodb.morphia.geo;

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -71,7 +71,7 @@ public class GeoSpatialQueryTest {
         ds.save(new GeoEntity(20.0, 50.0));
         ds.save(new GeoEntity(30.0, 50.0));
 
-        List<GeoEntity> entities = query().where(MongodbExpressions.nearSphere(geoEntity.location, 50.0, 50.0)).fetch();
+        List<GeoEntity> entities = query().where(geoEntity.location.nearSphere(50.0, 50.0)).fetch();
         assertEquals(30.0, entities.get(0).getLocation()[0], 0.1);
         assertEquals(20.0, entities.get(1).getLocation()[0], 0.1);
         assertEquals(10.0, entities.get(2).getLocation()[0], 0.1);

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -25,7 +25,7 @@ import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
 import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.mongodb.domain.GeoEntity;
@@ -36,13 +36,13 @@ import com.querydsl.mongodb.morphia.MorphiaQuery;
 public class GeoSpatialQueryTest {
 
     private final String dbname = "geodb";
-    private final Mongo mongo;
+    private final MongoClient mongo;
     private final Morphia morphia;
     private final Datastore ds;
     private final QGeoEntity geoEntity = new QGeoEntity("geoEntity");
 
     public GeoSpatialQueryTest() throws UnknownHostException, MongoException {
-        mongo = new Mongo();
+        mongo = new MongoClient();
         morphia = new Morphia().map(GeoEntity.class);
         ds = morphia.createDatastore(mongo, dbname);
     }

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/GeoSpatialQueryTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
+import org.mongodb.morphia.geo.GeoJson;
+import org.mongodb.morphia.utils.IndexType;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
@@ -50,28 +52,43 @@ public class GeoSpatialQueryTest {
     @Before
     public void before() {
         ds.delete(ds.createQuery(GeoEntity.class));
-        ds.getCollection(GeoEntity.class).ensureIndex(new BasicDBObject("location","2d"));
+
+        String locationFieldName = QGeoEntity.geoEntity.location.getMetadata().getName();
+        ds.getCollection(GeoEntity.class).createIndex(new BasicDBObject(locationFieldName, IndexType.GEO2D.toIndexValue()));
+
+        String geoJsonLocationFieldName = QGeoEntity.geoEntity.locationAsGeoJson().getMetadata().getName();
+        ds.getCollection(GeoEntity.class).createIndex(new BasicDBObject(geoJsonLocationFieldName, IndexType.GEO2DSPHERE.toIndexValue()));
+
+        ds.save(new GeoEntity(10.0, 50.0));
+        ds.save(new GeoEntity(20.0, 50.0));
+        ds.save(new GeoEntity(30.0, 50.0));
     }
 
     @Test
     public void near() {
-        ds.save(new GeoEntity(10.0, 50.0));
-        ds.save(new GeoEntity(20.0, 50.0));
-        ds.save(new GeoEntity(30.0, 50.0));
-
         List<GeoEntity> entities = query().where(geoEntity.location.near(50.0, 50.0)).fetch();
-        assertEquals(30.0, entities.get(0).getLocation()[0], 0.1);
-        assertEquals(20.0, entities.get(1).getLocation()[0], 0.1);
-        assertEquals(10.0, entities.get(2).getLocation()[0], 0.1);
+        assertEntities(entities);
+    }
+
+    @Test
+    public void geojson_near() {
+        List<GeoEntity> entities = query().where(geoEntity.locationAsGeoJson().near(GeoJson.point(50.0, 50.0))).fetch();
+        assertEntities(entities);
     }
 
     @Test
     public void near_sphere() {
-        ds.save(new GeoEntity(10.0, 50.0));
-        ds.save(new GeoEntity(20.0, 50.0));
-        ds.save(new GeoEntity(30.0, 50.0));
-
         List<GeoEntity> entities = query().where(geoEntity.location.nearSphere(50.0, 50.0)).fetch();
+        assertEntities(entities);
+    }
+
+    @Test
+    public void geojson_near_sphere() {
+        List<GeoEntity> entities = query().where(geoEntity.locationAsGeoJson().nearSphere(GeoJson.point(50.0, 50.0))).fetch();
+        assertEntities(entities);
+    }
+
+    private void assertEntities(List<GeoEntity> entities) {
         assertEquals(30.0, entities.get(0).getLocation()[0], 0.1);
         assertEquals(20.0, entities.get(1).getLocation()[0], 0.1);
         assertEquals(10.0, entities.get(2).getLocation()[0], 0.1);

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
@@ -10,7 +10,7 @@ import org.junit.experimental.categories.Category;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
 
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
 import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.core.types.Predicate;
@@ -22,7 +22,7 @@ import com.querydsl.mongodb.morphia.MorphiaQuery;
 @Category(MongoDB.class)
 public class JoinTest {
 
-    private final Mongo mongo;
+    private final MongoClient mongo;
     private final Morphia morphia;
     private final Datastore ds;
 
@@ -33,7 +33,7 @@ public class JoinTest {
     private final QUser enemy = new QUser("enemy");
 
     public JoinTest() throws UnknownHostException, MongoException {
-        mongo = new Mongo();
+        mongo = new MongoClient();
         morphia = new Morphia().map(User.class).map(Item.class);
         ds = morphia.createDatastore(mongo, dbname);
     }

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
@@ -28,7 +28,7 @@ import org.mongodb.morphia.Morphia;
 
 import com.google.common.collect.Lists;
 import com.mongodb.BasicDBObject;
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.querydsl.core.NonUniqueResultException;
@@ -46,7 +46,7 @@ import com.querydsl.mongodb.morphia.MorphiaQuery;
 @Category(MongoDB.class)
 public class MongodbQueryTest {
 
-    private final Mongo mongo;
+    private final MongoClient mongo;
     private final Morphia morphia;
     private final Datastore ds;
 
@@ -62,7 +62,7 @@ public class MongodbQueryTest {
     City tampere, helsinki;
 
     public MongodbQueryTest() throws UnknownHostException, MongoException {
-        mongo = new Mongo();
+        mongo = new MongoClient();
         morphia = new Morphia().map(User.class).map(Item.class).map(MapEntity.class).map(Dates.class);
         ds = morphia.createDatastore(mongo, dbname);
     }

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
+import org.mongodb.morphia.geo.GeoJson;
+import org.mongodb.morphia.geo.QPoint;
 
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
@@ -34,6 +36,7 @@ import com.querydsl.mongodb.domain.QAddress;
 import com.querydsl.mongodb.domain.QDummyEntity;
 import com.querydsl.mongodb.domain.QPerson;
 import com.querydsl.mongodb.domain.QUser;
+import com.querydsl.mongodb.morphia.MorphiaExpressions;
 import com.querydsl.mongodb.morphia.MorphiaSerializer;
 
 public class MongodbSerializerTest {
@@ -242,9 +245,23 @@ public class MongodbSerializerTest {
     }
 
     @Test
+    public void near_geojson() {
+        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)));
+        BooleanExpression actualExpr = MorphiaExpressions.near(new QPoint("point"), GeoJson.point(2.0, 1.0));
+        assertQuery(actualExpr, dbo("point", dbo("$near", geoJsonPoint)));
+    }
+
+    @Test
     public void near_sphere() {
         assertQuery(MongodbExpressions.nearSphere(new Point("point"), 1.0, 2.0),
                 dbo("point", dbo("$nearSphere", dblist(1.0, 2.0))));
+    }
+
+    @Test
+    public void near_sphere_geojson() {
+        DBObject geoJsonPoint = dbo("$geometry", dbo("type", "Point").append("coordinates", dblist(1.0, 2.0)));
+        BooleanExpression actualExpr = MorphiaExpressions.nearSphere(new QPoint("point"), GeoJson.point(2.0, 1.0));
+        assertQuery(actualExpr, dbo("point", dbo("$nearSphere", geoJsonPoint)));
     }
 
     @Test

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
+import org.mongodb.morphia.Morphia;
 import org.mongodb.morphia.geo.GeoJson;
 import org.mongodb.morphia.geo.QPoint;
 
@@ -60,7 +61,7 @@ public class MongodbSerializerTest {
 
     @Before
     public void before() {
-        serializer = new MorphiaSerializer(null);
+        serializer = new MorphiaSerializer(new Morphia());
         entityPath = new PathBuilder<Object>(Object.class, "obj");
         title = entityPath.getString("title");
         year = entityPath.getNumber("year", Integer.class);

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/PolymorphicCollectionTest.java
@@ -10,7 +10,7 @@ import org.junit.experimental.categories.Category;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
 
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
 import com.querydsl.core.testutil.MongoDB;
 import com.querydsl.core.types.Predicate;
@@ -27,7 +27,7 @@ public class PolymorphicCollectionTest {
     private final Chips c1 = new Chips("c1");
 
     public PolymorphicCollectionTest() throws UnknownHostException, MongoException {
-        final Mongo mongo = new Mongo();
+        final MongoClient mongo = new MongoClient();
         morphia = new Morphia().map(Food.class);
         ds = morphia.createDatastore(mongo, "testdb");
     }

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/GeoEntity.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/GeoEntity.java
@@ -14,14 +14,18 @@
 package com.querydsl.mongodb.domain;
 
 import org.mongodb.morphia.annotations.Entity;
+import org.mongodb.morphia.geo.GeoJson;
+import org.mongodb.morphia.geo.Point;
 
 @Entity
 public class GeoEntity extends AbstractEntity {
 
     private Double[] location;
+    private Point locationAsGeoJson;
 
     public GeoEntity(double l1, double l2) {
-        location = new Double[]{l1, l2};
+        this.location = new Double[]{l1, l2};
+        this.locationAsGeoJson = GeoJson.point(location[0], location[1]);
     }
 
     public GeoEntity() { }
@@ -30,9 +34,13 @@ public class GeoEntity extends AbstractEntity {
         return location;
     }
 
-    public void setLocation(Double[] location) {
-        this.location = location;
+    public Point getLocationAsGeoJson() {
+        return locationAsGeoJson;
     }
 
+    public void setLocation(double l1, double l2) {
+        this.location = new Double[]{l1, l2};
+        this.locationAsGeoJson = GeoJson.point(location[0], location[1]);
+    }
 
 }


### PR DESCRIPTION
extends initial work done as part of '[Support for geospatial queries in Mongodb](https://bugs.launchpad.net/querydsl/+bug/727942)' to add support for querying using a GeoJSON point instead of legacy coordinates

upgrade MongoDB driver and Morphia versions
