### PR TITLE
Support Character.class in EnumConversion

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/support/EnumConversion.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/EnumConversion.java
@@ -58,9 +58,9 @@ public class EnumConversion<T> extends FactoryExpressionBase<T> {
     @Override
     public T newInstance(Object... args) {
         if (args[0] != null) {
-            if (args[0] instanceof String) {
+            if (args[0] instanceof String || args[0] instanceof Character) {
                 @SuppressWarnings("unchecked") //The expression type is an enum
-                T rv = (T) Enum.valueOf(getType().asSubclass(Enum.class), (String) args[0]);
+                T rv = (T) Enum.valueOf(getType().asSubclass(Enum.class), (String) args[0].toString());
                 return rv;
             } else if (args[0] instanceof Number) {
                 return values[((Number) args[0]).intValue()];

--- a/querydsl-core/src/test/java/com/querydsl/core/support/EnumConversionTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/EnumConversionTest.java
@@ -11,7 +11,14 @@ import com.querydsl.core.types.dsl.StringPath;
 
 public class EnumConversionTest {
 
-    public enum Color { GREEN, BLUE, RED, YELLOW, BLACK, WHITE }
+    public enum Color { GREEN, BLUE, RED, YELLOW, B, W }
+
+    @Test
+    public void nameForCharacter() {
+        EnumPath<Color> color = Expressions.enumPath(Color.class, "path");
+        EnumConversion<Color> conv = new EnumConversion<Color>(color);
+        assertEquals(Color.W, conv.newInstance('W'));
+    }
 
     @Test
     public void name() {


### PR DESCRIPTION
My Oracle database comes from a legacy system, some fields that should return Enum.class, are returning Character.class, and the EnumConversion class, have no handling for objects coming as Character.class.