### PR TITLE
Static properties referencing to the default variable properties

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
@@ -330,8 +330,8 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
         String typeName = type.toString();
 
         if (typeName.startsWith(Collection.class.getName())
-         || typeName.startsWith(List.class.getName())
-         || typeName.startsWith(Set.class.getName())) {
+                || typeName.startsWith(List.class.getName())
+                || typeName.startsWith(Set.class.getName())) {
             type = ((DeclaredType) type).getTypeArguments().get(0);
 
         } else if (typeName.startsWith(Map.class.getName())) {
@@ -478,7 +478,7 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
 
     private void validateMetaTypes() {
         @SuppressWarnings("unchecked") // Only concatenated
-        Iterable<? extends EntityType> entityTypes = Iterables.concat(
+                Iterable<? extends EntityType> entityTypes = Iterables.concat(
                 context.supertypes.values(),
                 context.entityTypes.values(),
                 context.extensionTypes.values(),

--- a/querydsl-apt/src/test/java/com/querydsl/apt/domain/QuerydslConfig2Test.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/domain/QuerydslConfig2Test.java
@@ -13,7 +13,10 @@
  */
 package com.querydsl.apt.domain;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
 
 import org.junit.Test;
 
@@ -38,6 +41,18 @@ public class QuerydslConfig2Test {
 
     }
 
+    @Config(entityAccessors = true, createDefaultVariableStaticProperties = true)
+    @QueryEntity
+    public static class EntityWithStaticProperties extends Superclass {
+
+        Entity prop1;
+
+        String stringProp;
+
+        List<String> stringProps;
+
+    }
+
     @QueryEntity
     public static class Superclass {
 
@@ -56,9 +71,30 @@ public class QuerydslConfig2Test {
         assertNotNull(QQuerydslConfig2Test_Entity.entity);
     }
 
+    @Test
+    public void testStaticProperties() {
+        assertEquals(QQuerydslConfig2Test_EntityWithStaticProperties.prop1_,
+                QQuerydslConfig2Test_EntityWithStaticProperties.entityWithStaticProperties.prop1);
+
+        assertEquals(QQuerydslConfig2Test_EntityWithStaticProperties.prop2_,
+                QQuerydslConfig2Test_EntityWithStaticProperties.entityWithStaticProperties.prop2);
+
+        assertEquals(QQuerydslConfig2Test_EntityWithStaticProperties.stringProp_,
+                QQuerydslConfig2Test_EntityWithStaticProperties.entityWithStaticProperties.stringProp);
+
+        assertEquals(QQuerydslConfig2Test_EntityWithStaticProperties.stringProps_,
+                QQuerydslConfig2Test_EntityWithStaticProperties.entityWithStaticProperties.stringProps);
+    }
+
     @Test(expected = NoSuchFieldException.class)
     public void create_default_variable() throws SecurityException, NoSuchFieldException {
         QQuerydslConfig2Test_Entity2.class.getField("entity2");
     }
+
+    @Test(expected = NoSuchFieldException.class)
+    public void create_entity_static_properties() throws SecurityException, NoSuchFieldException {
+        QQuerydslConfig2Test_Entity.class.getField("prop1_");
+    }
+
 }
 

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/SerializerConfig.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/SerializerConfig.java
@@ -50,6 +50,13 @@ public interface SerializerConfig {
     boolean createDefaultVariable();
 
     /**
+     * the static properties for default variable is created
+     *
+     * @return if the static properties for default variable is created
+     */
+    boolean createStaticPropertiesForDefaultVariable();
+
+    /**
      * the name of the default variable
      *
      * @return the name of the default variable

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/SimpleSerializerConfig.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/SimpleSerializerConfig.java
@@ -23,7 +23,7 @@ import com.querydsl.core.annotations.Config;
  */
 public final class SimpleSerializerConfig implements SerializerConfig {
 
-    public static final SerializerConfig DEFAULT = new SimpleSerializerConfig(false, false, false, true, "");
+    public static final SerializerConfig DEFAULT = new SimpleSerializerConfig(false, false, false, true, false, "");
 
     public static SerializerConfig getConfig(Config annotation) {
         return new SimpleSerializerConfig(
@@ -31,10 +31,11 @@ public final class SimpleSerializerConfig implements SerializerConfig {
                 annotation.listAccessors(),
                 annotation.mapAccessors(),
                 annotation.createDefaultVariable(),
+                annotation.createDefaultVariableStaticProperties(),
                 annotation.defaultVariableName());
     }
 
-    private final boolean entityAccessors, listAccessors, mapAccessors, createDefaultVariable;
+    private final boolean entityAccessors, listAccessors, mapAccessors, createDefaultVariable, createDefaultVariableStaticProperties;
 
     private final String defaultVariableName;
 
@@ -48,6 +49,22 @@ public final class SimpleSerializerConfig implements SerializerConfig {
         this.listAccessors = listAccessors;
         this.mapAccessors = mapAccessors;
         this.createDefaultVariable = createDefaultVariable;
+        this.createDefaultVariableStaticProperties = false;
+        this.defaultVariableName = defaultVariableName;
+    }
+
+  public SimpleSerializerConfig(
+            boolean entityAccessors,
+            boolean listAccessors,
+            boolean mapAccessors,
+            boolean createDefaultVariable,
+            boolean createDefaultVariableStaticProperties,
+            String defaultVariableName) {
+        this.entityAccessors = entityAccessors;
+        this.listAccessors = listAccessors;
+        this.mapAccessors = mapAccessors;
+        this.createDefaultVariable = createDefaultVariable;
+        this.createDefaultVariableStaticProperties = createDefaultVariableStaticProperties;
         this.defaultVariableName = defaultVariableName;
     }
 
@@ -69,6 +86,11 @@ public final class SimpleSerializerConfig implements SerializerConfig {
     @Override
     public boolean createDefaultVariable() {
         return createDefaultVariable;
+    }
+
+    @Override
+    public boolean createStaticPropertiesForDefaultVariable() {
+        return createDefaultVariableStaticProperties;
     }
 
     @Override

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/SerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/SerializerTest.java
@@ -64,30 +64,30 @@ public class SerializerTest {
     @Test
     public void entitySerializer() throws Exception {
         new EntitySerializer(typeMappings, Collections.<String>emptyList())
-            .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
+                .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
     }
 
     @Test
     public void entitySerializer2() throws Exception {
         new EntitySerializer(typeMappings,Collections.<String>emptyList())
-            .serialize(type, new SimpleSerializerConfig(true,true,true,true,""), new JavaWriter(writer));
+                .serialize(type, new SimpleSerializerConfig(true,true,true,true,""), new JavaWriter(writer));
     }
 
     @Test
     public void embeddableSerializer() throws Exception {
         new EmbeddableSerializer(typeMappings,Collections.<String>emptyList())
-            .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
+                .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
     }
 
     @Test
     public void supertypeSerializer() throws IOException {
         new SupertypeSerializer(typeMappings,Collections.<String>emptyList())
-            .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
+                .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
     }
 
     @Test
     public void projectionSerializer() throws IOException {
         new ProjectionSerializer(typeMappings)
-            .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
+                .serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
     }
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/annotations/Config.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/annotations/Config.java
@@ -53,6 +53,11 @@ public @interface Config {
     boolean createDefaultVariable() default true;
 
     /**
+     * Create static properties for default variable in query type
+     */
+    boolean createDefaultVariableStaticProperties() default false;
+
+    /**
      * The name of the default variable in query type
      */
     String defaultVariableName() default "";

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
@@ -333,7 +333,7 @@ public class MetaDataSerializer extends EntitySerializer {
         if (queryType.getPackageName().startsWith("com.querydsl")) {
             String localRawName = writer.getRawName(field.getType());
             serialize(model, field, queryType, writer, "create" + field.getType().getSimpleName(),
-                    writer.getClassConstant(localRawName));
+                    config, writer.getClassConstant(localRawName));
         } else {
             super.customField(model, field, config, writer);
         }


### PR DESCRIPTION
Hi guys,
This PR allows to generate additional static properties, which are just a reference to properties of the default variable, for instance: 

```java
public class QPerson extends EntityPathBase<Person> {

    public static final QPerson person = new QPerson("person");
 
    public final StringPath firstName = createString("firstName");

    public static final StringPath firstName_ = person.firstName;

}
```

so it is possible to write:

`QPerson.firstName_` instead of `QPerson.person.firstName`. I believe that it will noticeably reduce amount of redundant code in some projects.

I've added `createDefaultVariableStaticProperties` Config param for this and it should be backward-compatible