### PR TITLE
Adding KEY as a reserved word for QueryDSL 3.x

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLTemplates.java
@@ -71,7 +71,7 @@ public class SQLTemplates extends Templates {
                     "GLOBAL", "GRANT", "GROUP", "GROUPING", "HAVING", "HOLD",
                     "HOUR", "IDENTITY", "IN", "INDICATOR", "INNER", "INOUT",
                     "INSENSITIVE", "INSERT", "INT", "INTEGER", "INTERSECT",
-                    "INTERSECTION", "INTERVAL", "INTO", "IS", "JOIN", "LAG",
+                    "INTERSECTION", "INTERVAL", "INTO", "IS", "JOIN", "KEY", "LAG",
                     "LANGUAGE", "LARGE", "LAST_VALUE", "LATERAL", "LEAD",
                     "LEADING", "LEFT", "LIKE", "LIKE_REGEX", "LN", "LOCAL",
                     "LOCALTIME", "LOCALTIMESTAMP", "LOWER", "MATCH", "MAX",


### PR DESCRIPTION
MS SQL Server rejects queries for columns named key without being escaped. [MS SQL Reserved Keywords](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql)

Without KEY being part of the default reserved words, I need to override the MS SQL Templates and override `requiresQuotes`. 

An alternative design would be to allow addition of keywords via configuration, but that is needless complexity IMHO. KEY is in the default list of keywords in QueryDSL 4. 