### PR TITLE
Do not truncate the nanoseconds of java 8 timestamps

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
@@ -1,13 +1,15 @@
 package com.querydsl.sql.types;
 
-import java.sql.*;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 import javax.annotation.Nullable;
-
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * JSR310LocalDateTimeType maps {@linkplain java.time.LocalDateTime}
@@ -44,7 +46,6 @@ public class JSR310LocalDateTimeType extends AbstractJSR310DateTimeType<LocalDat
 
     @Override
     public void setValue(PreparedStatement st, int startIndex, LocalDateTime value) throws SQLException {
-        Instant i = value.toInstant(ZoneOffset.UTC);
-        st.setTimestamp(startIndex, new Timestamp(i.toEpochMilli()), utc());
+        st.setTimestamp(startIndex, Timestamp.from(value.toInstant(ZoneOffset.UTC)), utc());
     }
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
@@ -1,12 +1,15 @@
 package com.querydsl.sql.types;
 
-import java.sql.*;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 import javax.annotation.Nullable;
-
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 /**
  * JSR310OffsetDateTimeType maps {@linkplain java.time.OffsetDateTime}
@@ -44,6 +47,6 @@ public class JSR310OffsetDateTimeType extends AbstractJSR310DateTimeType<OffsetD
 
     @Override
     public void setValue(PreparedStatement st, int startIndex, OffsetDateTime value) throws SQLException {
-        st.setTimestamp(startIndex, new Timestamp(value.toInstant().toEpochMilli()), utc());
+        st.setTimestamp(startIndex, Timestamp.from(value.toInstant()), utc());
     }
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
@@ -1,12 +1,15 @@
 package com.querydsl.sql.types;
 
-import java.sql.*;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 import javax.annotation.Nullable;
-
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 /**
  * JSR310ZonedDateTimeType maps {@linkplain java.time.ZonedDateTime}
@@ -43,6 +46,6 @@ public class JSR310ZonedDateTimeType extends AbstractJSR310DateTimeType<ZonedDat
 
     @Override
     public void setValue(PreparedStatement st, int startIndex, ZonedDateTime value) throws SQLException {
-        st.setTimestamp(startIndex, new Timestamp(value.toInstant().toEpochMilli()), utc());
+        st.setTimestamp(startIndex, Timestamp.from(value.toInstant()), utc());
     }
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310LocalDateTimeTypeTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310LocalDateTimeTypeTest.java
@@ -1,7 +1,7 @@
 package com.querydsl.sql.types;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.easymock.EasyMock;
+import org.junit.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -10,8 +10,8 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
-import org.easymock.EasyMock;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class JSR310LocalDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<LocalDateTime> {
 
@@ -22,7 +22,7 @@ public class JSR310LocalDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<
     @Test
     public void set() throws SQLException {
         LocalDateTime value = LocalDateTime.now();
-        Timestamp ts = new Timestamp(value.toInstant(ZoneOffset.UTC).toEpochMilli());
+        Timestamp ts = Timestamp.from(value.toInstant(ZoneOffset.UTC));
 
         PreparedStatement stmt = EasyMock.createNiceMock(PreparedStatement.class);
         stmt.setTimestamp(1, ts, UTC);
@@ -35,7 +35,7 @@ public class JSR310LocalDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<
     @Test
     public void jodaSet() throws SQLException {
         LocalDateTime value = LocalDateTime.now();
-        Timestamp ts = new Timestamp(value.toInstant(ZoneOffset.UTC).toEpochMilli());
+        Timestamp ts = Timestamp.from(value.toInstant(ZoneOffset.UTC));
 
         PreparedStatement stmt = EasyMock.createNiceMock(PreparedStatement.class);
         stmt.setTimestamp(1, ts, UTC);
@@ -48,7 +48,7 @@ public class JSR310LocalDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<
     @Test
     public void get() throws SQLException {
         ResultSet resultSet = EasyMock.createNiceMock(ResultSet.class);
-        EasyMock.expect(resultSet.getTimestamp(1, UTC)).andReturn(new Timestamp(UTC.getTimeInMillis()));
+        EasyMock.expect(resultSet.getTimestamp(1, UTC)).andReturn(Timestamp.from(UTC.toInstant()));
         EasyMock.replay(resultSet);
 
         LocalDateTime result = type.getValue(resultSet, 1);

--- a/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310OffsetDateTimeTypeTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310OffsetDateTimeTypeTest.java
@@ -1,7 +1,7 @@
 package com.querydsl.sql.types;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.easymock.EasyMock;
+import org.junit.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -9,8 +9,8 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 
-import org.easymock.EasyMock;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class JSR310OffsetDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<OffsetDateTime> {
 
@@ -21,7 +21,7 @@ public class JSR310OffsetDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest
     @Test
     public void set() throws SQLException {
         OffsetDateTime value = OffsetDateTime.now();
-        Timestamp ts = new Timestamp(value.toInstant().toEpochMilli());
+        Timestamp ts = Timestamp.from(value.toInstant());
 
         PreparedStatement stmt = EasyMock.createNiceMock(PreparedStatement.class);
         stmt.setTimestamp(1, ts, UTC);
@@ -34,7 +34,7 @@ public class JSR310OffsetDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest
     @Test
     public void jodaSet() throws SQLException {
         OffsetDateTime value = OffsetDateTime.now();
-        Timestamp ts = new Timestamp(value.toInstant().toEpochMilli());
+        Timestamp ts = Timestamp.from(value.toInstant());
 
         PreparedStatement stmt = EasyMock.createNiceMock(PreparedStatement.class);
         stmt.setTimestamp(1, ts);
@@ -47,7 +47,7 @@ public class JSR310OffsetDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest
     @Test
     public void get() throws SQLException {
         ResultSet resultSet = EasyMock.createNiceMock(ResultSet.class);
-        EasyMock.expect(resultSet.getTimestamp(1, UTC)).andReturn(new Timestamp(UTC.getTimeInMillis()));
+        EasyMock.expect(resultSet.getTimestamp(1, UTC)).andReturn(Timestamp.from(UTC.toInstant()));
         EasyMock.replay(resultSet);
 
         OffsetDateTime result = type.getValue(resultSet, 1);

--- a/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310ZonedDateTimeTypeTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310ZonedDateTimeTypeTest.java
@@ -1,7 +1,7 @@
 package com.querydsl.sql.types;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.easymock.EasyMock;
+import org.junit.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -9,8 +9,8 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 
-import org.easymock.EasyMock;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class JSR310ZonedDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<ZonedDateTime> {
 
@@ -21,7 +21,7 @@ public class JSR310ZonedDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<
     @Test
     public void set() throws SQLException {
         ZonedDateTime value = ZonedDateTime.now();
-        Timestamp ts = new Timestamp(value.toInstant().toEpochMilli());
+        Timestamp ts = Timestamp.from(value.toInstant());
 
         PreparedStatement stmt = EasyMock.createNiceMock(PreparedStatement.class);
         stmt.setTimestamp(1, ts, UTC);
@@ -34,7 +34,7 @@ public class JSR310ZonedDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<
     @Test
     public void jodaSet() throws SQLException {
         ZonedDateTime value = ZonedDateTime.now();
-        Timestamp ts = new Timestamp(value.toInstant().toEpochMilli());
+        Timestamp ts = Timestamp.from(value.toInstant());
 
         PreparedStatement stmt = EasyMock.createNiceMock(PreparedStatement.class);
         stmt.setTimestamp(1, ts);
@@ -47,7 +47,7 @@ public class JSR310ZonedDateTimeTypeTest extends AbstractJSR310DateTimeTypeTest<
     @Test
     public void get() throws SQLException {
         ResultSet resultSet = EasyMock.createNiceMock(ResultSet.class);
-        EasyMock.expect(resultSet.getTimestamp(1, UTC)).andReturn(new Timestamp(UTC.getTimeInMillis()));
+        EasyMock.expect(resultSet.getTimestamp(1, UTC)).andReturn(Timestamp.from(UTC.toInstant()));
         EasyMock.replay(resultSet);
 
         ZonedDateTime result = type.getValue(resultSet, 1);


### PR DESCRIPTION
The current code truncates the nano seconds when converting java 8 timestamps (`LocalDateTime`, `OffsetDateTime`, ...). This makes it impossible to do a comparison of timestamps at the database level since there may be timestamp values containing nano seconds stored in the database.