### PR TITLE
Explicitly sets a timezone for querydsl-sql tests.

### DIFF
--- a/querydsl-sql/pom.xml
+++ b/querydsl-sql/pom.xml
@@ -21,7 +21,7 @@
       org.joda.time.*;version="[1.6,3)",
       ${osgi.import.package.root}
     </osgi.import.package>
-
+    <argLine>-Xms256m -Xmx512m -Duser.timezone=UTC</argLine>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fixes #2098 

Recreation of https://github.com/querydsl/querydsl/pull/2099 because I messed up on issue numbers.