### PR TITLE
jpa doc Customer entity code invalide "[" token

### DIFF
--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
@@ -227,7 +227,7 @@ public class Customer {
         firstName = fn;
     }
 
-    public void setLastName(String ln)[
+    public void setLastName(String ln) {
         lastName = ln;
     }
 }


### PR DESCRIPTION
In Jpa document, Customer entity code has wrong token "[" in "setLastName" method. Replacing "[" to "{" make setLastName method become  valid.
