### PR TITLE
Explicitly sets a timezone for querydsl-sql tests.

### DIFF
--- a/querydsl-sql/pom.xml
+++ b/querydsl-sql/pom.xml
@@ -259,6 +259,7 @@
                 <value>target/derby.log</value>
             </property>
           </systemProperties>
+          <argLine>-Duser.timezone=UTC</argLine>
         </configuration>
       </plugin>         
       


### PR DESCRIPTION
Fixes #2005