### PR TITLE
Added shouldGenerateInverseForeignKeys method to NamingStrategy

### DIFF
--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/AbstractNamingStrategy.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/AbstractNamingStrategy.java
@@ -18,6 +18,7 @@ import javax.lang.model.SourceVersion;
 import com.querydsl.codegen.EntityType;
 import com.querydsl.sql.SchemaAndTable;
 import com.querydsl.sql.codegen.support.ForeignKeyData;
+import com.querydsl.sql.codegen.support.InverseForeignKeyData;
 
 /**
  * {@code AbstractNamingStrategy} is an abstract base class for {@link NamingStrategy} implementations
@@ -149,4 +150,8 @@ public abstract class AbstractNamingStrategy implements NamingStrategy {
         return getClassName(schemaAndTable.getTable());
     }
 
+    @Override
+    public boolean shouldGenerateInverseForeignKeys(SchemaAndTable schemaAndTable, InverseForeignKeyData inverseForeignKeyData) {
+        return true;
+    }
 }

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/NamingStrategy.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/NamingStrategy.java
@@ -16,6 +16,7 @@ package com.querydsl.sql.codegen;
 import com.querydsl.codegen.EntityType;
 import com.querydsl.sql.SchemaAndTable;
 import com.querydsl.sql.codegen.support.ForeignKeyData;
+import com.querydsl.sql.codegen.support.InverseForeignKeyData;
 
 /**
  * {@code NamingStrategy} defines a conversion strategy from table to class and column
@@ -185,4 +186,14 @@ public interface NamingStrategy {
      */
     String getPackage(String basePackage, SchemaAndTable schemaAndTable);
 
-}
+    /**
+     * Returns <code>true</code> if the inverse foreign key reference should be generated in the table,
+     * otherwise <code>false</code>.
+     *
+     * @param schemaAndTable the schema and table
+     * @param inverseForeignKeyData the inverse foreign key in the table
+     * @return
+     */
+    boolean shouldGenerateInverseForeignKeys(SchemaAndTable schemaAndTable, InverseForeignKeyData inverseForeignKeyData);
+
+    }


### PR DESCRIPTION
For a project I need to filter generated inverse foreign key then I added  method shouldGenerateInverseForeignKeys to NamingStrategy.
MetaDataExporter will use new method to filter list of inverse foreign key list.
 