### PR TITLE
Store original state of dmlWithSchema

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
@@ -466,9 +466,10 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
         serialize(Position.AFTER_SELECT, metadata.getFlags());
         append("from ");
 
+        boolean originalDmlWithSchema = dmlWithSchema;
         dmlWithSchema = true;
         handle(entity);
-        dmlWithSchema = false;
+        dmlWithSchema = originalDmlWithSchema;
 
         if (metadata.getWhere() != null) {
             append(templates.getWhere()).handle(metadata.getWhere());
@@ -490,9 +491,10 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
         }
         serialize(Position.AFTER_SELECT, metadata.getFlags());
 
+        boolean originalDmlWithSchema = dmlWithSchema;
         dmlWithSchema = true;
         handle(entity);
-        dmlWithSchema = false;
+        dmlWithSchema = originalDmlWithSchema;
         append(" ");
         // columns
         if (!columns.isEmpty()) {
@@ -558,9 +560,10 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
         }
         serialize(Position.AFTER_SELECT, metadata.getFlags());
 
+        boolean originalDmlWithSchema = dmlWithSchema;
         dmlWithSchema = true;
         handle(entity);
-        dmlWithSchema = false;
+        dmlWithSchema = originalDmlWithSchema;
         // columns
         if (!columns.isEmpty()) {
             append(" (");
@@ -612,9 +615,10 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
         }
         serialize(Position.AFTER_SELECT, metadata.getFlags());
 
+        boolean originalDmlWithSchema = dmlWithSchema;
         dmlWithSchema = true;
         handle(entity);
-        dmlWithSchema = false;
+        dmlWithSchema = originalDmlWithSchema;
         append("\n");
         append(templates.getSet());
         boolean first = true;


### PR DESCRIPTION
This is a follow on PR from the discussion in #2075.

It protects the original state of the dmlWithSchema flag rather than explicitly setting it to `false`.