### PR TITLE
Adds methods to SQLListenerContext to retrieve SQLBindings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,7 @@
                   <excludes>
                     <exclude>com/querydsl/core/types/dsl/PathBuilderValidator</exclude>
                     <exclude>com/querydsl/sql/Union</exclude>
+                    <exclude>com/querydsl/sql/SQLListenerContextImpl</exclude>
                   </excludes>
                   <compatibilityType>BACKWARD_COMPATIBLE_USER</compatibilityType>
                   <dumpDetails>true</dumpDetails>

--- a/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
@@ -277,7 +277,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
             SQLSerializer serializer = serialize(false);
             queryString = serializer.toString();
             logQuery(queryString, serializer.getConstants());
-            context.addSQL(queryString);
+            context.addSQL(getSQL(serializer));
             listeners.rendered(context);
 
             listeners.notifyQuery(queryMixin.getMetadata());
@@ -353,7 +353,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
             SQLSerializer serializer = serialize(false);
             queryString = serializer.toString();
             logQuery(queryString, serializer.getConstants());
-            context.addSQL(queryString);
+            context.addSQL(getSQL(serializer));
             listeners.rendered(context);
 
 
@@ -429,7 +429,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
             SQLSerializer serializer = serialize(false);
             queryString = serializer.toString();
             logQuery(queryString, serializer.getConstants());
-            context.addSQL(queryString);
+            context.addSQL(getSQL(serializer));
             listeners.rendered(context);
 
             listeners.notifyQuery(queryMixin.getMetadata());
@@ -600,7 +600,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
             SQLSerializer serializer = serialize(true);
             queryString = serializer.toString();
             logQuery(queryString, serializer.getConstants());
