### PR TITLE
Fix bugs in EclipseLinkHandler#iterate()

### DIFF
--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
@@ -17,10 +17,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
+import org.eclipse.persistence.config.HintValues;
 import org.eclipse.persistence.config.QueryHints;
-import org.eclipse.persistence.config.ResultSetType;
 import org.eclipse.persistence.jpa.JpaQuery;
 import org.eclipse.persistence.queries.Cursor;
 
@@ -54,20 +55,40 @@ class EclipseLinkHandler implements QueryHandler {
     @SuppressWarnings("unchecked")
     @Override
     public <T> CloseableIterator<T> iterate(Query query, FactoryExpression<?> projection) {
+        boolean canUseCursor = false;
+        try {
+            canUseCursor = query.unwrap(Query.class) instanceof JpaQuery;
+        } catch (PersistenceException e) {} // can't unwrap, just ignore the exception
+
         Iterator<T> iterator = null;
         Closeable closeable = null;
-        if (query instanceof JpaQuery) {
-            JpaQuery<T> elQuery = (JpaQuery<T>) query;
-            elQuery.setHint(QueryHints.RESULT_SET_TYPE, ResultSetType.ForwardOnly);
-            elQuery.setHint(QueryHints.SCROLLABLE_CURSOR, true);
-            final Cursor cursor = elQuery.getResultCursor();
+        if (canUseCursor) {
+            query.setHint(QueryHints.CURSOR, HintValues.TRUE);
+            final Cursor cursor = (Cursor) query.getSingleResult();
+            final int pageSize = cursor.getPageSize();
             closeable = new Closeable() {
                 @Override
                 public void close() throws IOException {
                     cursor.close();
                 }
             };
-            iterator = cursor;
+            iterator = new Iterator<T>() {
+                private int rowsSinceLastClear = 0;
+                
+                @Override
+                public boolean hasNext() {
+                    return cursor.hasNext();
+                }
+
+                @Override
+                public T next() {
+                    if (rowsSinceLastClear++ == pageSize) {
+                        rowsSinceLastClear = 0;
+                        cursor.clear();
+                    }
+                    return (T) cursor.next();
+                }
+            };
         } else {
             iterator = query.getResultList().iterator();
         }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
@@ -58,7 +58,7 @@ class EclipseLinkHandler implements QueryHandler {
         boolean canUseCursor = false;
         try {
             canUseCursor = query.unwrap(Query.class) instanceof JpaQuery;
-        } catch (PersistenceException e) {} // can't unwrap, just ignore the exception
+        } catch (PersistenceException e) { } // can't unwrap, just ignore the exception
 
         Iterator<T> iterator = null;
         Closeable closeable = null;
@@ -74,7 +74,7 @@ class EclipseLinkHandler implements QueryHandler {
             };
             iterator = new Iterator<T>() {
                 private int rowsSinceLastClear = 0;
-                
+
                 @Override
                 public boolean hasNext() {
                     return cursor.hasNext();


### PR DESCRIPTION
EclipseLinkHandler's implementation of iterate() is heavily bugged:
- Some environments (e.g. WildFly) wrap the Query, causing the
instanceof check to fail, which prevents a cursor from being used. Fix
this by unwrapping the Query first.
- Telling EclipseLink to use a scrollable cursor, then telling it to use
a result set type of FORWARD_ONLY, makes no sense and causes the SQL
Server JDBC driver to throw an exception. Fix this by using a regular
CursoredStream instead.
- The original code never tells EclipseLink to release objects, causing
any benefit from using a cursor to be lost since all objects are
retained until the cursor is closed. Fix this by releasing objects after
completing each page.

With these changes, iterate() now works correctly on WildFly 13 with EclipseLink 2.7.2 and mssql-jdbc 6.5.3.