### PR TITLE
Fix inconsistency between final and non-final methods in ComparableExpression, ComparableExpressionBase and SimpleExpression

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
@@ -51,7 +51,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @param to inclusive end of range
      * @return this between from and to
      */
-    public final BooleanExpression between(@Nullable T from, @Nullable T to) {
+    public BooleanExpression between(@Nullable T from, @Nullable T to) {
         if (from == null) {
             if (to != null) {
                 return Expressions.booleanOperation(Ops.LOE, mixin, ConstantImpl.create(to));
@@ -74,7 +74,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @param to inclusive end of range
      * @return this between from and to
      */
-    public final BooleanExpression between(@Nullable Expression<T> from, @Nullable Expression<T> to) {
+    public BooleanExpression between(@Nullable Expression<T> from, @Nullable Expression<T> to) {
         if (from == null) {
             if (to != null) {
                 return Expressions.booleanOperation(Ops.LOE, mixin, to);
@@ -98,7 +98,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @param to inclusive end of range
      * @return this not between from and to
      */
-    public final BooleanExpression notBetween(T from, T to) {
+    public BooleanExpression notBetween(T from, T to) {
         return between(from, to).not();
     }
 
@@ -111,7 +111,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @param to inclusive end of range
      * @return this not between from and to
      */
-    public final BooleanExpression notBetween(Expression<T> from, Expression<T> to) {
+    public BooleanExpression notBetween(Expression<T> from, Expression<T> to) {
         return between(from, to).not();
     }
 
@@ -246,7 +246,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @return this &lt; right
      * @see java.lang.Comparable#compareTo(Object)
      */
-    public final BooleanExpression lt(T right) {
+    public BooleanExpression lt(T right) {
         return lt(ConstantImpl.create(right));
     }
 
@@ -257,7 +257,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @return this &lt; right
      * @see java.lang.Comparable#compareTo(Object)
      */
-    public final BooleanExpression lt(Expression<T> right) {
+    public BooleanExpression lt(Expression<T> right) {
         return Expressions.booleanOperation(Ops.LT, mixin, right);
     }
 
@@ -308,7 +308,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @return this &lt;= right
      * @see java.lang.Comparable#compareTo(Object)
      */
-    public final BooleanExpression loe(T right) {
+    public BooleanExpression loe(T right) {
         return Expressions.booleanOperation(Ops.LOE, mixin, ConstantImpl.create(right));
     }
 
@@ -319,7 +319,7 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @return this &lt;= right
      * @see java.lang.Comparable#compareTo(Object)
      */
-    public final BooleanExpression loe(Expression<T> right) {
+    public BooleanExpression loe(Expression<T> right) {
         return Expressions.booleanOperation(Ops.LOE, mixin, right);
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
@@ -43,7 +43,7 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
      *
      * @return ascending order by this
      */
-    public final OrderSpecifier<T> asc() {
+    public OrderSpecifier<T> asc() {
         if (asc == null) {
             asc = new OrderSpecifier<T>(Order.ASC, mixin);
         }
@@ -57,7 +57,7 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
      * @return coalesce
      */
     @SuppressWarnings("unchecked")
-    public final Coalesce<T> coalesce(Expression<?>...exprs) {
+    public Coalesce<T> coalesce(Expression<?>...exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (Expression expr : exprs) {
             coalesce.add(expr);
@@ -71,7 +71,7 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
      * @param args additional arguments
      * @return coalesce
      */
-    public final Coalesce<T> coalesce(T... args) {
+    public Coalesce<T> coalesce(T... args) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (T arg : args) {
             coalesce.add(arg);
@@ -84,7 +84,7 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
      *
      * @return descending order by this
      */
-    public final OrderSpecifier<T> desc() {
+    public OrderSpecifier<T> desc() {
         if (desc == null) {
             desc = new OrderSpecifier<T>(Order.DESC, mixin);
         }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
@@ -318,7 +318,7 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      * @param right rhs of the comparison
      * @return this not in right
      */
-    public final BooleanExpression notIn(CollectionExpression<?,? extends T> right) {
+    public BooleanExpression notIn(CollectionExpression<?,? extends T> right) {
         return Expressions.booleanOperation(Ops.NOT_IN, mixin, right);
     }
 
@@ -328,7 +328,7 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      * @param right rhs of the comparison
      * @return this not in right
      */
-    public final BooleanExpression notIn(SubQueryExpression<? extends T> right) {
+    public BooleanExpression notIn(SubQueryExpression<? extends T> right) {
         return Expressions.booleanOperation(Ops.NOT_IN, mixin, right);
     }
 
@@ -338,7 +338,7 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      * @param right rhs of the comparison
      * @return this not in right
      */
-    public final BooleanExpression notIn(Expression<? extends T>... right) {
+    public BooleanExpression notIn(Expression<? extends T>... right) {
         return Expressions.booleanOperation(Ops.NOT_IN, mixin, Expressions.list(right));
     }
 


### PR DESCRIPTION
Most methods in ComparableExpression, ComparableExpressionBase and SimpleExpression are non-final and thus open for extension. Some methods however are final. Most of these methods are even introduced in the same commit.

Admittedly, the behavior of these methods should rely on the base implementations most of the time. However, sometimes it is necessary to override these methods. For example parameters that are mapped using a custom type, might need to be wrapped in for example a [`org.hibernate.jpa.TypedParameterValue`](https://docs.jboss.org/hibernate/orm/current/javadocs/org/hibernate/jpa/TypedParameterValue.html) before they should be put in a `Constant` expression. `Expression` type implementations for these types of custom types, may want to take responsibility for this conversion:


```java
@Override
public BooleanExpression eq(T right) {
    return super.eq((Expression) Expressions.constant(new TypedParameterValue(PostgreSQLIntervalType.INSTANCE, right)));
}
```

This change allows extensions from `ComparableExpression`, `ComparableExpressionBase` and `SimpleExpression` for a couple of additional methods. Most of the methods were already non-final anyway.

Fixes #2564