### PR TITLE
refactor: added `HibernateHandlerTest` code and refactoring `HibernateHandler` (#2264)

### DIFF
--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
@@ -37,16 +37,18 @@ class HibernateHandler implements QueryHandler {
     @Override
     public void addEntity(Query query, String alias, Class<?> type) {
         if (query instanceof NativeQuery) {
-            NativeQuery hibernateQuery = (NativeQuery) query;
-            hibernateQuery.addEntity(alias, type);
+            query.unwrap(NativeQuery.class).addEntity(alias, type);
+        } else {
+            throw new IllegalArgumentException(String.format("invalid Query type `%s` in HibernateHandler", query.getClass()));
         }
     }
 
     @Override
     public void addScalar(Query query, String alias, Class<?> type) {
         if (query instanceof NativeQuery) {
-            NativeQuery hibernateQuery = (NativeQuery) query;
-            hibernateQuery.addScalar(alias);
+            query.unwrap(NativeQuery.class).addScalar(alias);
+        } else {
+            throw new IllegalArgumentException(String.format("invalid Query type `%s` in HibernateHandler", query.getClass()));
         }
     }
 
@@ -81,7 +83,7 @@ class HibernateHandler implements QueryHandler {
     public boolean transform(Query query, FactoryExpression<?> projection) {
         if (query instanceof NativeQuery) {
             ResultTransformer transformer = new FactoryExpressionTransformer(projection);
-            ((NativeQuery) query).setResultTransformer(transformer);
+            query.unwrap(NativeQuery.class).setResultTransformer(transformer);
             return true;
         } else {
             return false;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
@@ -36,20 +36,12 @@ class HibernateHandler implements QueryHandler {
 
     @Override
     public void addEntity(Query query, String alias, Class<?> type) {
-        if (query instanceof NativeQuery) {
-            query.unwrap(NativeQuery.class).addEntity(alias, type);
-        } else {
-            throw new IllegalArgumentException(String.format("invalid Query type `%s` in HibernateHandler", query.getClass()));
-        }
+        query.unwrap(NativeQuery.class).addEntity(alias, type);
     }
 
     @Override
     public void addScalar(Query query, String alias, Class<?> type) {
-        if (query instanceof NativeQuery) {
-            query.unwrap(NativeQuery.class).addScalar(alias);
-        } else {
-            throw new IllegalArgumentException(String.format("invalid Query type `%s` in HibernateHandler", query.getClass()));
-        }
+        query.unwrap(NativeQuery.class).addScalar(alias);
     }
 
     @Override

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateHandlerTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateHandlerTest.java
@@ -1,0 +1,115 @@
+package com.querydsl.jpa;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javax.persistence.Query;
+
+import org.hibernate.query.NativeQuery;
+import org.hibernate.query.spi.ScrollableResultsImplementor;
+import org.hibernate.transform.ResultTransformer;
+import org.junit.Test;
+
+import com.mysema.commons.lang.IteratorAdapter;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.jpa.domain4.Library;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hibernate.ScrollMode.FORWARD_ONLY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HibernateHandlerTest {
+
+    private final HibernateHandler hibernateHandler = new HibernateHandler();
+    private final NativeQuery nativeQuery = createMock(NativeQuery.class);
+    private final String alias = "library";
+    private final Class<Library> classType = Library.class;
+
+    @Test
+    public void should_add_entity() {
+        expect(nativeQuery.unwrap(NativeQuery.class)).andReturn(nativeQuery);
+        expect(nativeQuery.addEntity(alias, classType)).andReturn(nativeQuery);
+        replay(nativeQuery);
+
+        hibernateHandler.addEntity(nativeQuery, alias, classType);
+
+        verify(nativeQuery);
+    }
+
+    @Test
+    public void should_add_scalar() {
+        expect(nativeQuery.unwrap(NativeQuery.class)).andReturn(nativeQuery);
+        expect(nativeQuery.addScalar(alias)).andReturn(nativeQuery);
+        replay(nativeQuery);
+
+        hibernateHandler.addScalar(nativeQuery, alias, classType);
+
+        verify(nativeQuery);
+    }
+
+    @Test
+    public void should_get_false_when_check_native_query_type() {
+        assertFalse(hibernateHandler.createNativeQueryTyped());
+    }
+
+    @Test
+    public void should_get_true_when_check_wrap_entity_projections_for_hibernate_query_syntax_by_using_curly_braces() {
+        assertTrue(hibernateHandler.wrapEntityProjections());
+    }
+
+    @Test
+    public void should_return_transforming_iterator_when_call_iterate_function() {
+        ScrollableResultsImplementor scrollableResultsImplementor = createMock(ScrollableResultsImplementor.class);
+        FactoryExpression<?> factoryExpression = createMock(FactoryExpression.class);
+
+        expect(nativeQuery.unwrap(NativeQuery.class)).andReturn(nativeQuery);
+        expect(nativeQuery.scroll(FORWARD_ONLY)).andReturn(scrollableResultsImplementor);
+
+        assertEquals(TransformingIterator.class, hibernateHandler.iterate(nativeQuery, factoryExpression).getClass());
+    }
+
+    @Test
+    public void should_return_iterator_adapter_when_call_iterate_function() {
+        Query query = createMock(Query.class);
+        List queryResultList = createMock(List.class);
+        Iterator iterator = createMock(Iterator.class);
+
+        expect(query.getResultList()).andReturn(queryResultList);
+        expect(queryResultList.iterator()).andReturn(iterator);
+        replay(query);
+
+        assertEquals(IteratorAdapter.class, hibernateHandler.iterate(query, null).getClass());
+    }
+
+    @Test
+    public void should_ReturnTransformingIterator_when_other_query_implementor() {
+        Query query = createMock(Query.class);
+        FactoryExpression<?> factoryExpression = createMock(FactoryExpression.class);
+        List queryResultList = createMock(List.class);
+        Iterator iterator = createMock(Iterator.class);
+
+        expect(query.getResultList()).andReturn(queryResultList);
+        expect(queryResultList.iterator()).andReturn(iterator);
+        replay(query);
+
+        assertEquals(TransformingIterator.class, hibernateHandler.iterate(query, factoryExpression).getClass());
+    }
+
+    @Test
+    public void should_transform() {
+        FactoryExpression<?> projection = createMock(FactoryExpression.class);
+
+        expect(nativeQuery.unwrap(NativeQuery.class)).andReturn(nativeQuery);
+        expect(nativeQuery.setResultTransformer(anyObject(ResultTransformer.class))).andReturn(nativeQuery);
+        replay(nativeQuery);
+
+        assertTrue(hibernateHandler.transform(nativeQuery, projection));
+    }
+
+}

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateHandlerTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateHandlerTest.java
@@ -3,8 +3,11 @@ package com.querydsl.jpa;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
+import org.batoo.jpa.core.impl.criteria.QueryImpl;
+import org.eclipse.persistence.internal.localization.ExceptionLocalization;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.transform.ResultTransformer;
@@ -42,6 +45,19 @@ public class HibernateHandlerTest {
         verify(nativeQuery);
     }
 
+    @Test(expected = PersistenceException.class)
+    public void addEntity_should_throw_persistence_exception_when_invalid_query_type() {
+        Query notSupportedQuery = createMock(QueryImpl.class);
+        PersistenceException expectedThrow =
+            new PersistenceException(ExceptionLocalization.buildMessage("unable_to_unwrap_jpa",
+                                                                        new String[]{Query.class.getName(), NativeQuery.class.getName()}));
+
+        expect(notSupportedQuery.unwrap(NativeQuery.class)).andThrow(expectedThrow);
+        replay(notSupportedQuery);
+
+        hibernateHandler.addEntity(notSupportedQuery, alias, classType);
+    }
+
     @Test
     public void should_add_scalar() {
         expect(nativeQuery.unwrap(NativeQuery.class)).andReturn(nativeQuery);
@@ -51,6 +67,19 @@ public class HibernateHandlerTest {
         hibernateHandler.addScalar(nativeQuery, alias, classType);
 
         verify(nativeQuery);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void addScalar_should_throw_persistence_exception_when_invalid_query_type() {
+        Query notSupportedQuery = createMock(QueryImpl.class);
+        PersistenceException expectedThrow =
+            new PersistenceException(ExceptionLocalization.buildMessage("unable_to_unwrap_jpa",
+                                                                        new String[]{Query.class.getName(), NativeQuery.class.getName()}));
+
+        expect(notSupportedQuery.unwrap(NativeQuery.class)).andThrow(expectedThrow);
+        replay(notSupportedQuery);
+
+        hibernateHandler.addScalar(notSupportedQuery, alias, classType);
     }
 
     @Test


### PR DESCRIPTION
## Description

This issue has already been resolved, I did some refactoring with the test code.
* (https://github.com/querydsl/querydsl/pull/2510)

## Major changes

* Fix to throw an error

If the implementation of query is changed on hibernate side, logic skipping problem may occur once again. when this happens we should be aware of the problem.

