### PR TITLE
Register APT extensions by service loader

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
@@ -213,6 +213,12 @@ public class DefaultConfiguration implements Configuration {
             // do nothing
         }
 
+        ServiceLoader<Extension> loader = ServiceLoader.load(Extension.class, Extension.class.getClassLoader());
+
+        for (Extension extension : loader) {
+            extension.addSupport(module);
+        }
+
         defaultSerializerConfig = new SimpleSerializerConfig(entityAccessors, listAccessors,
                 mapAccessors, createDefaultVariable, "");
 

--- a/querydsl-apt/src/main/java/com/querydsl/apt/Extension.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/Extension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.apt;
+
+import com.querydsl.codegen.AbstractModule;
+
+/**
+ * {@code Extension} allows for custom code generation extensions to be registered as service provider
+ *
+ * @author Jan-Willem Gmelig Meyling
+ *
+ */
+public interface Extension {
+
+    /**
+     * Register custom types to the given codegen module
+     *
+     * @param module module to be customized
+     */
+    void addSupport(AbstractModule module);
+
+}


### PR DESCRIPTION
Ability to register APT extensions through a [Service Loader API](https://itnext.io/java-service-provider-interface-understanding-it-via-code-30e1dd45a091). Through this means additional artefacts on the classpath can add behaviour to the code generation. This allows for the `querydsl-spatial` module to be developed separately - after removal, but it also opens the door for other extensions that want to hook on the code generation (i.e. any sort of custom types).