### PR TITLE
Added requiresSchemaInWhere option to SQLTemplates.

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/CUBRIDTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/CUBRIDTemplates.java
@@ -53,7 +53,7 @@ public class CUBRIDTemplates extends SQLTemplates {
     }
 
     public CUBRIDTemplates(char escape, boolean quote) {
-        super(Keywords.CUBRID, "\"", escape, quote);
+        super(Keywords.CUBRID, "\"", escape, quote, false);
         setDummyTable(null);
         addCustomType(NumericBooleanType.DEFAULT);
         setParameterMetadataAvailable(false);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/DB2Templates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/DB2Templates.java
@@ -61,7 +61,7 @@ public class DB2Templates extends SQLTemplates {
     }
 
     public DB2Templates(char escape, boolean quote) {
-        super(Keywords.DB2, "\"", escape, quote);
+        super(Keywords.DB2, "\"", escape, quote, false);
         setDummyTable("sysibm.sysdummy1");
         setAutoIncrement(" generated always as identity");
         setFunctionJoinsWrapped(true);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/DerbyTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/DerbyTemplates.java
@@ -54,7 +54,7 @@ public class DerbyTemplates extends SQLTemplates {
     }
 
     public DerbyTemplates(char escape, boolean quote) {
-        super(Keywords.DERBY, "\"", escape, quote);
+        super(Keywords.DERBY, "\"", escape, quote, true);
         setDummyTable("sysibm.sysdummy1");
         setAutoIncrement(" generated always as identity");
         setFunctionJoinsWrapped(true);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/FirebirdTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/FirebirdTemplates.java
@@ -51,7 +51,7 @@ public class FirebirdTemplates extends SQLTemplates {
     }
 
     public FirebirdTemplates(char escape, boolean quote) {
-        super(Keywords.FIREBIRD, "\"", escape, quote);
+        super(Keywords.FIREBIRD, "\"", escape, quote, false);
         setDummyTable("RDB$DATABASE");
         setUnionsWrapped(false);
         setWrapSelectParameters(true);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/H2Templates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/H2Templates.java
@@ -46,7 +46,7 @@ public class H2Templates extends SQLTemplates {
     }
 
     public H2Templates(char escape, boolean quote) {
-        super(Keywords.H2, "\"", escape, quote);
+        super(Keywords.H2, "\"", escape, quote, false);
         setNativeMerge(true);
         setMaxLimit(2 ^ 31);
         setLimitRequired(true);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/HSQLDBTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/HSQLDBTemplates.java
@@ -46,7 +46,7 @@ public class HSQLDBTemplates extends SQLTemplates {
     }
 
     public HSQLDBTemplates(char escape, boolean quote) {
-        super(Keywords.HSQLDB, "\"", escape, quote);
+        super(Keywords.HSQLDB, "\"", escape, quote, false);
         setLimitRequired(true);
         setAutoIncrement(" identity");
         setDefaultValues("\ndefault values");

--- a/querydsl-sql/src/main/java/com/querydsl/sql/MySQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/MySQLTemplates.java
@@ -56,7 +56,7 @@ public class MySQLTemplates extends SQLTemplates {
     }
 
     public MySQLTemplates(char escape, boolean quote) {
-        super(Keywords.MYSQL, "`", escape, quote);
+        super(Keywords.MYSQL, "`", escape, quote, false);
         setArraysSupported(false);
         setParameterMetadataAvailable(false);
         setLimitRequired(true);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
@@ -72,7 +72,7 @@ public class OracleTemplates extends SQLTemplates {
     }
 
     public OracleTemplates(char escape, boolean quote) {
-        super(Keywords.ORACLE, "\"", escape, quote);
+        super(Keywords.ORACLE, "\"", escape, quote, false);
         setParameterMetadataAvailable(false);
         setBatchCountViaGetUpdateCount(true);
         setWithRecursive("with ");

--- a/querydsl-sql/src/main/java/com/querydsl/sql/PostgreSQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/PostgreSQLTemplates.java
@@ -48,7 +48,7 @@ public class PostgreSQLTemplates extends SQLTemplates {
     }
 
     public PostgreSQLTemplates(char escape, boolean quote) {
-        super(Keywords.POSTGRESQL, "\"", escape, quote);
+        super(Keywords.POSTGRESQL, "\"", escape, quote, false);
         setDummyTable(null);
         setCountDistinctMultipleColumns(true);
         setCountViaAnalytics(true);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
@@ -471,7 +471,21 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
         dmlWithSchema = false;
 
         if (metadata.getWhere() != null) {
-            append(templates.getWhere()).handle(metadata.getWhere());
+            serializeForWhere(metadata);
+        }
+    }
+
+    void serializeForWhere(QueryMetadata metadata) {
+        boolean requireSchemaInWhere = templates.isRequiresSchemaInWhere();
+        boolean originalDmlWithSchema = dmlWithSchema;
+
+        if (requireSchemaInWhere) {
+            dmlWithSchema = true;
+        }
+        append(templates.getWhere()).handle(metadata.getWhere());
+
+        if (requireSchemaInWhere) {
+            dmlWithSchema = originalDmlWithSchema;
         }
     }
 
@@ -634,7 +648,7 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
         skipParent = false;
 
         if (metadata.getWhere() != null) {
-            append(templates.getWhere()).handle(metadata.getWhere());
+            serializeForWhere(metadata);
         }
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLServerTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLServerTemplates.java
@@ -64,7 +64,7 @@ public class SQLServerTemplates extends SQLTemplates {
     }
 
     protected SQLServerTemplates(Set<String> keywords, char escape, boolean quote) {
-        super(keywords, "\"", escape, quote);
+        super(keywords, "\"", escape, quote, false);
         setDummyTable("");
         setNullsFirst(null);
         setNullsLast(null);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
@@ -126,6 +126,8 @@ public class SQLTemplates extends Templates {
 
     private final boolean useQuotes;
 
+    private final boolean requiresSchemaInWhere;
+
     private boolean printSchema;
 
     private String createTable = "create table ";
@@ -250,14 +252,19 @@ public class SQLTemplates extends Templates {
 
     @Deprecated
     protected SQLTemplates(String quoteStr, char escape, boolean useQuotes) {
-        this(Keywords.DEFAULT, quoteStr, escape, useQuotes);
+        this(Keywords.DEFAULT, quoteStr, escape, useQuotes, false);
     }
 
     protected SQLTemplates(Set<String> reservedKeywords, String quoteStr, char escape, boolean useQuotes) {
+        this(reservedKeywords, quoteStr, escape, useQuotes, false);
+    }
+
+    protected SQLTemplates(Set<String> reservedKeywords, String quoteStr, char escape, boolean useQuotes, boolean requiresSchemaInWhere) {
         super(escape);
         this.reservedWords = reservedKeywords;
         this.quoteStr = quoteStr;
         this.useQuotes = useQuotes;
+        this.requiresSchemaInWhere = requiresSchemaInWhere;
 
         add(SQLOps.ALL, "{0}.*");
 
@@ -708,6 +715,10 @@ public class SQLTemplates extends Templates {
 
     public final boolean isCountDistinctMultipleColumns() {
         return countDistinctMultipleColumns;
+    }
+
+    public final boolean isRequiresSchemaInWhere() {
+        return requiresSchemaInWhere;
     }
 
     public final boolean isPrintSchema() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplatesRegistry.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplatesRegistry.java
@@ -75,7 +75,7 @@ public class SQLTemplatesRegistry {
             return new SQLTemplates.Builder() {
                 @Override
                 protected SQLTemplates build(char escape, boolean quote) {
-                    return new SQLTemplates(Keywords.DEFAULT, "\"", escape, quote);
+                    return new SQLTemplates(Keywords.DEFAULT, "\"", escape, quote, false);
                 }
             };
         }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLiteTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLiteTemplates.java
@@ -57,7 +57,7 @@ public class SQLiteTemplates extends SQLTemplates {
     }
 
     public SQLiteTemplates(char escape, boolean quote) {
-        super(Keywords.SQLITE, "\"", escape, quote);
+        super(Keywords.SQLITE, "\"", escape, quote, false);
         setDummyTable(null);
         addCustomType(BigDecimalAsDoubleType.DEFAULT);
         addCustomType(BigIntegerAsLongType.DEFAULT);


### PR DESCRIPTION
This option allows templates to generate where clauses with the pattern
`<SCHEMA>.<TABLE>.<COLUMN>` in the column specs.

Derby doesn't appear to support `<TABLE>.<COLUMN>` when using
`<SCHEMA>.<TABLE>` in the from unless the default schema is set and matches
the `<SCHEMA>` in the from clause.

#2074 