### PR TITLE
enable Morphia converters

### DIFF
--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/morphia/MorphiaSerializer.java
@@ -23,6 +23,7 @@ import org.mongodb.morphia.annotations.Reference;
 import org.mongodb.morphia.mapping.Mapper;
 
 import com.mongodb.DBRef;
+import com.querydsl.core.types.Constant;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.PathMetadata;
 import com.querydsl.mongodb.MongodbSerializer;
@@ -39,6 +40,12 @@ public class MorphiaSerializer extends MongodbSerializer {
 
     public MorphiaSerializer(Morphia morphia) {
         this.morphia = morphia;
+    }
+
+    @Override
+    public Object visit(Constant<?> expr, Void context) {
+        Object value = super.visit(expr, context);
+        return morphia.getMapper().toMongoObject(null, null, value);
     }
 
     @Override

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
@@ -56,6 +56,7 @@ public class MongodbQueryTest {
     private final QAddress address = QAddress.address;
     private final QMapEntity mapEntity = QMapEntity.mapEntity;
     private final QDates dates = QDates.dates;
+    private final QCountry country = QCountry.country;
 
     List<User> users = Lists.newArrayList();
     User u1, u2, u3, u4;
@@ -71,6 +72,7 @@ public class MongodbQueryTest {
     public void before() throws UnknownHostException, MongoException {
         ds.delete(ds.createQuery(Item.class));
         ds.delete(ds.createQuery(User.class));
+        ds.delete(ds.createQuery(Country.class));
         ds.delete(ds.createQuery(MapEntity.class));
 
         tampere = new City("Tampere", 61.30, 23.50);
@@ -589,6 +591,15 @@ public class MongodbQueryTest {
         assertEquals(
                 new BasicDBObject().append("firstName", "Bob").append("lastName", "Wilson"),
                 query.asDBObject());
+    }
+
+    @Test
+    public void converter() {
+        Country germany = new Country("Germany", Locale.GERMANY);
+        ds.save(germany);
+
+        Country fetchedCountry = query(Country.class).where(country.defaultLocale.eq(Locale.GERMANY)).fetchOne();
+        assertEquals(germany, fetchedCountry);
     }
 
     //TODO

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbSerializerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
+import org.mongodb.morphia.Morphia;
 
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
@@ -57,7 +58,7 @@ public class MongodbSerializerTest {
 
     @Before
     public void before() {
-        serializer = new MorphiaSerializer(null);
+        serializer = new MorphiaSerializer(new Morphia());
         entityPath = new PathBuilder<Object>(Object.class, "obj");
         title = entityPath.getString("title");
         year = entityPath.getNumber("year", Integer.class);

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Country.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/Country.java
@@ -1,0 +1,29 @@
+package com.querydsl.mongodb.domain;
+
+import java.util.Locale;
+
+import org.mongodb.morphia.annotations.Converters;
+import org.mongodb.morphia.annotations.Entity;
+
+@Entity
+@Converters(LocaleConverter.class)
+public class Country extends AbstractEntity {
+    private String name;
+    private Locale defaultLocale;
+
+    Country() { }
+
+    public Country(String name, Locale defaultLocale) {
+        this.name = name;
+        this.defaultLocale = defaultLocale;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Locale getDefaultLocale() {
+        return defaultLocale;
+    }
+
+}

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/LocaleConverter.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain/LocaleConverter.java
@@ -1,0 +1,38 @@
+package com.querydsl.mongodb.domain;
+
+import java.util.Locale;
+
+import org.mongodb.morphia.converters.SimpleValueConverter;
+import org.mongodb.morphia.converters.TypeConverter;
+import org.mongodb.morphia.mapping.MappedField;
+import org.mongodb.morphia.mapping.MappingException;
+
+public class LocaleConverter extends TypeConverter implements SimpleValueConverter {
+
+    public LocaleConverter() {
+        super(Locale.class);
+    }
+
+    @Override
+    public final Object encode(Object value, MappedField optionalExtraInfo) throws MappingException {
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Locale)) {
+            throw new MappingException("Unable to convert " + value.getClass().getName());
+        }
+        return ((Locale) value).toLanguageTag();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Locale decode(Class targetClass, Object fromDBObject, MappedField optionalExtraInfo) throws MappingException {
+        if (fromDBObject == null) {
+            return null;
+        }
+        if (fromDBObject instanceof String) {
+            return Locale.forLanguageTag((String) fromDBObject);
+        }
+        throw new MappingException("Unable to convert " + fromDBObject.getClass().getName());
+    }
+}


### PR DESCRIPTION
Most of MongoDB queries is built without Morphia, so that converters are not automatically integrated. This pull request adds an explicit call to the mapper.
