### PR TITLE
[#658] Support JPQL Treated paths for WHERE clause

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,9 @@
                     <exclude>com/querydsl/sql/types/LocalDateTimeType</exclude>
                     <exclude>com/querydsl/sql/types/LocalDateType</exclude>
                     <exclude>com/querydsl/sql/types/LocalTimeType</exclude>
+                    <exclude>com/querydsl/jpa/Hibernate5Templates</exclude>
+                    <exclude>com/querydsl/jpa/HibernateHandler</exclude>
+                    <exclude>com/querydsl/jpa/JPAExpressions</exclude>
                   </excludes>
                   <compatibilityType>BACKWARD_COMPATIBLE_USER</compatibilityType>
                   <dumpDetails>true</dumpDetails>

--- a/querydsl-core/src/main/java/com/querydsl/core/types/PathType.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/PathType.java
@@ -65,7 +65,12 @@ public enum PathType implements Operator {
     /**
      * Root path
      */
-    VARIABLE;
+    VARIABLE,
+
+    /**
+     * Treated path
+     */
+    TREATED_PATH;
 
     @Override
     public Class<?> getType() {

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAExpressions.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAExpressions.java
@@ -17,10 +17,18 @@ import com.querydsl.core.Tuple;
 import com.querydsl.core.types.CollectionExpression;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionException;
 import com.querydsl.core.types.Ops;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.PathType;
+import com.querydsl.core.types.dsl.BeanPath;
 import com.querydsl.core.types.dsl.ComparableExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
+
+import javax.persistence.Entity;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
 
 /**
  * {@code JPAExpressions} provides factory methods for JPQL specific operations
@@ -103,6 +111,31 @@ public final class JPAExpressions {
     }
 
     /**
+     * Create a JPA 2.1 treated path.
+     *
+     * @param path The path to apply the treat operation on
+     * @param subtype subtype class
+     * @param <U> the subtype class
+     * @param <T> the expression type
+     * @return subtype instance with the same identity
+     */
+    public static <U extends BeanPath<? extends T>, T> U treat(BeanPath<? extends T> path, Class<U> subtype)  {
+        try {
+            Class<? extends T> entitySubType = getConcreteEntitySubType(subtype);
+            PathMetadata pathMetadata = new PathMetadata(path, getEntityName(entitySubType), PathType.TREATED_PATH);
+            return subtype.getConstructor(PathMetadata.class).newInstance(pathMetadata);
+        } catch (InstantiationException e) {
+            throw new ExpressionException(e.getMessage(), e);
+        } catch (IllegalAccessException e) {
+            throw new ExpressionException(e.getMessage(), e);
+        } catch (InvocationTargetException e) {
+            throw new ExpressionException(e.getMessage(), e);
+        } catch (NoSuchMethodException e) {
+            throw new ExpressionException(e.getMessage(), e);
+        }
+    }
+
+    /**
      * Create a avg(col) expression
      *
      * @param col collection
@@ -140,6 +173,22 @@ public final class JPAExpressions {
      */
     public static StringExpression type(EntityPath<?> path) {
         return Expressions.stringOperation(JPQLOps.TYPE, path);
+    }
+
+    private static String getEntityName(Class<?> clazz) {
+        final Entity entityAnnotation = clazz.getAnnotation(Entity.class);
+        if (entityAnnotation != null && entityAnnotation.name().length() > 0) {
+            return entityAnnotation.name();
+        } else if (clazz.getPackage() != null) {
+            String pn = clazz.getPackage().getName();
+            return clazz.getName().substring(pn.length() + 1);
+        } else {
+            return clazz.getName();
+        }
+    }
+
+    private static <U extends BeanPath<? extends T>, T> Class<? extends T> getConcreteEntitySubType(Class<U> subtype) {
+        return (Class<? extends T>) ((ParameterizedType) subtype.getGenericSuperclass()).getActualTypeArguments()[0];
     }
 
     private JPAExpressions() { }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLTemplates.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLTemplates.java
@@ -144,6 +144,7 @@ public class JPQLTemplates extends Templates {
         // path types
         add(PathType.PROPERTY, "{0}.{1s}");
         add(PathType.VARIABLE, "{0s}");
+        add(PathType.TREATED_PATH, "treat({0} as {1s})");
 
         // case for eq
         add(Ops.CASE_EQ, "case {1} end");

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPQLSerializerTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPQLSerializerTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.querydsl.core.DefaultQueryMetadata;
 import com.querydsl.core.JoinType;
 import com.querydsl.core.QueryMetadata;
+import com.querydsl.core.domain.QAnimal;
 import com.querydsl.core.domain.QCat;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
@@ -251,6 +252,21 @@ public class JPQLSerializerTest {
         assertEquals("select domesticCat\n" +
                 "from Cat cat\n" +
                 "  inner join treat(cat.mate as DomesticCat) as domesticCat", serializer.toString());
+    }
+
+    @Test
+    public void treated_path() {
+        QAnimal animal = QAnimal.animal;
+        JPQLSerializer serializer = new JPQLSerializer(HQLTemplates.DEFAULT);
+        QueryMetadata md = new DefaultQueryMetadata();
+        md.addJoin(JoinType.DEFAULT, animal);
+
+        md.addWhere(JPAExpressions.treat(animal, QCat.class).breed.eq(1));
+        md.setProjection(animal);
+        serializer.serialize(md, false, null);
+        assertEquals("select animal\n" +
+                "from Animal animal\n" +
+                "where treat(animal as Cat).breed = ?1", serializer.toString());
     }
 
     @Test


### PR DESCRIPTION
JPA 2.1 introduced the TREAT operator for explicit casting. Initial support for TREAT in the FROM clause was added in PR #705. However, the [specification](https://download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf) also describes the notion of `treated_subpath` expressions (chapter 4.4.4.1) that are allowed in the WHERE clause of a query.

The syntax is as follows:

> ```
> treated_subpath ::= TREAT(general_subpath AS subtype)
>
> single_valued_path_expression ::= qualified_identification_variable | 
>     TREAT(qualified_identification_variable AS subtype) | 
>     state_field_path_expression | 
>     single_valued_object_path_expression
> ```

And can be used as such:

```SQL
SELECT e FROM Employee e JOIN e.projects p WHERE TREAT(p AS LargeProject).budget > 1000
```

(Example from chapter 4.4.9).

This pull request adds the support for treated subpaths in QueryDSL. It does so by introducing a new `PathType` and convenience method `JPAExpressions.treat`.

Fixes #658

A full list of treat support throughout JPA providers can be found at https://github.com/beikov/jpa-treat-variations