### PR TITLE
added SQL Server 2016 support to SQLTemplatesRegistry

### DIFF
--- a/querydsl-sql/src/main/java/com/mysema/query/sql/SQLTemplatesRegistry.java
+++ b/querydsl-sql/src/main/java/com/mysema/query/sql/SQLTemplatesRegistry.java
@@ -55,6 +55,7 @@ public class SQLTemplatesRegistry {
         // sqlserver
         if (name.equals("microsft sql server")) {
             switch (md.getDatabaseMajorVersion()) {
+                case 13:
                 case 12:
                 case 11: return sqlserver2012;
                 case 10: return sqlserver2008;


### PR DESCRIPTION
Would like to have this in the Querydsl 3 release, if possible.
backport of #2211 
Definitely fixes #2258 