### PR TITLE
Change scope of hibernate-jpa-2.0-api to compile

### DIFF
--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -34,18 +34,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <version>1.0.0.Final</version>
+      <scope>compile</scope>
+    </dependency>
     
     <!-- provided -->
     <dependency>
       <groupId>javax.jdo</groupId>
       <artifactId>jdo-api</artifactId>
       <version>${jdo.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <version>1.0.0.Final</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -35,9 +35,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <version>1.0.0.Final</version>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>2.2.3</version>
       <scope>compile</scope>
     </dependency>
     

--- a/querydsl-hibernate-search/pom.xml
+++ b/querydsl-hibernate-search/pom.xml
@@ -72,9 +72,9 @@
     </dependency>    
  
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <version>1.0.0.Final</version>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>2.2.3</version>
       <scope>compile</scope>
     </dependency>
 

--- a/querydsl-hibernate-search/pom.xml
+++ b/querydsl-hibernate-search/pom.xml
@@ -75,7 +75,7 @@
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
       <version>2.2.3</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/querydsl-jpa-codegen/pom.xml
+++ b/querydsl-jpa-codegen/pom.xml
@@ -64,9 +64,9 @@
     </dependency>    
  
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <version>1.0.0.Final</version>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>2.2.3</version>
       <scope>compile</scope>
     </dependency>
 

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -75,9 +75,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
-      <version>1.0.0.Final</version>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>2.2.3</version>
       <scope>provided</scope>
     </dependency>
 

--- a/querydsl-maven-plugin/pom.xml
+++ b/querydsl-maven-plugin/pom.xml
@@ -87,9 +87,9 @@
             <version>${jdo.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.0-api</artifactId>
-            <version>1.0.0.Final</version>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>2.2.3</version>
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
This PR changes the scope of `hibernate-jpa-2.0-api` from `provided` to `compile` and fixes #2501.

I tested on my own machine; here's the output from `gradle dependencies` of a project that uses `querydsl-apt`:

```
annotationProcessor - Annotation processors and their dependencies for source set 'main'.
+--- com.querydsl:querydsl-apt:4.3.2-SNAPSHOT
|    +--- com.querydsl:querydsl-codegen:4.3.2-SNAPSHOT
|    |    +--- com.querydsl:querydsl-core:4.3.2-SNAPSHOT
|    |    |    +--- com.google.guava:guava:18.0
|    |    |    +--- com.google.code.findbugs:jsr305:1.3.9
|    |    |    +--- com.mysema.commons:mysema-commons-lang:0.2.4
|    |    |    \--- com.infradna.tool:bridge-method-annotation:1.13
|    |    +--- com.mysema.codegen:codegen:0.6.8
|    |    |    +--- com.google.guava:guava:18.0
|    |    |    \--- org.eclipse.jdt.core.compiler:ecj:4.3.1
|    |    +--- javax.inject:javax.inject:1
|    |    \--- org.reflections:reflections:0.9.9
|    |         +--- com.google.guava:guava:15.0
|    |         +--- org.javassist:javassist:3.18.2-GA
|    |         \--- com.google.code.findbugs:annotations:2.0.1
|    \--- org.hibernate.javax.persistence:hibernate-jpa-2.0-api:1.0.0.Final # <- did not appear for 4.3.1
\--- org.projectlombok:lombok:1.18.2
```

Fixes #2553 
Fixes #2554
Fixes #2488
Fixes #2501