-            context.addSQL(queryString);
+            context.addSQL(getSQL(serializer));
             listeners.rendered(context);
 
             constants = serializer.getConstants();

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -498,7 +498,10 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
      * @return SQL string and bindings
      */
     public SQLBindings getSQL() {
-        SQLSerializer serializer = serialize(false);
+        return getSQL(serialize(false));
+    }
+
+    protected SQLBindings getSQL(SQLSerializer serializer) {
         ImmutableList.Builder<Object> args = ImmutableList.builder();
         Map<ParamExpression<?>, Object> params = getMetadata().getParams();
         for (Object o : serializer.getConstants()) {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -34,6 +34,8 @@ import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.Wildcard;
 
+import static com.google.common.collect.Lists.newArrayList;
+
 /**
  * {@code ProjectableSQLQuery} is the base type for SQL query implementations
  *
@@ -502,7 +504,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     }
 
     protected SQLBindings getSQL(SQLSerializer serializer) {
-        ImmutableList.Builder<Object> args = ImmutableList.builder();
+        List<Object> args = newArrayList();
         Map<ParamExpression<?>, Object> params = getMetadata().getParams();
         for (Object o : serializer.getConstants()) {
             if (o instanceof ParamExpression) {
@@ -513,7 +515,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
             }
             args.add(o);
         }
-        return new SQLBindings(serializer.toString(), args.build());
+        return new SQLBindings(serializer.toString(), args);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLBindings.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLBindings.java
@@ -13,7 +13,12 @@
  */
 package com.querydsl.sql;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@code SQLBindings} provides the SQL query string and bindings
@@ -23,21 +28,48 @@ import com.google.common.collect.ImmutableList;
  */
 public class SQLBindings {
 
+    private static final Logger log = LoggerFactory.getLogger(SQLBindings.class);
+
     private final String sql;
 
-    private final ImmutableList<Object> bindings;
+    private final List<Object> bindings;
 
+    @Deprecated
     public SQLBindings(String sql, ImmutableList<Object> bindings) {
+        this(sql, (List<Object>) bindings);
+        log.warn("Using deprecated SQLBindings constructor");
+    }
+
+    public SQLBindings(String sql, List<Object> bindings) {
         this.sql = sql;
-        this.bindings = bindings;
+        this.bindings = Collections.unmodifiableList(bindings);
     }
 
     public String getSQL() {
         return sql;
     }
 
-    public ImmutableList<Object> getBindings() {
+    public List<Object> getNullFriendlyBindings() {
         return bindings;
+    }
+
+    /**
+     * Returns the bindings for this instance.
+     *
+     * @deprecated use {@link #getNullFriendlyBindings()} instead - this method is broken as null is a meaningful element
+     * and ImmutableList is null-hostile.
+     * @return an ImmutableList copy of the contents of {@link #getNullFriendlyBindings()}, with nulls removed
+     */
+    @Deprecated
+    public ImmutableList<Object> getBindings() {
+        final ImmutableList.Builder<Object> builder = ImmutableList.builder();
+        for (Object o : getNullFriendlyBindings()) {
+            if (o != null) {
+                builder.add(o);
+            }
+        }
+
+        return builder.build();
     }
 
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerContext.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerContext.java
@@ -63,6 +63,15 @@ public interface SQLListenerContext {
     String getSQL();
 
     /**
+     * Return the underlying sql including bindings or first in a batch query
+     *
+     * <p>NOTE : This can be null depending on the stage of the query execution</p>
+     *
+     * @return the underlying sql including bindings or first in a batch query
+     */
+    SQLBindings getSQLBindings();
+
+    /**
      * Return the underlying sql collection if the query is a batch query
      *
      * <p>NOTE : This can be empty depending on the stage of the query execution</p>
@@ -70,6 +79,15 @@ public interface SQLListenerContext {
      * @return the underlying sql collection if the query is a batch query
      */
     Collection<String> getSQLStatements();
+
+    /**
+     * Return the underlying sql collection including bindings if the query is a batch query
+     *
+     * <p>NOTE : This can be empty depending on the stage of the query execution</p>
+     *
+     * @return the underlying sql collection including bindings if the query is a batch query
+     */
+    Collection<SQLBindings> getAllSQLBindings();
 
     /**
      * Return the underlying entity affected

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerContextImpl.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerContextImpl.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.base.Function;
 import com.querydsl.core.QueryMetadata;
 
 /**
@@ -34,7 +35,7 @@ public class SQLListenerContextImpl implements SQLListenerContext {
 
     private final QueryMetadata md;
 
-    private final List<String> sqlStatements;
+    private final List<SQLBindings> sqlStatements;
 
     private final List<PreparedStatement> preparedStatements;
 
@@ -61,7 +62,7 @@ public class SQLListenerContextImpl implements SQLListenerContext {
         this(metadata, null, null);
     }
 
-    public void addSQL(final String sql) {
+    public void addSQL(final SQLBindings sql) {
         this.sqlStatements.add(sql);
     }
 
@@ -93,11 +94,26 @@ public class SQLListenerContextImpl implements SQLListenerContext {
 
     @Override
     public String getSQL() {
+        return sqlStatements.isEmpty() ? null : sqlStatements.get(0).getSQL();
+    }
+
+    @Override
+    public SQLBindings getSQLBindings() {
         return sqlStatements.isEmpty() ? null : sqlStatements.get(0);
     }
 
     @Override
     public Collection<String> getSQLStatements() {
+        return Lists.transform(sqlStatements, new Function<SQLBindings, String>() {
+            @Override
+            public String apply(SQLBindings sqlBindings) {
+                return sqlBindings.getSQL();
+            }
+        });
+    }
+
+    @Override
+    public Collection<SQLBindings> getAllSQLBindings() {
         return sqlStatements;
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
@@ -24,7 +24,6 @@ import javax.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
-import com.google.common.collect.ImmutableList;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.dml.DMLClause;
 import com.querydsl.core.support.QueryBase;
@@ -32,6 +31,8 @@ import com.querydsl.core.types.ParamExpression;
 import com.querydsl.core.types.ParamNotSetException;
 import com.querydsl.core.types.Path;
 import com.querydsl.sql.*;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 /**
  * {@code AbstractSQLClause} is a superclass for SQL based DMLClause implementations
@@ -124,7 +125,7 @@ public abstract class AbstractSQLClause<C extends AbstractSQLClause<C>> implemen
 
     protected SQLBindings createBindings(QueryMetadata metadata, SQLSerializer serializer) {
         String queryString = serializer.toString();
-        ImmutableList.Builder<Object> args = ImmutableList.builder();
+        List<Object> args = newArrayList();
         Map<ParamExpression<?>, Object> params = metadata.getParams();
         for (Object o : serializer.getConstants()) {
             if (o instanceof ParamExpression) {
@@ -135,7 +136,7 @@ public abstract class AbstractSQLClause<C extends AbstractSQLClause<C>> implemen
             }
             args.add(o);
         }
-        return new SQLBindings(queryString, args.build());
+        return new SQLBindings(queryString, args);
     }
 
     protected SQLSerializer createSerializer() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLDeleteClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLDeleteClause.java
@@ -131,7 +131,7 @@ public class SQLDeleteClause extends AbstractSQLClause<SQLDeleteClause> implemen
         queryString = serializer.toString();
         constants = serializer.getConstants();
         logQuery(logger, queryString, constants);
-        context.addSQL(queryString);
+        context.addSQL(createBindings(metadata, serializer));
         listeners.rendered(context);
 
         listeners.prePrepare(context);
@@ -152,7 +152,7 @@ public class SQLDeleteClause extends AbstractSQLClause<SQLDeleteClause> implemen
         queryString = serializer.toString();
         constants = serializer.getConstants();
         logQuery(logger, queryString, constants);
-        context.addSQL(queryString);
+        context.addSQL(createBindings(metadata, serializer));
         listeners.rendered(context);
 
         Map<String, PreparedStatement> stmts = Maps.newHashMap();
@@ -174,7 +174,7 @@ public class SQLDeleteClause extends AbstractSQLClause<SQLDeleteClause> implemen
             listeners.preRender(context);
             serializer = createSerializer();
             serializer.serializeDelete(batches.get(i), entity);
-            context.addSQL(serializer.toString());
+            context.addSQL(createBindings(metadata, serializer));
             listeners.rendered(context);
 
             stmt = stmts.get(serializer.toString());

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLInsertClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLInsertClause.java
@@ -265,7 +265,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
         } else {
             serializer.serializeInsert(metadata, entity, columns, values, subQuery);
         }
-        context.addSQL(serializer.toString());
+        context.addSQL(createBindings(metadata, serializer));
         listeners.rendered(context);
         return prepareStatementAndSetParameters(serializer, withKeys);
     }
@@ -290,7 +290,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
             stmt.addBatch();
         }
         stmts.put(serializer.toString(), stmt);
-        context.addSQL(serializer.toString());
+        context.addSQL(createBindings(metadata, serializer));
         listeners.rendered(context);
 
         // add other batches
@@ -301,7 +301,7 @@ public class SQLInsertClause extends AbstractSQLClause<SQLInsertClause> implemen
             serializer = createSerializer();
             serializer.serializeInsert(metadata, entity, batch.getColumns(),
                     batch.getValues(), batch.getSubQuery());
-            context.addSQL(serializer.toString());
+            context.addSQL(createBindings(metadata, serializer));
             listeners.rendered(context);
 
             stmt = stmts.get(serializer.toString());

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
@@ -381,7 +381,7 @@ public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements
         PreparedStatement stmt = null;
         if (batches.isEmpty()) {
             serializer.serializeMerge(metadata, entity, keys, columns, values, subQuery);
-            context.addSQL(serializer.toString());
+            context.addSQL(createBindings(metadata, serializer));
             listeners.rendered(context);
 
             listeners.prePrepare(context);
@@ -392,7 +392,7 @@ public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements
             serializer.serializeMerge(metadata, entity,
                     batches.get(0).getKeys(), batches.get(0).getColumns(),
                     batches.get(0).getValues(), batches.get(0).getSubQuery());
-            context.addSQL(serializer.toString());
+            context.addSQL(createBindings(metadata, serializer));
             listeners.rendered(context);
 
             stmt = prepareStatementAndSetParameters(serializer, withKeys);
@@ -408,7 +408,7 @@ public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements
                 listeners.preRender(context);
                 serializer = createSerializer();
                 serializer.serializeMerge(metadata, entity, batch.getKeys(), batch.getColumns(), batch.getValues(), batch.getSubQuery());
-                context.addSQL(serializer.toString());
+                context.addSQL(createBindings(metadata, serializer));
                 listeners.rendered(context);
 
                 setParameters(stmt, serializer.getConstants(), serializer.getConstantPaths(), metadata.getParams());
@@ -430,7 +430,7 @@ public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements
         serializer.serializeMerge(metadata, entity,
                 batches.get(0).getKeys(), batches.get(0).getColumns(),
                 batches.get(0).getValues(), batches.get(0).getSubQuery());
-        context.addSQL(serializer.toString());
+        context.addSQL(createBindings(metadata, serializer));
         listeners.rendered(context);
 
         PreparedStatement stmt = prepareStatementAndSetParameters(serializer, withKeys);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLUpdateClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLUpdateClause.java
@@ -126,7 +126,7 @@ public class SQLUpdateClause extends AbstractSQLClause<SQLUpdateClause> implemen
         queryString = serializer.toString();
         constants = serializer.getConstants();
         logQuery(logger, queryString, constants);
-        context.addSQL(queryString);
+        context.addSQL(createBindings(metadata, serializer));
         listeners.prepared(context);
 
         listeners.prePrepare(context);
@@ -146,7 +146,7 @@ public class SQLUpdateClause extends AbstractSQLClause<SQLUpdateClause> implemen
         queryString = serializer.toString();
         constants = serializer.getConstants();
         logQuery(logger, queryString, constants);
-        context.addSQL(queryString);
+        context.addSQL(createBindings(metadata, serializer));
         listeners.rendered(context);
 
         Map<String, PreparedStatement> stmts = Maps.newHashMap();
@@ -168,7 +168,7 @@ public class SQLUpdateClause extends AbstractSQLClause<SQLUpdateClause> implemen
             listeners.preRender(context);
             serializer = createSerializer();
             serializer.serializeUpdate(batches.get(i).getMetadata(), entity, batches.get(i).getUpdates());
-            context.addSQL(serializer.toString());
+            context.addSQL(createBindings(metadata, serializer));
             listeners.rendered(context);
 
             stmt = stmts.get(serializer.toString());

--- a/querydsl-sql/src/main/java/com/querydsl/sql/teradata/SetQueryBandClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/teradata/SetQueryBandClause.java
@@ -16,12 +16,14 @@ package com.querydsl.sql.teradata;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import javax.inject.Provider;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.querydsl.sql.Configuration;
 import com.querydsl.sql.SQLBindings;
@@ -108,9 +110,9 @@ public class SetQueryBandClause extends AbstractSQLClause<SetQueryBandClause> {
     public List<SQLBindings> getSQL() {
         SQLBindings bindings;
         if (configuration.getUseLiterals() || forSession) {
-            bindings = new SQLBindings(toString(), ImmutableList.of());
+            bindings = new SQLBindings(toString(), Collections.emptyList());
         } else {
-            bindings = new SQLBindings(toString(), ImmutableList.<Object>of(parameter));
+            bindings = new SQLBindings(toString(), Lists.<Object>newArrayList(parameter));
         }
         return ImmutableList.of(bindings);
     }


### PR DESCRIPTION
This was added as an alternative to just getting an SQL string. Internally,
SQLListenerContextImpl now only takes SQLBindings and the getSQL and
getSQLStatements methods delegate to SQLBindings#getSQL. This required
shuffling around AbstractSQLQuery and SQL*Clause to create bindings sooner to
pass through to addSQL even though we derive the same data later on inside
AbstractSQLClause#setParameters - I figured this was preferable to larger-scale
refactoring.

Fixes #1839