### PR TITLE
Show property names list when QueryInit path fails

### DIFF
--- a/querydsl-apt/src/main/java/com/mysema/query/apt/AbstractQuerydslProcessor.java
+++ b/querydsl-apt/src/main/java/com/mysema/query/apt/AbstractQuerydslProcessor.java
@@ -503,10 +503,11 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
         for (String init : property.getInits()) {
             if (!init.startsWith("*") && property.getType() instanceof EntityType) {
                 String initProperty = init.contains(".") ? init.substring(0, init.indexOf('.')) : init;
-                if (!((EntityType)property.getType()).getPropertyNames().contains(initProperty)) {
+                Set<String> propertyNames = ((EntityType) property.getType()).getPropertyNames();
+                if (!propertyNames.contains(initProperty)) {
                     processingEnv.getMessager().printMessage(Kind.ERROR,
                         "Illegal inits of " + entityType.getFullName()+ "." + property.getName() + ": " +
-                        initProperty + " not found");
+                        initProperty + " not found in " + propertyNames);
                 }
             }
         }


### PR DESCRIPTION
Having scratched my head a fair bit around QueryInit over time, I thought I'd check out the code to see what I can and cannot specify as a QueryInit path.

This patch just makes it much clearer as to what QueryDSL can see (e.g. that it can see super class properties, but without need for _super - which was my guesswork).
