### PR TITLE
Bind APT ProcessingEnvironment in APT module

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
@@ -20,6 +20,7 @@ import java.util.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.*;
 import javax.lang.model.type.TypeMirror;
@@ -78,8 +79,8 @@ public class DefaultConfiguration implements Configuration {
     private Function<EntityType, String> variableNameFunction;
 
     public DefaultConfiguration(
+            ProcessingEnvironment processingEnvironment,
             RoundEnvironment roundEnv,
-            Map<String, String> options,
             Collection<String> keywords,
             @Nullable Class<? extends Annotation> entitiesAnn,
             Class<? extends Annotation> entityAnn,
@@ -91,6 +92,7 @@ public class DefaultConfiguration implements Configuration {
         this.excludedPackages = new HashSet<String>();
         this.includedClasses = new HashSet<String>();
         this.includedPackages = new HashSet<String>();
+        module.bind(ProcessingEnvironment.class, processingEnvironment);
         module.bind(RoundEnvironment.class, roundEnv);
         module.bind(CodegenModule.KEYWORDS, keywords);
         this.entitiesAnn = entitiesAnn;
@@ -122,6 +124,7 @@ public class DefaultConfiguration implements Configuration {
         boolean listAccessors = false;
         boolean mapAccessors = false;
         boolean createDefaultVariable = true;
+        Map<String, String> options = processingEnvironment.getOptions();
 
         if (options.containsKey(QUERYDSL_ENTITY_ACCESSORS)) {
             entityAccessors = Boolean.valueOf(options.get(QUERYDSL_ENTITY_ACCESSORS));

--- a/querydsl-apt/src/main/java/com/querydsl/apt/QuerydslAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/QuerydslAnnotationProcessor.java
@@ -41,7 +41,7 @@ public class QuerydslAnnotationProcessor extends AbstractQuerydslProcessor {
         Class<? extends Annotation> skip = QueryTransient.class;
 
         return new DefaultConfiguration(
-                roundEnv, processingEnv.getOptions(), Collections.<String>emptySet(), entities,
+                processingEnv, roundEnv, Collections.<String>emptySet(), entities,
                 entity, superType, embeddable, embedded, skip);
     }
 

--- a/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateAnnotationProcessor.java
@@ -40,7 +40,7 @@ public class HibernateAnnotationProcessor extends JPAAnnotationProcessor {
             Class<? extends Annotation> embeddable = Embeddable.class;
             Class<? extends Annotation> embedded = Embedded.class;
             Class<? extends Annotation> skip = Transient.class;
-            return new HibernateConfiguration(roundEnv, processingEnv, processingEnv.getOptions(), entity, superType,
+            return new HibernateConfiguration(roundEnv, processingEnv, entity, superType,
                     embeddable, embedded, skip);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateConfiguration.java
@@ -17,7 +17,6 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -36,13 +35,12 @@ public class HibernateConfiguration extends JPAConfiguration {
     public HibernateConfiguration(
             RoundEnvironment roundEnv,
             ProcessingEnvironment processingEnv,
-            Map<String,String> options,
             Class<? extends Annotation> entityAnn,
             Class<? extends Annotation> superTypeAnn,
             Class<? extends Annotation> embeddableAnn,
             Class<? extends Annotation> embeddedAnn,
             Class<? extends Annotation> skipAnn) throws ClassNotFoundException {
-        super(roundEnv, processingEnv, options, entityAnn, superTypeAnn, embeddableAnn, embeddedAnn, skipAnn);
+        super(roundEnv, processingEnv, entityAnn, superTypeAnn, embeddableAnn, embeddedAnn, skipAnn);
     }
 
     @SuppressWarnings("unchecked")

--- a/querydsl-apt/src/main/java/com/querydsl/apt/jdo/JDOAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/jdo/JDOAnnotationProcessor.java
@@ -45,7 +45,7 @@ public class JDOAnnotationProcessor extends AbstractQuerydslProcessor {
         Class<? extends Annotation> embeddable = EmbeddedOnly.class;
         Class<? extends Annotation> embedded = QueryEmbedded.class;
         Class<? extends Annotation> skip = NotPersistent.class;
-        return new JDOConfiguration(roundEnv, processingEnv.getOptions(),
+        return new JDOConfiguration(processingEnv, roundEnv,
                 entities, entity, superType, embeddable, embedded, skip);
     }
 }

--- a/querydsl-apt/src/main/java/com/querydsl/apt/jdo/JDOConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/jdo/JDOConfiguration.java
@@ -17,8 +17,8 @@ package com.querydsl.apt.jdo;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
-import java.util.Map;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.jdo.annotations.*;
 import javax.lang.model.element.Element;
@@ -51,14 +51,14 @@ public class JDOConfiguration extends DefaultConfiguration {
                     Order.class, Persistent.class, PrimaryKey.class, QueryType.class, QueryInit.class,
                     QueryTransient.class, Serialized.class, Transactional.class, Unique.class, Value.class);
 
-    public JDOConfiguration(RoundEnvironment roundEnv,
-            Map<String, String> options,
+    public JDOConfiguration(ProcessingEnvironment processingEnvironment,
+            RoundEnvironment roundEnv,
             Class<? extends Annotation> entitiesAnn,
             Class<? extends Annotation> entityAnn,
             Class<? extends Annotation> superTypeAnn,
             Class<? extends Annotation> embeddableAnn,
             Class<? extends Annotation> embeddedAnn, Class<? extends Annotation> skipAnn) {
-        super(roundEnv, options, Keywords.JDO, entitiesAnn, entityAnn, superTypeAnn,
+        super(processingEnvironment, roundEnv, Keywords.JDO, entitiesAnn, entityAnn, superTypeAnn,
                 embeddableAnn, embeddedAnn, skipAnn);
     }
 

--- a/querydsl-apt/src/main/java/com/querydsl/apt/jpa/JPAAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/jpa/JPAAnnotationProcessor.java
@@ -39,7 +39,7 @@ public class JPAAnnotationProcessor extends AbstractQuerydslProcessor {
         Class<? extends Annotation> embeddable = Embeddable.class;
         Class<? extends Annotation> embedded = Embedded.class;
         Class<? extends Annotation> skip = Transient.class;
-        return new JPAConfiguration(roundEnv, processingEnv, processingEnv.getOptions(),
+        return new JPAConfiguration(roundEnv, processingEnv,
                 entity, superType, embeddable, embedded, skip);
     }
 

--- a/querydsl-apt/src/main/java/com/querydsl/apt/jpa/JPAConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/jpa/JPAConfiguration.java
@@ -15,7 +15,6 @@ package com.querydsl.apt.jpa;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -45,13 +44,12 @@ public class JPAConfiguration extends DefaultConfiguration {
 
     public JPAConfiguration(RoundEnvironment roundEnv,
             ProcessingEnvironment processingEnv,
-            Map<String,String> options,
             Class<? extends Annotation> entityAnn,
             Class<? extends Annotation> superTypeAnn,
             Class<? extends Annotation> embeddableAnn,
             Class<? extends Annotation> embeddedAnn,
             Class<? extends Annotation> skipAnn) {
-        super(roundEnv, options, Keywords.JPA, QueryEntities.class, entityAnn, superTypeAnn,
+        super(processingEnv, roundEnv, Keywords.JPA, QueryEntities.class, entityAnn, superTypeAnn,
             embeddableAnn, embeddedAnn, skipAnn);
         this.annotations = getAnnotations();
         this.types = processingEnv.getTypeUtils();

--- a/querydsl-apt/src/main/java/com/querydsl/apt/morphia/MorphiaAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/morphia/MorphiaAnnotationProcessor.java
@@ -46,8 +46,8 @@ public class MorphiaAnnotationProcessor extends AbstractQuerydslProcessor {
         Class<? extends Annotation> superType = QuerySupertype.class;
         Class<? extends Annotation> embedded = Embedded.class;
         Class<? extends Annotation> skip = Transient.class;
-        DefaultConfiguration conf = new DefaultConfiguration(roundEnv,
-                processingEnv.getOptions(), Collections.<String>emptySet(),
+        DefaultConfiguration conf = new DefaultConfiguration(processingEnv, roundEnv,
+                Collections.<String>emptySet(),
                 entities, entity, superType, null, embedded, skip);
         try {
             @SuppressWarnings("unchecked") // Point is an Expression<Double[]>

--- a/querydsl-apt/src/main/java/com/querydsl/apt/roo/RooAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/roo/RooAnnotationProcessor.java
@@ -47,7 +47,7 @@ public class RooAnnotationProcessor extends AbstractQuerydslProcessor {
         Class<? extends Annotation> embeddable = Embeddable.class;
         Class<? extends Annotation> embedded = Embedded.class;
         Class<? extends Annotation> skip = Transient.class;
-        DefaultConfiguration conf = new JPAConfiguration(roundEnv, processingEnv, processingEnv.getOptions(),
+        DefaultConfiguration conf = new JPAConfiguration(roundEnv, processingEnv,
                 entity, superType, embeddable, embedded, skip);
         conf.setAlternativeEntityAnnotation(RooJpaActiveRecord.class);
         return conf;


### PR DESCRIPTION
Kind of a companion to my other PR #2512, this PR makes it more easily to extend QueryDSL.

The `AbstractModule` already exposes its `RoundEnvironment`, but not the `ProcessingEnvironment`. Any `Element` returned from the `RoundEnvironment` is very likely to need processing by the `Types` utils only available through the `ProcessingEnvironment`. Exposing the `ProcessingEnvironment` through `AbstractModule.get(ProcessingEnvironment.class)` provides this flexibility.

