### PR TITLE
allow eviction of DEFAULT template cache - this leaks memory, JVM get OOM fast if the expressions are big.

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/TemplateFactory.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/TemplateFactory.java
@@ -268,5 +268,20 @@ public class TemplateFactory {
         return rv.toString();
     }
 
+    /**
+     * Allow eviction of cache entry to avoid leaking memory. For example:
+     *          TemplateFactory.DEFAULT.clearCache(someKey);
+     * @param key
+     */
+    public void clearCache(final String key){
+        cache.remove(key);
+    }
 
+    /**
+     * Allow eviction of  all cache entries to avoid leaking memory. For example:
+     *          TemplateFactory.DEFAULT.clearCache();
+     */
+    public void clearCache(){
+        cache.clear();
+    }
 }


### PR DESCRIPTION
TemplateFactory.cache leaks memory, JVM get OOM fast if the expressions are big.
Provide methods to clearCache optionally.