### PR TITLE
Support generic query type mappings in TypeMapping (fixes #2561)

### DIFF
--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/TypeMappings.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/TypeMappings.java
@@ -33,6 +33,8 @@ import com.querydsl.core.types.TemplateExpression;
  */
 public abstract class TypeMappings {
 
+    private final Map<Type, Type> genericQueryTypes = new HashMap<Type, Type>();
+
     private final Map<String, Type> queryTypes = new HashMap<String, Type>();
 
     private final Map<TypeCategory, Type> exprTypes
@@ -57,7 +59,9 @@ public abstract class TypeMappings {
     }
 
     public Type getExprType(Type type, EntityType model, boolean raw, boolean rawParameters, boolean extend) {
-        if (queryTypes.containsKey(type.getFullName())) {
+        if (genericQueryTypes.containsKey(type)) {
+            return genericQueryTypes.get(type);
+        } else if (queryTypes.containsKey(type.getFullName())) {
             return queryTypes.get(type.getFullName());
         } else {
             return getQueryType(exprTypes, type, model, raw, rawParameters, extend);
@@ -69,7 +73,9 @@ public abstract class TypeMappings {
     }
 
     public Type getPathType(Type type, EntityType model, boolean raw, boolean rawParameters, boolean extend) {
-        if (queryTypes.containsKey(type.getFullName())) {
+        if (genericQueryTypes.containsKey(type)) {
+            return genericQueryTypes.get(type);
+        } else if (queryTypes.containsKey(type.getFullName())) {
             return queryTypes.get(type.getFullName());
         } else {
             return getQueryType(pathTypes, type, model, raw, rawParameters, extend);
@@ -121,9 +127,11 @@ public abstract class TypeMappings {
 
     public void register(Type type, Type queryType) {
         queryTypes.put(type.getFullName(), queryType);
+        genericQueryTypes.put(type, queryType);
     }
 
     public boolean isRegistered(Type type) {
         return queryTypes.containsKey(type.getFullName());
     }
+
 }

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/TypeMappingsTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/TypeMappingsTest.java
@@ -16,10 +16,14 @@ package com.querydsl.codegen;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.mysema.codegen.model.SimpleType;
 import org.junit.Test;
 
 import com.mysema.codegen.model.ClassType;
 import com.mysema.codegen.model.Type;
+
+import java.util.Collections;
+import java.util.List;
 
 public class TypeMappingsTest {
 
@@ -41,7 +45,23 @@ public class TypeMappingsTest {
         TypeMappings typeMappings = new JavaTypeMappings();
         typeMappings.register(new ClassType(Double[].class), new ClassType(Point.class));
         assertTrue(typeMappings.isRegistered(new ClassType(Double[].class)));
+    }
 
+    @Test
+    public void testGenericTypeRegistration() {
+        SimpleType rawListType = new SimpleType(List.class.getName());
+        SimpleType integerListType = new SimpleType(rawListType, Collections.<Type> singletonList(new SimpleType(Integer.class.getName())));
+        SimpleType longListType = new SimpleType(rawListType, Collections.<Type> singletonList(new SimpleType(Long.class.getName())));
+
+        SimpleType integerListTypeExpression = new SimpleType("integerListTypeExpression");
+        SimpleType longListTypeExpression = new SimpleType("longListTypeExpression");
+
+        TypeMappings typeMappings = new JavaTypeMappings();
+        typeMappings.register(integerListType, integerListTypeExpression);
+        typeMappings.register(longListType, longListTypeExpression);
+
+        assertEquals(integerListTypeExpression, typeMappings.getExprType(integerListType, null, false));
+        assertEquals(longListTypeExpression, typeMappings.getExprType(longListType, null, false));
     }
 
 }


### PR DESCRIPTION
Type parameters may be declared for `SimpleType`, but in the determination of the query type it is always looked up by raw type.

Types may be extended for the support of custom expressions. For example `querydsl-spatial` does this with the `GeometryType`:

```java
for (Map.Entry<String, String> entry : additions.entrySet()) {
    typeMappings.register(
            new SimpleType("org.geolatte.geom." + entry.getKey()),
            new SimpleType("com.querydsl.spatial." + entry.getValue()));
}
``` 

However, due to the limitation described above, extensions are not able to specify specific path implementations for different bounds, or for example pass on the generic bound to the path expression, like:

* `SomeGenericClass<Integer>` -> `SomeGenericPath<Integer>`
* `SomeGenericClass<Long>` -> `SomeGenericPath<Long>`

Because the mapping is based on raw class name, the latter will override the previous binding, and `SomeGenericPath<Long>` will be used for both types.


Fixes #2561

This feature is useful for implementing custom types. A proof of concept can be seen in my https://github.com/jwgmeligmeyling/hibernate-types-querydsl-apt repository.