### PR TITLE
Add SQL symbolic type to java type mapping for maven plugin

### DIFF
--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
@@ -37,6 +37,7 @@ import com.querydsl.sql.codegen.NamingStrategy;
 import com.querydsl.sql.codegen.support.NumericMapping;
 import com.querydsl.sql.codegen.support.RenameMapping;
 import com.querydsl.sql.codegen.support.TypeMapping;
+import com.querydsl.sql.codegen.support.SQLTypeMapping;
 import com.querydsl.sql.types.Type;
 
 /**
@@ -264,6 +265,13 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
      * @parameter
      */
     private RenameMapping[] renameMappings;
+
+    /**
+     * SQL type name to Java type mappings
+     *
+     * @parameter
+     */
+    private SQLTypeMapping[] sqlTypeMappings;
 
     /**
      * switch for generating scala sources
@@ -496,6 +504,12 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
             }
             if (renameMappings != null) {
                 for (RenameMapping mapping : renameMappings) {
+                    mapping.apply(configuration);
+                }
+            }
+
+            if (sqlTypeMappings != null) {
+                for (SQLTypeMapping mapping : sqlTypeMappings) {
                     mapping.apply(configuration);
                 }
             }

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/SQLTypeMapping.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/SQLTypeMapping.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.sql.codegen.support;
+
+import com.querydsl.sql.Configuration;
+
+/**
+ * {@code SQLTypeMapping} customizes mappings SQL symbolic type to data types.
+ *
+ * @author Walery Wysotsky
+ *
+ */
+public class SQLTypeMapping implements Mapping {
+
+    private String sqlType;
+
+    private String javaType;
+
+    @Override
+    public void apply(Configuration configuration) {
+        try {
+            configuration.registerType(sqlType, Class.forName(javaType));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getSQLType() {
+        return sqlType;
+    }
+
+    public void setSQLType(String sqlType) {
+        this.sqlType = sqlType;
+    }
+
+    public String getJavaType() {
+        return javaType;
+    }
+
+    public void setJavaType(String javaType) {
+        this.javaType = javaType;
+    }
+}


### PR DESCRIPTION
Example, map Oracle type NVARCHAR2, pom.xml:
```java
<sqlTypeMappings>
  <sqlTypeMapping>
    <sqlType>nvarchar2</sqlType>
    <javaType>java.lang.String</javaType>
  </sqlTypeMapping>
<sqlTypeMapping>
```