### PR TITLE
Fix missing scope for jda dependency in querydsl-apt

### DIFF
--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -40,6 +40,7 @@
       <groupId>javax.jdo</groupId>
       <artifactId>jdo-api</artifactId>
       <version>${jdo.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>


### PR DESCRIPTION
Fixes #2138 