### PR TITLE
Explicitly declare NonUniqueResultException for fetchOne

### DIFF
--- a/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
@@ -196,7 +196,7 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         queryMixin.setUnique(true);
         if (queryMixin.getMetadata().getModifiers().getLimit() == null) {
             limit(2L);

--- a/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
@@ -46,7 +46,7 @@ public interface Fetchable<T> {
      * @throws NonUniqueResultException if there is more than one matching result
      * @return first result or null
      */
-    T fetchOne();
+    T fetchOne() throws NonUniqueResultException;
 
     /**
      * Get the projection as a typed closeable Iterator

--- a/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchable.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchable.java
@@ -37,7 +37,7 @@ public class DummyFetchable<T> implements Fetchable<T> {
 
     @Nullable
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         if (results.size() > 1) {
             throw new NonUniqueResultException();
         } else if (results.isEmpty()) {

--- a/querydsl-hibernate-search/src/main/java/com/querydsl/hibernate/search/AbstractSearchQuery.java
+++ b/querydsl-hibernate-search/src/main/java/com/querydsl/hibernate/search/AbstractSearchQuery.java
@@ -152,11 +152,11 @@ public abstract class AbstractSearchQuery<T, Q extends AbstractSearchQuery<T,Q>>
 
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         try {
             return (T) createQuery(false).uniqueResult();
         } catch (org.hibernate.NonUniqueResultException e) {
-            throw new NonUniqueResultException();
+            throw new NonUniqueResultException(e);
         }
     }
 

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -307,7 +307,7 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
 
     @Nullable
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         if (getMetadata().getModifiers().getLimit() == null) {
             limit(2);
         }

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
@@ -222,7 +222,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
     @SuppressWarnings("unchecked")
     @Override
     @Nullable
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         if (getMetadata().getModifiers().getLimit() == null) {
             limit(2);
         }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPASubQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPASubQuery.java
@@ -15,6 +15,7 @@ package com.querydsl.jpa;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.DefaultQueryMetadata;
+import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
@@ -62,7 +63,7 @@ class JPASubQuery<T> extends JPAQueryBase<T, JPASubQuery<T>> {
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         throw new UnsupportedOperationException();
     }
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
@@ -322,14 +322,14 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
 
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         try {
             QueryModifiers modifiers = getMetadata().getModifiers();
             Query query = createQuery(modifiers, false);
             try {
                 return (T) query.uniqueResult();
             } catch (org.hibernate.NonUniqueResultException e) {
-                throw new NonUniqueResultException();
+                throw new NonUniqueResultException(e);
             }
         } finally {
             reset();

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
@@ -211,7 +211,7 @@ public abstract class AbstractHibernateSQLQuery<T, Q extends AbstractHibernateSQ
 
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         try {
             Query query = createQuery();
             return (T) uniqueResult(query);
@@ -225,7 +225,7 @@ public abstract class AbstractHibernateSQLQuery<T, Q extends AbstractHibernateSQ
         try {
             return query.uniqueResult();
         } catch (org.hibernate.NonUniqueResultException e) {
-            throw new NonUniqueResultException();
+            throw new NonUniqueResultException(e);
         }
     }
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -247,7 +247,7 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
     @Nullable
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         try {
             Query query = createQuery(getMetadata().getModifiers(), false);
             return (T) getSingleResult(query);
@@ -255,7 +255,7 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
             logger.trace(e.getMessage(),e);
             return null;
         } catch (javax.persistence.NonUniqueResultException e) {
-            throw new NonUniqueResultException();
+            throw new NonUniqueResultException(e);
         } finally {
             reset();
         }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
@@ -292,7 +292,7 @@ public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>
 
     @Override
     @SuppressWarnings("unchecked")
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         Query query = createQuery();
         return (T) uniqueResult(query);
     }
@@ -305,7 +305,7 @@ public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>
             logger.trace(e.getMessage(),e);
             return null;
         } catch (javax.persistence.NonUniqueResultException e) {
-            throw new NonUniqueResultException();
+            throw new NonUniqueResultException(e);
         } finally {
             reset();
         }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.DefaultQueryMetadata;
+import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
@@ -86,7 +87,7 @@ class QueryHelper<T> extends JPAQueryBase<T, QueryHelper<T>> {
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         throw new UnsupportedOperationException();
     }
 

--- a/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
+++ b/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
@@ -330,7 +330,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         return oneResult(true);
     }
 

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
@@ -332,7 +332,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         return oneResult(true);
     }
 

--- a/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
+++ b/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
@@ -372,7 +372,7 @@ public abstract class AbstractLuceneQuery<T, Q extends AbstractLuceneQuery<T, Q>
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         return oneResult(true);
     }
 

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/AbstractMongodbQuery.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/AbstractMongodbQuery.java
@@ -338,7 +338,7 @@ public abstract class AbstractMongodbQuery<K, Q extends AbstractMongodbQuery<K, 
     }
 
     @Override
-    public K fetchOne() {
+    public K fetchOne() throws NonUniqueResultException {
         try {
             Long limit = queryMixin.getMetadata().getModifiers().getLimit();
             if (limit == null) {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.FetchableQuery;
 import com.querydsl.core.JoinFlag;
+import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.Query;
 import com.querydsl.core.QueryFlag;
 import com.querydsl.core.QueryFlag.Position;
@@ -391,7 +392,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         if (getMetadata().getModifiers().getLimit() == null
             && !queryMixin.getMetadata().getProjection().toString().contains("count(")) {
             limit(2);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.core.NonUniqueResultException;
 import com.querydsl.core.Query;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.QueryResults;
@@ -55,7 +56,7 @@ public class UnionImpl<T, Q extends ProjectableSQLQuery<T, Q> & Query<Q>>  imple
     }
 
     @Override
-    public T fetchOne() {
+    public T fetchOne() throws NonUniqueResultException {
         return query.fetchOne();
     }
 


### PR DESCRIPTION
Fetchable.fetchOne() declares in it's javadoc that it throws
NonUniqueResultException. It should therefore be explicitly declared in
the method signature as well.
All implementations must also declare in their signature that they throw.

This also has the desirable side-effect of the javadoc of all of the
implementors inheriting the @throws section from the javadoc of the
interface as well.

Fixes #2232