### PR TITLE
Translate SQLException thrown during connection acquisition

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLQueryFactory.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLQueryFactory.java
@@ -34,9 +34,11 @@ public class SQLQueryFactory extends AbstractSQLQueryFactory<SQLQuery<?>> {
     static class DataSourceProvider implements Provider<Connection> {
 
         private final DataSource ds;
+        private final Configuration configuration;
 
-        public DataSourceProvider(DataSource ds) {
+        public DataSourceProvider(DataSource ds, Configuration configuration) {
             this.ds = ds;
+            this.configuration = configuration;
         }
 
         @Override
@@ -44,7 +46,7 @@ public class SQLQueryFactory extends AbstractSQLQueryFactory<SQLQuery<?>> {
             try {
                 return ds.getConnection();
             } catch (SQLException e) {
-                throw new RuntimeException(e.getMessage(), e);
+                throw configuration.translate(e);
             }
         }
 
@@ -63,7 +65,7 @@ public class SQLQueryFactory extends AbstractSQLQueryFactory<SQLQuery<?>> {
     }
 
     public SQLQueryFactory(Configuration configuration, DataSource dataSource, boolean release) {
-        super(configuration, new DataSourceProvider(dataSource));
+        super(configuration, new DataSourceProvider(dataSource, configuration));
         if (release) {
             configuration.addListener(SQLCloseListener.DEFAULT);
         }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLQueryFactoryTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLQueryFactoryTest.java
@@ -16,13 +16,17 @@ package com.querydsl.sql;
 import static org.junit.Assert.assertNotNull;
 
 import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLTransientConnectionException;
 
 import javax.inject.Provider;
+import javax.sql.DataSource;
 
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.querydsl.core.QueryException;
 import com.querydsl.sql.domain.QSurvey;
 
 public class SQLQueryFactoryTest {
@@ -70,4 +74,15 @@ public class SQLQueryFactoryTest {
         assertNotNull(queryFactory.merge(QSurvey.survey));
     }
 
+    @Test(expected = QueryException.class)
+    public void dataSourceProviderException() throws SQLException {
+        SQLException e = new SQLTransientConnectionException();
+
+        DataSource ds = EasyMock.createStrictMock(DataSource.class);
+        EasyMock.expect(ds.getConnection()).andThrow(e);
+        EasyMock.replay(ds);
+
+        SQLQueryFactory exceptionQueryFactory = new SQLQueryFactory(new Configuration(SQLTemplates.DEFAULT), ds);
+        exceptionQueryFactory.getConnection();
+    }
 }


### PR DESCRIPTION
I noticed (while debugging a connection failure in an application) that SQLQueryFactory.DataSourceProvider's get method always throws RuntimeException when an SQLException is thrown during connect instead of delegating construction of the exception to the defined SQLExceptionTranslator.

This forces API consumers to implement custom logic to catch RuntimeException and then do the mapping on the RuntimeException cause (if not null).

This is obviously suboptimal, so I propose delegating to the SQLExceptionTranslation defined in the Configuration (which defaults to DefaultSQLExceptionTranslator if none is defined by the user).

I have not written tests yet as I wanted to get feedback on the change first, but I can write unit tests once there is some agreement on the approach.