### PR TITLE
issue-2303: Consider optimising AbstractSQL::newInstance (becomes a b…

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionUtils.java
@@ -16,8 +16,6 @@ package com.querydsl.core.types;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.querydsl.core.util.ArrayUtils;
-
 /**
  * Utility class to expand {@link FactoryExpression} constructor arguments and compress {@link FactoryExpression}
  * invocation arguments
@@ -59,7 +57,7 @@ public final class FactoryExpressionUtils {
 
         @Override
         public T newInstance(Object... a) {
-            return inner.newInstance(compress(inner.getArgs(), a));
+            return inner.newInstance(compress(inner.getArgs(), a, 0));
         }
 
         @Override
@@ -140,7 +138,7 @@ public final class FactoryExpressionUtils {
         return counter;
     }
 
-    private static Object[] compress(List<Expression<?>> exprs, Object[] args) {
+    private static Object[] compress(List<Expression<?>> exprs, Object[] args, int from) {
         Object[] rv = new Object[exprs.size()];
         int offset = 0;
         for (int i = 0; i < exprs.size(); i++) {
@@ -151,11 +149,11 @@ public final class FactoryExpressionUtils {
             if (expr instanceof FactoryExpression<?>) {
                 FactoryExpression<?> fe = (FactoryExpression<?>) expr;
                 int fullArgsLength = countArguments(fe);
-                Object[] compressed = compress(fe.getArgs(), ArrayUtils.subarray(args, offset, offset + fullArgsLength));
+                Object[] compressed = compress(fe.getArgs(), args, offset);
                 rv[i] = fe.newInstance(compressed);
                 offset += fullArgsLength;
             } else {
-                rv[i] = args[offset];
+                rv[i] = args[from + offset];
                 offset++;
             }
         }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
@@ -195,6 +195,11 @@ public final class Configuration {
         return getType(path, clazz).getValue(rs, i);
     }
 
+    @Nullable
+    public <T> T get(ResultSet rs,int i, Type<T> type) throws SQLException {
+        return type.getValue(rs, i);
+    }
+
     /**
      * Get the schema/table override
      *
@@ -269,7 +274,7 @@ public final class Configuration {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private <T> Type<T> getType(@Nullable Path<?> path, Class<T> clazz) {
+    <T> Type<T> getType(@Nullable Path<?> path, Class<T> clazz) {
         if (hasTableColumnTypes && path != null && !clazz.equals(Null.class)
                 && path.getMetadata().getParent() instanceof RelationalPath) {
             String table = ((RelationalPath) path.getMetadata().getParent()).getTableName();


### PR DESCRIPTION
Attaching the patch which optimizes following codepath
1. FactoryExpressionUtils::compress (reduces System.arrayCopy)
2. AbstractSQLQuery::fetch (improves record population, reduces object creation for every record)

JMH Result: 
------------
#JMH version: 1.20
#VM version: JDK 1.8.0_161, VM 25.161-b12
#VM options: -Xms2g -Xmx2g

Without Patch (baseline):
------------
select 1 col from employee (100 rows): 15.001 ops/ms
select 2 col from employee (100 rows): 11.360 ops/ms
select 3 col from employee (100 rows): 8.975 ops/ms
select 4 col from employee (100 rows): 7.281 ops/ms
select 5 col from employee (100 rows): 5.682 ops/ms


With Patch:
------------
select 1 col from employee (100 rows): 15.076 ops/ms
select 2 col from employee (100 rows): 13.658 ops/ms
select 3 col from employee (100 rows): 12.568 ops/ms
select 4 col from employee (100 rows): 10.021 ops/ms
select 5 col from employee (100 rows): 8.013 ops/ms

When more columns are retrieved, the provides much larger improvement in the order of ~50%. I have not run any benchmarks on larger queries, but shorter queries this would be highly beneficial.

Can someone please review?