### PR TITLE
make NOTE diagnostic printing in APT optional

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/APTOptions.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/APTOptions.java
@@ -96,6 +96,11 @@ public final class APTOptions {
      */
     public static final String QUERYDSL_VARIABLE_NAME_FUNCTION_CLASS = "querydsl.variableNameFunctionClass";
 
+    /**
+     * set whether info level messages should be written to stdout (default: false)
+     */
+    public static final String QUERYDSL_LOG_INFO = "querydsl.logInfo";
+
     private APTOptions() { }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/AbstractProcessorTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/AbstractProcessorTest.java
@@ -66,8 +66,8 @@ public abstract class AbstractProcessorTest {
         options.addAll(getAPTOptions());
         options.addAll(classes);
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = getStdOut();
+        ByteArrayOutputStream err = getStdErr();
         int compilationResult = compiler.run(null, out, err, options.toArray(new String[options.size()]));
 
 //        Processor.elementCache.clear();
@@ -75,6 +75,14 @@ public abstract class AbstractProcessorTest {
             System.err.println(compiler.getClass().getName());
             Assert.fail("Compilation Failed:\n " + new String(err.toByteArray(), "UTF-8"));
         }
+    }
+
+    protected ByteArrayOutputStream getStdOut() {
+        return new ByteArrayOutputStream();
+    }
+
+    protected ByteArrayOutputStream getStdErr() {
+        return new ByteArrayOutputStream();
     }
 
     protected Collection<String> getAPTOptions() {

--- a/querydsl-apt/src/test/java/com/querydsl/apt/NoteTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/NoteTest.java
@@ -1,0 +1,63 @@
+package com.querydsl.apt;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class NoteTest extends AbstractProcessorTest {
+
+    private Collection<String> aptOptions;
+
+    private ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+    private static final String packagePath = "src/test/java/com/querydsl/apt/";
+
+    public void process() throws IOException {
+        List<String> classes = getFiles(packagePath);
+        process(QuerydslAnnotationProcessor.class, classes, "includedClasses");
+    }
+
+    @Override
+    protected Collection<String> getAPTOptions() {
+        return aptOptions;
+    }
+
+    @Override
+    protected ByteArrayOutputStream getStdErr() {
+        return err;
+    }
+
+    protected boolean isStdErrEmpty() {
+        return getStdErr().toByteArray().length == 0;
+    }
+
+    @Test
+    public void processDefault() throws IOException {
+        aptOptions = Collections.emptyList();
+        process();
+        assertTrue(isStdErrEmpty());
+    }
+
+    @Test
+    public void processEnabled() throws IOException {
+        aptOptions = Arrays.asList("-Aquerydsl.logInfo=true");
+        process();
+        assertFalse(isStdErrEmpty());
+    }
+
+    @Test
+    public void processDisabled() throws IOException {
+        aptOptions = Arrays.asList("-Aquerydsl.logInfo=false");
+        process();
+        assertTrue(isStdErrEmpty());
+    }
+
+}


### PR DESCRIPTION
Since javac doesn't support hiding only NOTE diagnostic messages,
you have to hide them together with WARN. That's usually not what
you want however, since compiler WARN messages might point out
bugs in your code, so you would want to leave them on.

Solution is to not print NOTE by default and enable it with an
additional compiler arg with -A:
http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html#options

With this change that means you can pass -Aquerydsl.logInfo=true
will
enable NOTE messages, but by default they are not logged.

resolves #2032
