### PR TITLE
Allow extension of AbstractQuery#createQuery

### DIFF
--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -94,7 +94,7 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
         return createQuery(getMetadata().getModifiers(), false);
     }
 
-    private Query createQuery(@Nullable QueryModifiers modifiers, boolean forCount) {
+    protected Query createQuery(@Nullable QueryModifiers modifiers, boolean forCount) {
         JPQLSerializer serializer = serialize(forCount);
         String queryString = serializer.toString();
         logQuery(queryString, serializer.getConstantToLabel());


### PR DESCRIPTION
Subclasses of `AbstractQuery` may override `createQuery()`, but not `createQuery(QueryModifiers, boolean)`. This leads to issues when subclasses want to adjust the rendering method. While overriding `createQuery` covers most use cases, some specific methods use `createQuery(QueryModifiers, boolean)` instead.  As a result, one has to override `fetchCount`, `fetchResults`, `getResultList` , `fetchOne` and `getSingleResult` as well.

As a proof of concept, see how I've extended `AbstractQuery` for it to execute queries on top of [Blaze-Persistence](https://github.com/Blazebit/blaze-persistence) Criteria Builder API in: https://github.com/jwgmeligmeyling/blaze-persistence-querydsl