### PR TITLE
Simplify array creation

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathBase.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathBase.java
@@ -216,9 +216,7 @@ public class RelationalPathBase<T> extends BeanPath<T> implements RelationalPath
     }
 
     public Path<?>[] all() {
-        Path<?>[] all = new Path[columnMetadata.size()];
-        columnMetadata.keySet().toArray(all);
-        return all;
+        return columnMetadata.keySet().toArray(new Path<?>[columnMetadata.size()]);
     }
 
     @Override


### PR DESCRIPTION
There are two styles to convert a collection to an array: either using a pre-sized array (like c.toArray(new String[c.size()])) or using an empty array (like c.toArray(new String[0]).

In older Java versions using pre-sized array was recommended, as the reflection call which is necessary to create an array of proper size was quite slow. However since late updates of OpenJDK 6 this call was intrinsified, making the performance of the empty array version the same and sometimes even better, compared to the pre-sized version.