### PR TITLE
Fixed NEXTVAL Operator for MS SQLServer (starting with 2012)

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLServer2012Templates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLServer2012Templates.java
@@ -64,6 +64,7 @@ public class SQLServer2012Templates extends SQLServerTemplates {
 
     protected SQLServer2012Templates(Set<String> keywords, char escape, boolean quote) {
         super(keywords, escape, quote);
+        add(SQLOps.NEXTVAL, "next value for {0s}");
     }
 
     @Override

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLServer2012TemplatesTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLServer2012TemplatesTest.java
@@ -105,7 +105,7 @@ public class SQLServer2012TemplatesTest extends AbstractSQLTemplatesTest {
 
     @Test
     public void nextVal() {
-        Operation<String> nextval = ExpressionUtils.operation(String.class, SQLOps.NEXTVAL, ConstantImpl.create("myseq"));       
+        Operation<String> nextval = ExpressionUtils.operation(String.class, SQLOps.NEXTVAL, ConstantImpl.create("myseq"));
         assertSerialized(nextval, "next value for myseq");
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLServer2012TemplatesTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLServer2012TemplatesTest.java
@@ -105,8 +105,8 @@ public class SQLServer2012TemplatesTest extends AbstractSQLTemplatesTest {
 
     @Test
     public void nextVal() {
-        Operation<String> nextval = ExpressionUtils.operation(String.class, SQLOps.NEXTVAL, ConstantImpl.create("myseq"));
-        assertEquals("myseq.nextval", new SQLSerializer(new Configuration(new SQLServerTemplates())).handle(nextval).toString());
+        Operation<String> nextval = ExpressionUtils.operation(String.class, SQLOps.NEXTVAL, ConstantImpl.create("myseq"));       
+        assertSerialized(nextval, "next value for myseq");
     }
 
 }


### PR DESCRIPTION
Hi,
The nextval operator is wrong for SQL Server. It should be "next value for ". 
See https://docs.microsoft.com/en-us/sql/t-sql/functions/next-value-for-transact-sql

Thanks.
theodor