### PR TITLE
Enable AntMetaDataExporter "namingStrategyClass" and "beanSerializerClass" properties

### DIFF
--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
@@ -121,12 +121,12 @@ public class AntMetaDataExporter extends Task {
     /**
      * naming strategy class to override (default: DefaultNamingStrategy)
      */
-    private String namingStrategyClass;
+    private String namingStrategyClass = DefaultNamingStrategy.class.getName();
 
     /**
-     * bean serializer class
+     * bean serializer class (default: BeanSerializer)
      */
-    private String beanSerializerClass;
+    private String beanSerializerClass = BeanSerializer.class.getName();
 
     /**
      * serializer class to override
@@ -286,7 +286,6 @@ public class AntMetaDataExporter extends Task {
             dbConn = DriverManager.getConnection(jdbcUrl, jdbcUser, jdbcPassword);
             Configuration configuration = new Configuration(SQLTemplates.DEFAULT);
 
-            NamingStrategy namingStrategy = new DefaultNamingStrategy();
             MetaDataExporter exporter = new MetaDataExporter();
             if (namePrefix != null) {
                 exporter.setNamePrefix(namePrefix);
@@ -306,7 +305,7 @@ public class AntMetaDataExporter extends Task {
             exporter.setPackageName(packageName);
             exporter.setBeanPackageName(beanPackageName);
             exporter.setTargetFolder(new File(targetFolder));
-            exporter.setNamingStrategy(namingStrategy);
+            exporter.setNamingStrategy((NamingStrategy) Class.forName(namingStrategyClass).newInstance());
             exporter.setInnerClassesForKeys(innerClassesForKeys);
             exporter.setSchemaPattern(schemaPattern);
             exporter.setTableNamePattern(tableNamePattern);
@@ -329,7 +328,7 @@ public class AntMetaDataExporter extends Task {
             }
 
             if (exportBeans) {
-                BeanSerializer serializer = new BeanSerializer();
+                BeanSerializer serializer = (BeanSerializer) Class.forName(beanSerializerClass).newInstance();
                 if (beanInterfaces != null) {
                     for (String iface : beanInterfaces) {
                         int sepIndex = iface.lastIndexOf('.');


### PR DESCRIPTION
AntMetaDataExporter "namingStrategyClass" and "beanSerializerClass" properties are being ignored and therefore one cannot change the defaults (DefaultNamingStrategy and BeanSerializer, respectively).
