### PR TITLE
Azure cosmosdb support

### DIFF
--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -35,7 +35,11 @@ import com.querydsl.core.types.*;
  *
  */
 public abstract class MongodbSerializer implements Visitor<Object, Void> {
-
+    /**
+     * Flag to skip pattern quote.
+     * By default false.
+     */
+    public static boolean skipPatternQuote = false;
     public Object handle(Expression<?> expression) {
         return expression.accept(this, null);
     }
@@ -79,6 +83,9 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
     }
 
     private String regexValue(Operation<?> expr, int index) {
+        if (skipPatternQuote) {
+          return expr.getArg(index).accept(this, null).toString();
+        }
         return Pattern.quote(expr.getArg(index).accept(this, null).toString());
     }
 

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -37,6 +37,7 @@ import com.querydsl.core.types.*;
 public abstract class MongodbSerializer implements Visitor<Object, Void> {
     /**
      * Flag to skip pattern quote.
+     * {@link java.util.regex.Pattern}
      * By default false.
      */
     public static boolean skipPatternQuote = false;


### PR DESCRIPTION
Azure Cosmos database contains query issue due to the different type of regex engine or syntax used in both Cosmos/MongoDB database. Our standalone MongoServer used PCRE(Perl compatible regular expressions) but Cosmos using ECMAScript regex expressions. Our spring boot QueryDsl library generates Perl syntax based regex query. So incompatible syntax issues while running against Cosmos database.

Ex:   Perl contains syntax: { "name" : { "$regex" : ".*\\Qscript\\E.*"}}
	Similar Cosmos Syntax: { "name" : { "$regex" : "script"}}

Reference: 
https://feedback.azure.com/forums/263030-azure-cosmos-db/suggestions/32760031-support-q-and-e-escape-sequence-for-regex
https://docs.mongodb.com/manual/reference/operator/query/regex/


**Note:** Regarding this issue we have raised a support thicket already.
Ticket No: https://github.com/querydsl/querydsl/issues/2396