### PR TITLE
2052: Fixed problem with custom types in ant metadata exporter

### DIFF
--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
@@ -176,7 +176,7 @@ public class AntMetaDataExporter extends Task {
     /**
      * custom types to use
      */
-    private String[] customTypes;
+    private List<String> customTypes = Lists.newArrayList();
 
     /**
      * scala generation mode
@@ -592,12 +592,11 @@ public class AntMetaDataExporter extends Task {
         this.columnAnnotations = columnAnnotations;
     }
 
-    public String[] getCustomTypes() {
-        return customTypes;
-    }
-
-    public void setCustomTypes(String[] customTypes) {
-        this.customTypes = customTypes;
+    /**
+     * Adds custom type to ant
+     */
+    public void addCustomType(String customType) {
+        customTypes.add(customType);
     }
 
     public boolean isCreateScalaSources() {

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
@@ -600,6 +600,34 @@ public class AntMetaDataExporter extends Task {
         customTypes.add(customType);
     }
 
+    /**
+     * Gets a list of custom types
+     * @return a list of custom types
+     * @deprecated Use addCustomType instead
+     */
+    public String[] getCustomTypes() {
+        String[] customTypes = new String[this.customTypes.size()];
+        for (int i = 0; i < this.customTypes.size(); i++) {
+            CustomType customType = this.customTypes.get(i);
+            customTypes[i] = customType.getClassName();
+        }
+        return customTypes;
+    }
+
+    /**
+     * Sets a list of custom types
+     * @param strings a list of custom types
+     * @deprecated Use addCustomType instead
+     */
+    public void setCustomTypes(String[] strings) {
+        this.customTypes.clear();
+        for (String string : strings) {
+            CustomType customType = new CustomType();
+            customType.setClassName(string);
+            this.customTypes.add(customType);
+        }
+    }
+
     public boolean isCreateScalaSources() {
         return createScalaSources;
     }

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
@@ -31,6 +31,7 @@ import com.querydsl.sql.SQLTemplates;
 import com.querydsl.sql.codegen.DefaultNamingStrategy;
 import com.querydsl.sql.codegen.MetaDataExporter;
 import com.querydsl.sql.codegen.NamingStrategy;
+import com.querydsl.sql.codegen.support.CustomType;
 import com.querydsl.sql.codegen.support.NumericMapping;
 import com.querydsl.sql.codegen.support.RenameMapping;
 import com.querydsl.sql.codegen.support.TypeMapping;
@@ -176,7 +177,7 @@ public class AntMetaDataExporter extends Task {
     /**
      * custom types to use
      */
-    private List<String> customTypes = Lists.newArrayList();
+    private List<CustomType> customTypes = Lists.newArrayList();
 
     /**
      * scala generation mode
@@ -351,8 +352,8 @@ public class AntMetaDataExporter extends Task {
                 exporter.setSourceEncoding(sourceEncoding);
             }
             if (customTypes != null) {
-                for (String cl : customTypes) {
-                    configuration.register((Type<?>) Class.forName(cl).newInstance());
+                for (CustomType customType : customTypes) {
+                    configuration.register((Type<?>) Class.forName(customType.getClassName()).newInstance());
                 }
             }
             if (typeMappings != null) {
@@ -595,7 +596,7 @@ public class AntMetaDataExporter extends Task {
     /**
      * Adds custom type to ant
      */
-    public void addCustomType(String customType) {
+    public void addCustomType(CustomType customType) {
         customTypes.add(customType);
     }
 

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/CustomType.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/CustomType.java
@@ -1,0 +1,19 @@
+package com.querydsl.sql.codegen.support;
+
+/**
+ * Models a custom type for the AntMetaDataExporter
+ */
+public class CustomType {
+  private String className;
+
+  public CustomType() {
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public void setClassName(String aClassName) {
+    className = aClassName;
+  }
+}


### PR DESCRIPTION
Fixed problem with AntMetaDataExporter not being able to add custom types using build.xml file, or a gradle ant task.

This was already fixed for typeMapping, numericMapping and renameMapping. Now it also works for customTypes.

I also removed the setter/getter as these are not needed for nested elements

Check https://ant.apache.org/manual/develop.html for details on what setters are supported. You can also check it for more details on nested elements.