### PR TITLE
use LinkedHashSet for deterministic order

### DIFF
--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
@@ -34,7 +34,7 @@ public class EntityType extends TypeAdapter implements Comparable<EntityType> {
 
     private final Map<Class<?>,Annotation> annotations = new HashMap<Class<?>,Annotation>();
 
-    private final Set<Constructor> constructors = new HashSet<Constructor>();
+    private final Set<Constructor> constructors = new LinkedHashSet<Constructor>();
 
     private int escapeSuffix = 1;
 


### PR DESCRIPTION
The tests in `com.querydsl.apt.GenericExporterTest#execute` and `com.querydsl.apt.GenericExporterTest#execute2` can fail due to a different iteration order. The failure is presented as follows.

execute2(com.querydsl.apt.GenericExporterTest) 
java.lang.AssertionError: Following expected failures succeeded:[QQueryProjectionTest_EntityWithProjection.java]
at org.junit.Assert.fail(Assert.java:88)
at com.querydsl.apt.GenericExporterTest.execute(GenericExporterTest.java:156)
at com.querydsl.apt.GenericExporterTest.execute2(GenericExporterTest.java:95)


I have analyzed why this will happen and I want to share the following stack trace of the `HashSet.iterator` with you:
java.util.HashSet.iterator(HashSet.java:173)
com.querydsl.codegen.EntitySerializer.introFactoryMethods(EntitySerializer.java:342)
com.querydsl.codegen.EntitySerializer.intro(EntitySerializer.java:276)
......
com.querydsl.apt.AbstractProcessorTest.process(AbstractProcessorTest.java:54)
com.querydsl.apt.GenericExporterTest.execute2(GenericExporterTest.java:60)

The initialization of the `HashSet` in `querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java`. The specification about `HashSet` says that "it makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html

The original tests may fail or pass without any changes made to the source code and cannot serve as good regression tests. The fix is to use `LinkedHashSet` instead of `HashSet` so that the non-deterministic iteration order of HashSet is eliminated and the tests will become more stable.

