### PR TITLE
Adding KEY as a reserved word for QueryDSL 3.x

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLServerTemplates.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLServerTemplates.java
@@ -14,7 +14,9 @@
 package com.mysema.query.sql;
 
 import java.sql.Types;
+import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import com.mysema.query.QueryFlag;
 import com.mysema.query.QueryFlag.Position;
 import com.mysema.query.QueryMetadata;
@@ -42,6 +44,15 @@ public class SQLServerTemplates extends SQLTemplates {
         };
     }
 
+    private static final Set<String> MSSQL_SPECIFIC_KEYWORDS
+            = ImmutableSet.of("KEY");
+
+    private static final Set<String> MSSQL_RESERVED_WORDS
+            = ImmutableSet.<String>builder()
+                          .addAll(SQL_RESERVED_WORDS)
+                          .addAll(MSSQL_SPECIFIC_KEYWORDS)
+                          .build();
+
     private String topTemplate = "top {0s} ";
 
     public SQLServerTemplates() {
@@ -53,7 +64,7 @@ public class SQLServerTemplates extends SQLTemplates {
     }
 
     public SQLServerTemplates(char escape, boolean quote) {
-        super("\"", escape, quote);
+        super(MSSQL_RESERVED_WORDS, "\"", escape, quote);
         setDummyTable("");
         setNullsFirst(null);
         setNullsLast(null);


### PR DESCRIPTION
MS SQL Server rejects queries for columns named key without being escaped. [MS SQL Reserved Keywords](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql)

This PR is an alternative to [PR 2183](https://github.com/querydsl/querydsl/pull/2183). Instead of adding "KEY" to SQLTemplates.SQL_RESERVED_WORDS, construct an ImmutableSet in SQLServerTemplates consisting of the union of SQLTemplates.SQL_RESERVED_WORDS and MS SQL specific keywords. 