### PR TITLE
Add javax.inject:javax.inject:1:jar as runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
         <version>${slf4j.version}</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/querydsl-codegen/pom.xml
+++ b/querydsl-codegen/pom.xml
@@ -37,7 +37,6 @@
     <dependency>  
       <groupId>javax.inject</groupId>  
       <artifactId>javax.inject</artifactId>  
-      <version>1</version>  
     </dependency>
 
     <dependency>

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -95,7 +95,6 @@
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
-      <version>1</version>
     </dependency>
     
     <dependency>

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -92,6 +92,11 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
     
     <dependency>
       <groupId>com.querydsl</groupId>


### PR DESCRIPTION
Since the javax.inject.Provider interface is imported and used in every constructor of the *QueryFactory classes ( example at https://github.com/querydsl/querydsl/blob/master/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAQueryFactory.java#L17 ), it should be a runtime dependency and not only provided.

Fixes #2026 