### PR TITLE
ResultTransformers for Guava collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,10 @@
   <groupId>com.querydsl</groupId>
   <artifactId>querydsl-root</artifactId>
   <version>5.0.0-SNAPSHOT</version>
-  <name>Querydsl</name>
+    <modules>
+        <module>querydsl-guava</module>
+    </modules>
+    <name>Querydsl</name>
   <description>parent project for Querydsl modules</description>
   <url>${project.homepage}</url>
   

--- a/querydsl-collections/pom.xml
+++ b/querydsl-collections/pom.xml
@@ -68,6 +68,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.querydsl</groupId>
+      <artifactId>querydsl-guava</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
       <version>${cglib.version}</version>

--- a/querydsl-collections/src/test/java/com/querydsl/collections/GroupBy4Test.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/GroupBy4Test.java
@@ -1,8 +1,29 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.querydsl.collections;
 
-import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.map;
-import static org.junit.Assert.assertEquals;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.querydsl.core.annotations.QueryEntity;
+import com.querydsl.core.group.guava.GuavaGroupBy;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,9 +31,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-
-import com.querydsl.core.annotations.QueryEntity;
+import static com.querydsl.core.group.GroupBy.list;
+import static com.querydsl.core.group.guava.GuavaGroupBy.groupBy;
+import static com.querydsl.core.group.guava.GuavaGroupBy.map;
+import static org.junit.Assert.assertEquals;
 
 
 public class GroupBy4Test {
@@ -47,6 +69,205 @@ public class GroupBy4Test {
         assertEquals(2, grouped.get("1").size());
         assertEquals(new HashSet<>(Arrays.asList("abc", "pqr")),  grouped.get("1").keySet());
 
+    }
+
+    @Test
+    public void test2() {
+        List<Table> data = Lists.newArrayList();
+        data.add(new Table("1", "abc", "111"));
+        data.add(new Table("1", "pqr", "222"));
+        data.add(new Table("2", "abc", "333"));
+        data.add(new Table("2", "pqr", "444"));
+        data.add(new Table("3", "abc", "555"));
+        data.add(new Table("3", "pqr", "666"));
+
+        QGroupBy4Test_Table table = QGroupBy4Test_Table.table;
+        Multimap<String, String> transform = CollQueryFactory
+                .from(table, data)
+                .transform(groupBy(table.col1).asMultimap(table.col2));
+
+        Multimap<String, String> expected = HashMultimap.create(
+                ImmutableMultimap.<String, String> builder()
+                        .putAll("1", "abc", "pqr")
+                        .putAll("2", "abc", "pqr")
+                        .putAll("3", "abc", "pqr")
+                        .build());
+
+        assertEquals(expected, transform);
+    }
+
+    @Test
+    public void test3() {
+        List<Table> data = Lists.newArrayList();
+        data.add(new Table("1", "abc", "111"));
+        data.add(new Table("1", "pqr", "222"));
+        data.add(new Table("2", "abc", "333"));
+        data.add(new Table("2", "pqr", "444"));
+        data.add(new Table("3", "abc", "555"));
+        data.add(new Table("3", "pqr", "666"));
+
+        QGroupBy4Test_Table table = QGroupBy4Test_Table.table;
+        Multimap<String, Map<String, String>> transform = CollQueryFactory
+                .from(table, data)
+                .transform(groupBy(table.col1).asMultimap(
+                        map(table.col2, table.col3)
+                ));
+
+        HashMultimap<String, Map<String, String>> expected = HashMultimap.create(ImmutableMultimap.<String, Map<String, String>>builder()
+                .putAll("1", ImmutableMap.of("abc", "111"), ImmutableMap.of("pqr", "222"))
+                .putAll("2", ImmutableMap.of("abc", "333"), ImmutableMap.of("pqr", "444"))
+                .putAll("3", ImmutableMap.of("abc", "555"), ImmutableMap.of("pqr", "666"))
+                .build()
+        );
+
+        assertEquals(expected, transform);
+    }
+
+    @Test
+    public void test4() {
+        List<Table> data = Lists.newArrayList();
+        data.add(new Table("1", "abc", "111"));
+        data.add(new Table("1", "pqr", "222"));
+        data.add(new Table("2", "abc", "333"));
+        data.add(new Table("2", "pqr", "444"));
+        data.add(new Table("3", "abc", "555"));
+        data.add(new Table("3", "pqr", "666"));
+
+
+        QGroupBy4Test_Table table = QGroupBy4Test_Table.table;
+        com.google.common.collect.Table<String, String, String> transform = CollQueryFactory
+                .from(table, data)
+                .transform(groupBy(table.col1).asTable(table.col2, table.col3));
+
+        ImmutableTable<String, String, String> expected = ImmutableTable.<String, String, String> builder()
+                .put("1", "abc", "111")
+                .put("1", "pqr", "222")
+                .put("2", "abc", "333")
+                .put("2", "pqr", "444")
+                .put("3", "abc", "555")
+                .put("3", "pqr", "666")
+                .build();
+
+        assertEquals(expected, transform);
+    }
+
+    @Test
+    public void test5() {
+        List<Table> data = Lists.newArrayList();
+        data.add(new Table("1", "abc", "111"));
+        data.add(new Table("1", "pqr", "222"));
+        data.add(new Table("2", "abc", "333"));
+        data.add(new Table("2", "pqr", "444"));
+        data.add(new Table("3", "abc", "555"));
+        data.add(new Table("3", "pqr", "666"));
+        data.add(new Table("3", "pqr", "777"));
+
+
+        QGroupBy4Test_Table table = QGroupBy4Test_Table.table;
+        com.google.common.collect.Table<String, String, List<String>> transform = CollQueryFactory
+                .from(table, data)
+                .transform(groupBy(table.col1).asTable(table.col2, list(table.col3)));
+
+        ImmutableTable<String, String, List<String>> expected = ImmutableTable.<String, String, List<String>> builder()
+                .put("1", "abc", ImmutableList.of("111"))
+                .put("1", "pqr", ImmutableList.of("222"))
+                .put("2", "abc", ImmutableList.of("333"))
+                .put("2", "pqr", ImmutableList.of("444"))
+                .put("3", "abc", ImmutableList.of("555"))
+                .put("3", "pqr", ImmutableList.of("666", "777"))
+                .build();
+
+        assertEquals(expected, transform);
+    }
+
+    @Test
+    public void test6() {
+        List<Table> data = Lists.newArrayList();
+        data.add(new Table("1", "abc", "111"));
+        data.add(new Table("1", "pqr", "222"));
+        data.add(new Table("2", "abc", "333"));
+        data.add(new Table("2", "pqr", "444"));
+        data.add(new Table("3", "abc", "555"));
+        data.add(new Table("3", "pqr", "666"));
+        data.add(new Table("3", "pqr", "777"));
+
+
+        QGroupBy4Test_Table table = QGroupBy4Test_Table.table;
+        Map<String, Multimap<String, String>> transform = CollQueryFactory
+                .from(table, data)
+                .transform(groupBy(table.col1).as(GuavaGroupBy.multimap(table.col2, table.col3)));
+
+        ImmutableMap<String, Multimap<String, String>> expected = ImmutableMap.<String, Multimap<String, String>> builder()
+                .put("1", HashMultimap.create(ImmutableMultimap.<String, String> builder().putAll("abc", "111").putAll("pqr", "222").build()))
+                .put("2", HashMultimap.create(ImmutableMultimap.<String, String> builder().putAll("abc", "333").putAll("pqr", "444").build()))
+                .put("3", HashMultimap.create(ImmutableMultimap.<String, String> builder().putAll("abc", "555").putAll("pqr", "666", "777").build()))
+                .build();
+
+        assertEquals(expected, transform);
+    }
+
+    @Test
+    public void test7() {
+        List<Table> data = Lists.newArrayList();
+        data.add(new Table("1", "abc", "111"));
+        data.add(new Table("1", "pqr", "222"));
+        data.add(new Table("2", "abc", "333"));
+        data.add(new Table("2", "pqr", "444"));
+        data.add(new Table("3", "abc", "555"));
+        data.add(new Table("3", "pqr", "666"));
+        data.add(new Table("3", "pqr", "777"));
+
+        QGroupBy4Test_Table table = QGroupBy4Test_Table.table;
+        Map<String, com.google.common.collect.Table<String, String, Map<String, List<String>>>> transform = CollQueryFactory
+                .from(table, data)
+                .transform(groupBy(table.col1).as(GuavaGroupBy.table(
+                        table.col1, table.col2, map(table.col2, list(table.col3)))));
+
+        ImmutableMap<String, com.google.common.collect.Table<String, String, Map<String, List<String>>>> expected =
+                ImmutableMap.<String, com.google.common.collect.Table<String, String, Map<String, List<String>>>>builder()
+                .put("1", ImmutableTable.<String, String, Map<String, List<String>>>builder()
+                        .put("1", "abc", ImmutableMap.<String, List<String>> of("abc", ImmutableList.of("111")))
+                        .put("1", "pqr", ImmutableMap.<String, List<String>> of("pqr", ImmutableList.of("222")))
+                        .build())
+                .put("2", ImmutableTable.<String, String, Map<String, List<String>>>builder()
+                        .put("2", "abc", ImmutableMap.<String, List<String>> of("abc", ImmutableList.of("333")))
+                        .put("2", "pqr", ImmutableMap.<String, List<String>> of("pqr", ImmutableList.of("444")))
+                        .build())
+                .put("3", ImmutableTable.<String, String, Map<String, List<String>>>builder()
+                        .put("3", "abc", ImmutableMap.<String, List<String>> of("abc", ImmutableList.of("555")))
+                        .put("3", "pqr", ImmutableMap.<String, List<String>> of("pqr", ImmutableList.of("666", "777")))
+                        .build())
+                .build();
+
+        assertEquals(expected, transform);
+    }
+
+    @Test
+    public void test8() {
+        List<Table> data = Lists.newArrayList();
+        data.add(new Table("1", "abc", "111"));
+        data.add(new Table("1", "pqr", "222"));
+        data.add(new Table("2", "abc", "333"));
+        data.add(new Table("2", "pqr", "444"));
+        data.add(new Table("3", "abc", "555"));
+        data.add(new Table("3", "pqr", "666"));
+        data.add(new Table("3", "pqr", "777"));
+
+        QGroupBy4Test_Table table = QGroupBy4Test_Table.table;
+        com.google.common.collect.Table<String, Map<String, String>, List<String>> transform = CollQueryFactory
+                .from(table, data)
+                .transform(groupBy(table.col1).asTable(map(table.col1, table.col2), GuavaGroupBy.list(table.col3)));
+
+        ImmutableTable<String, Map<String, String>, List<String>> expected = ImmutableTable.<String, Map<String, String>, List<String>> builder()
+                .put("1", ImmutableMap.of("1", "abc"), ImmutableList.of("111"))
+                .put("1", ImmutableMap.of("1", "pqr"), ImmutableList.of("222"))
+                .put("2", ImmutableMap.of("2", "abc"), ImmutableList.of("333"))
+                .put("2", ImmutableMap.of("2", "pqr"), ImmutableList.of("444"))
+                .put("3", ImmutableMap.of("3", "abc"), ImmutableList.of("555"))
+                .put("3", ImmutableMap.of("3", "pqr"), ImmutableList.of("666", "777"))
+                .build();
+
+        assertEquals(expected, transform);
     }
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/group/AbstractGroupByTransformer.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/AbstractGroupByTransformer.java
@@ -28,7 +28,7 @@ import com.querydsl.core.types.*;
  * @param <K>
  * @param <T>
  */
-abstract class AbstractGroupByTransformer<K, T> implements ResultTransformer<T> {
+public abstract class AbstractGroupByTransformer<K, T> implements ResultTransformer<T> {
 
     private static final class FactoryExpressionAdapter<T> extends ExpressionBase<T> implements FactoryExpression<T> {
         private final FactoryExpression<T> expr;
@@ -64,7 +64,7 @@ abstract class AbstractGroupByTransformer<K, T> implements ResultTransformer<T> 
     protected final Expression<?>[] expressions;
 
     @SuppressWarnings("unchecked")
-    AbstractGroupByTransformer(Expression<K> key, Expression<?>... expressions) {
+    protected AbstractGroupByTransformer(Expression<K> key, Expression<?>... expressions) {
         List<Expression<?>> projection = new ArrayList<Expression<?>>(expressions.length);
         groupExpressions.add(new GOne<K>(key));
         projection.add(key);

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupBy.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupBy.java
@@ -36,7 +36,7 @@ import com.querydsl.core.types.Projections;
  * @author tiwe
  *
  */
-public final class GroupBy {
+public class GroupBy {
 
     /**
      * Create a new GroupByBuilder for the given key expression
@@ -340,6 +340,6 @@ public final class GroupBy {
         return new GMap.Mixin<K, V, T, U, SortedMap<T, U>>(key, value, GMap.createSorted(QPair.create(key, value), comparator));
     }
 
-    private GroupBy() { }
+    protected GroupBy() { }
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByGenericCollection.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByGenericCollection.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group;
+
+import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.core.FetchableQuery;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.FactoryExpressionUtils;
+import com.querydsl.core.types.Projections;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Provides aggregated results as a collection
+ *
+ * @param <K> Key type
+ * @param <V> Value type
+ * @param <RES> Concrete collection type
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class GroupByGenericCollection<K, V, RES extends Collection<V>> extends AbstractGroupByTransformer<K, RES> {
+
+    private final Supplier<RES> resultFactory;
+
+    GroupByGenericCollection(Supplier<RES> resultFactory, Expression<K> key, Expression<?>... expressions) {
+        super(key, expressions);
+        this.resultFactory = resultFactory;
+    }
+
+    @Override
+    public RES transform(FetchableQuery<?, ?> query) {
+        // create groups
+        FactoryExpression<Tuple> expr = FactoryExpressionUtils.wrap(Projections.tuple(expressions));
+        boolean hasGroups = false;
+        for (Expression<?> e : expr.getArgs()) {
+            hasGroups |= e instanceof GroupExpression;
+        }
+        if (hasGroups) {
+            expr = withoutGroupExpressions(expr);
+        }
+        final CloseableIterator<Tuple> iter = query.select(expr).iterate();
+
+        RES list = resultFactory.get();
+        GroupImpl group = null;
+        K groupId = null;
+        while (iter.hasNext()) {
+            @SuppressWarnings("unchecked") //This type is mandated by the key type
+                    K[] row = (K[]) iter.next().toArray();
+            if (group == null) {
+                group = new GroupImpl(groupExpressions, maps);
+                groupId = row[0];
+            } else if (!Objects.equals(groupId, row[0])) {
+                list.add(transform(group));
+                group = new GroupImpl(groupExpressions, maps);
+                groupId = row[0];
+            }
+            group.add(row);
+        }
+        if (group != null) {
+            list.add(transform(group));
+        }
+        iter.close();
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected V transform(Group group) {
+        return (V) group;
+    }
+}

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByGenericMap.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByGenericMap.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group;
+
+import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.core.FetchableQuery;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.FactoryExpressionUtils;
+import com.querydsl.core.types.Projections;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Provides aggregated results as a map
+ *
+ * @param <K> Map key type
+ * @param <V> Map value type
+ * @param <RES> Resulting map type
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class GroupByGenericMap<K, V, RES extends Map<K, V>> extends AbstractGroupByTransformer<K, RES> {
+
+    private final Supplier<RES> mapFactory;
+
+    GroupByGenericMap(Supplier<RES> mapFactory, Expression<K> key, Expression<?>... expressions) {
+        super(key, expressions);
+        this.mapFactory = mapFactory;
+    }
+
+    @Override
+    public RES transform(FetchableQuery<?, ?> query) {
+        Map<K, Group> groups = (Map) mapFactory.get();
+
+        // create groups
+        FactoryExpression<Tuple> expr = FactoryExpressionUtils.wrap(Projections.tuple(expressions));
+        boolean hasGroups = false;
+        for (Expression<?> e : expr.getArgs()) {
+            hasGroups |= e instanceof GroupExpression;
+        }
+        if (hasGroups) {
+            expr = withoutGroupExpressions(expr);
+        }
+        CloseableIterator<Tuple> iter = query.select(expr).iterate();
+        try {
+            while (iter.hasNext()) {
+                @SuppressWarnings("unchecked") //This type is mandated by the key type
+                        K[] row = (K[]) iter.next().toArray();
+                K groupId = row[0];
+                GroupImpl group = (GroupImpl) groups.get(groupId);
+                if (group == null) {
+                    group = new GroupImpl(groupExpressions, maps);
+                    groups.put(groupId, group);
+                }
+                group.add(row);
+            }
+        } finally {
+            iter.close();
+        }
+
+        // transform groups
+        return transform(groups);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    protected RES transform(Map<K, Group> groups) {
+        return (RES) groups;
+    }
+
+}

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupImpl.java
@@ -26,7 +26,7 @@ import com.querydsl.core.types.Ops;
  * @author tiwe
  *
  */
-class GroupImpl implements Group {
+public class GroupImpl implements Group {
 
     private final Map<Expression<?>, GroupCollector<?,?>> groupCollectorMap = new LinkedHashMap<Expression<?>, GroupCollector<?,?>>();
 
@@ -54,7 +54,7 @@ class GroupImpl implements Group {
     }
 
     @SuppressWarnings("unchecked")
-    void add(Object[] row) {
+    public void add(Object[] row) {
         int i = 0;
         for (GroupCollector groupCollector : groupCollectors) {
             groupCollector.add(row[i]);

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Expressions.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Expressions.java
@@ -46,6 +46,7 @@ import com.querydsl.core.types.Visitor;
  * @author tiwe
  *
  */
+@SuppressWarnings("FileLength")
 public final class Expressions {
 
     public static final NumberExpression<Integer> ONE = numberTemplate(Integer.class, "1");

--- a/querydsl-core/src/main/java/com/querydsl/core/util/ArrayUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/ArrayUtils.java
@@ -32,6 +32,14 @@ public final class ArrayUtils {
         return array;
     }
 
+    @SuppressWarnings("unchecked")
+    public static <T> T[] combine(Class<T> type, T first, T... rest) {
+        T[] array = (T[]) Array.newInstance(type, rest.length + 1);
+        array[0] = first;
+        System.arraycopy(rest, 0, array, 1, rest.length);
+        return array;
+    }
+
     public static Object[] combine(int size, Object[]... arrays) {
         int offset = 0;
         Object[] target = new Object[size];

--- a/querydsl-guava/pom.xml
+++ b/querydsl-guava/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>querydsl-root</artifactId>
+        <groupId>com.querydsl</groupId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>querydsl-guava</artifactId>
+    <name>Querydsl - Guava Group By utilities</name>
+    <description>Utilities for creating group by factory expressions for Guava collection types</description>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.0-jre</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GMultimap.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GMultimap.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group.guava;
+
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SortedSetMultimap;
+import com.google.common.collect.TreeMultimap;
+import com.mysema.commons.lang.Pair;
+import com.querydsl.core.group.AbstractGroupExpression;
+import com.querydsl.core.group.GroupCollector;
+import com.querydsl.core.group.GroupExpression;
+import com.querydsl.core.group.QPair;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+abstract class GMultimap<K, V, M extends Multimap<K,V>> extends AbstractGroupExpression<Pair<K, V>, M> {
+
+    private static final long serialVersionUID = 7106389414200843920L;
+
+    public GMultimap(QPair<K,V> qpair) {
+        super(Multimap.class, qpair);
+    }
+
+    protected abstract M createMap();
+
+    public static <T, U> GMultimap<T, U, Multimap<T,U>> createLinked(QPair<T, U> expr) {
+        return new GMultimap<T, U, Multimap<T, U>>(expr) {
+            @Override
+            protected Multimap<T, U> createMap() {
+                return LinkedHashMultimap.create();
+            }
+        };
+    }
+
+    public static <T extends Comparable<? super T>, U extends Comparable<? super U>> GMultimap<T, U, SortedSetMultimap<T, U>> createSorted(QPair<T, U> expr) {
+        return new GMultimap<T, U, SortedSetMultimap<T, U>>(expr) {
+            @Override
+            protected SortedSetMultimap<T, U> createMap() {
+                return TreeMultimap.create();
+            }
+        };
+    }
+
+    public static <T, U> GMultimap<T, U, SortedSetMultimap<T, U>> createSorted(QPair<T, U> expr, final Comparator<? super T> comparator, final Comparator<? super U> comparator2) {
+        return new GMultimap<T, U, SortedSetMultimap<T, U>>(expr) {
+            @Override
+            protected SortedSetMultimap<T, U> createMap() {
+                return TreeMultimap.create(comparator, comparator2);
+            }
+        };
+    }
+
+    @Override
+    public GroupCollector<Pair<K,V>, M> createGroupCollector() {
+        return new GroupCollector<Pair<K,V>, M>() {
+
+            private final M map = createMap();
+
+            @Override
+            public void add(Pair<K,V> pair) {
+                map.put(pair.getFirst(), pair.getSecond());
+            }
+
+            @Override
+            public M get() {
+                return map;
+            }
+
+        };
+    }
+
+    static class Mixin<K, V, T, U, R extends Multimap<? super T, ? super U>> extends AbstractGroupExpression<Pair<K, V>, R> {
+
+        private static final long serialVersionUID = 1939989270493531116L;
+
+        private class GroupCollectorImpl implements GroupCollector<Pair<K, V>, R> {
+
+            private final GroupCollector<Pair<T, U>, R> groupCollector;
+
+            private final Map<K, GroupCollector<K, T>> keyCollectors = new LinkedHashMap<K, GroupCollector<K, T>>();
+
+            private final Map<GroupCollector<K, T>, GroupCollector<V, U>> valueCollectors = new HashMap<GroupCollector<K, T>, GroupCollector<V, U>>();
+
+            public GroupCollectorImpl() {
+                this.groupCollector = mixin.createGroupCollector();
+            }
+
+            @Override
+            public void add(Pair<K, V> pair) {
+                K first = pair.getFirst();
+                GroupCollector<K, T> keyCollector = keyCollectors.get(first);
+                if (keyCollector == null) {
+                    keyCollector = keyExpression.createGroupCollector();
+                    keyCollectors.put(first, keyCollector);
+                }
+                keyCollector.add(first);
+                GroupCollector<V, U> valueCollector = valueCollectors.get(keyCollector);
+                if (valueCollector == null) {
+                    valueCollector = valueExpression.createGroupCollector();
+                    valueCollectors.put(keyCollector, valueCollector);
+                }
+                V second = pair.getSecond();
+                valueCollector.add(second);
+            }
+
+            @Override
+            public R get() {
+                for (GroupCollector<K, T> keyCollector : keyCollectors.values()) {
+                    T key = keyCollector.get();
+                    GroupCollector<V, U> valueCollector = valueCollectors.remove(keyCollector);
+                    U value = valueCollector.get();
+                    groupCollector.add(Pair.of(key, value));
+                }
+                keyCollectors.clear();
+                return groupCollector.get();
+            }
+
+        }
+
+        private final GroupExpression<Pair<T, U>, R> mixin;
+
+        private final GroupExpression<K, T> keyExpression;
+        private final GroupExpression<V, U> valueExpression;
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        public Mixin(GroupExpression<K, T> keyExpression, GroupExpression<V, U> valueExpression, AbstractGroupExpression<Pair<T, U>, R> mixin) {
+            super((Class) mixin.getType(), QPair.create(keyExpression.getExpression(), valueExpression.getExpression()));
+            this.keyExpression = keyExpression;
+            this.valueExpression = valueExpression;
+            this.mixin = mixin;
+        }
+
+        @Override
+        public GroupCollector<Pair<K, V>, R> createGroupCollector() {
+            return new GroupCollectorImpl();
+        }
+
+    }
+
+}

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GOne.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GOne.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group.guava;
+
+import com.querydsl.core.group.AbstractGroupExpression;
+import com.querydsl.core.group.GroupCollector;
+import com.querydsl.core.types.Expression;
+
+class GOne<T> extends AbstractGroupExpression<T, T> {
+
+    private static final long serialVersionUID = 3518868612387641383L;
+
+    @SuppressWarnings("unchecked")
+    public GOne(Expression<T> expr) {
+        super((Class) expr.getType(), expr);
+    }
+
+    @Override
+    public GroupCollector<T,T> createGroupCollector() {
+        return new GroupCollector<T,T>() {
+            private boolean first = true;
+
+            private T val;
+
+            @Override
+            public void add(T o) {
+                if (first) {
+                    val = o;
+                    first = false;
+                }
+            }
+
+            @Override
+            public T get() {
+                return val;
+            }
+        };
+    }
+}

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GTable.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GTable.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group.guava;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeBasedTable;
+import com.mysema.commons.lang.Pair;
+import com.querydsl.core.group.AbstractGroupExpression;
+import com.querydsl.core.group.GroupCollector;
+import com.querydsl.core.group.GroupExpression;
+import com.querydsl.core.group.QPair;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+abstract class GTable<R, C, V, M extends Table<R, C, V>> extends AbstractGroupExpression<Pair<Pair<R, C>, V>, M> {
+
+    private static final long serialVersionUID = 7106389414200843920L;
+
+    public GTable(QPair<Pair<R,C>, V> qpair) {
+        super(Table.class, qpair);
+    }
+
+    protected abstract M createTable();
+
+    public static <T, U, W> GTable<T, U, W, Table<T, U, W>> create(QPair<Pair<T, U>, W> expr) {
+        return new GTable<T, U, W, Table<T, U, W>>(expr) {
+            @Override
+            protected Table<T, U, W> createTable() {
+                return HashBasedTable.create();
+            }
+        };
+    }
+
+    public static <T extends Comparable<? super T>, U extends Comparable<? super U>, W> GTable<T, U, W, TreeBasedTable<T, U, W>> createSorted(QPair<Pair<T, U>, W> expr) {
+        return new GTable<T, U, W, TreeBasedTable<T, U, W>>(expr) {
+            @Override
+            protected TreeBasedTable<T, U, W> createTable() {
+                return TreeBasedTable.create();
+            }
+        };
+    }
+
+    public static <T, U, W> GTable<T, U, W, TreeBasedTable<T, U, W>> createSorted(QPair<Pair<T, U>, W> expr, final Comparator<? super T> rowComparator, final Comparator<? super U> columnComparator) {
+        return new GTable<T, U, W, TreeBasedTable<T, U, W>>(expr) {
+            @Override
+            protected TreeBasedTable<T, U, W> createTable() {
+                return TreeBasedTable.create(rowComparator, columnComparator);
+            }
+        };
+    }
+
+    @Override
+    public GroupCollector<Pair<Pair<R, C>, V>, M> createGroupCollector() {
+        return new GroupCollector<Pair<Pair<R, C>, V>, M>() {
+
+            private final M table = createTable();
+
+            @Override
+            public void add(Pair<Pair<R, C>, V> pair) {
+                table.put(pair.getFirst().getFirst(), pair.getFirst().getSecond(), pair.getSecond());
+            }
+
+            @Override
+            public M get() {
+                return table;
+            }
+
+        };
+    }
+
+    static class Mixin<R, C, V, T, U, W, RES extends Table<? super T, ? super U, ? super W>> extends AbstractGroupExpression<Pair<Pair<R, C>, V>, RES> {
+
+        private static final long serialVersionUID = 1939989270493531116L;
+
+        private class GroupCollectorImpl implements GroupCollector<Pair<Pair<R, C>, V>, RES> {
+
+            private final  GroupCollector<Pair<Pair<T, U>, W>, RES> groupCollector;
+
+            private final Table<R, C, GroupCollector<R, T>> rowCollectors = HashBasedTable.create();
+            private final Map<GroupCollector<R, T>, GroupCollector<C, U>> columnCollectors = new HashMap<GroupCollector<R, T>, GroupCollector<C, U>>();
+            private final Map<GroupCollector<C, U>, GroupCollector<V, W>> valueCollectors = new HashMap<GroupCollector<C, U>, GroupCollector<V, W>>();
+
+            public GroupCollectorImpl() {
+                this.groupCollector = mixin.createGroupCollector();
+            }
+
+            @Override
+            public void add(Pair<Pair<R, C>, V> pair) {
+                Pair<R, C> first = pair.getFirst();
+                R rowKey = first.getFirst();
+                C columnKey = first.getSecond();
+
+                GroupCollector<R, T> rowCollector = rowCollectors.get(rowKey, columnKey);
+                if (rowCollector == null) {
+                    rowCollector = rowExpression.createGroupCollector();
+                    rowCollectors.put(rowKey, columnKey, rowCollector);
+                }
+                rowCollector.add(rowKey);
+
+                GroupCollector<C, U> columnCollector = columnCollectors.get(rowCollector);
+                if (columnCollector == null) {
+                    columnCollector = columnExpression.createGroupCollector();
+                    columnCollectors.put(rowCollector, columnCollector);
+                }
+                columnCollector.add(columnKey);
+
+                GroupCollector<V, W> valueCollector = valueCollectors.get(columnCollector);
+                if (valueCollector == null) {
+                    valueCollector = valueExpression.createGroupCollector();
+                    valueCollectors.put(columnCollector, valueCollector);
+                }
+                V second = pair.getSecond();
+                valueCollector.add(second);
+            }
+
+            @Override
+            public RES get() {
+                for (GroupCollector<R, T> rowCollector : rowCollectors.values()) {
+                    T rowKey = rowCollector.get();
+                    GroupCollector<C, U> columnCollector = columnCollectors.get(rowCollector);
+                    U columnKey = columnCollector.get();
+                    GroupCollector<V, W> valueCollector = valueCollectors.get(columnCollector);
+                    W value = valueCollector.get();
+                    groupCollector.add(Pair.of(Pair.of(rowKey, columnKey), value));
+                }
+                return groupCollector.get();
+            }
+
+        }
+
+        private final GroupExpression<Pair<Pair<T, U>, W>, RES> mixin;
+        private final GroupExpression<R, T> rowExpression;
+        private final GroupExpression<C, U> columnExpression;
+        private final GroupExpression<V, W> valueExpression;
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        public Mixin(GroupExpression<R, T> rowExpression, GroupExpression<C, U> columnExpression, GroupExpression<V, W> valueExpression, AbstractGroupExpression<Pair<Pair<T, U>, W>, RES> mixin) {
+            super((Class) mixin.getType(), QPair.create(QPair.create(rowExpression.getExpression(), columnExpression.getExpression()), valueExpression.getExpression()));
+            this.rowExpression = rowExpression;
+            this.columnExpression = columnExpression;
+            this.valueExpression = valueExpression;
+            this.mixin = mixin;
+        }
+
+        @Override
+        public GroupCollector<Pair<Pair<R, C>, V>, RES> createGroupCollector() {
+            return new GroupCollectorImpl();
+        }
+    }
+
+}

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GroupByMultimap.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GroupByMultimap.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group.guava;
+
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.core.FetchableQuery;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.group.AbstractGroupByTransformer;
+import com.querydsl.core.group.Group;
+import com.querydsl.core.group.GroupExpression;
+import com.querydsl.core.group.GroupImpl;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.FactoryExpressionUtils;
+import com.querydsl.core.types.Projections;
+
+/**
+ * Provides aggregated results as a map
+ *
+ * @author Jan-Willem Gmelig Meyling
+ *
+ * @param <K> multi map key type
+ * @param <V> multi map value type
+ * @param <R> multi map type
+ */
+public class GroupByMultimap<K, V, R extends Multimap<K,V>> extends AbstractGroupByTransformer<K, R> {
+
+    GroupByMultimap(Expression<K> key, Expression<?>... expressions) {
+        super(key, expressions);
+    }
+
+    @Override
+    public R transform(FetchableQuery<?,?> query) {
+        Multimap<K, Group> groups = LinkedHashMultimap.create();
+
+        // create groups
+        FactoryExpression<Tuple> expr = FactoryExpressionUtils.wrap(Projections.tuple(expressions));
+        boolean hasGroups = false;
+        for (Expression<?> e : expr.getArgs()) {
+            hasGroups |= e instanceof GroupExpression;
+        }
+        if (hasGroups) {
+            expr = withoutGroupExpressions(expr);
+        }
+        CloseableIterator<Tuple> iter = query.select(expr).iterate();
+        try {
+            while (iter.hasNext()) {
+                @SuppressWarnings("unchecked") //This type is mandated by the key type
+                K[] row = (K[]) iter.next().toArray();
+                K groupId = row[0];
+                GroupImpl group = new GroupImpl(groupExpressions, maps);
+                groups.put(groupId, group);
+                group.add(row);
+            }
+        } finally {
+            iter.close();
+        }
+
+        // transform groups
+        return transform(groups);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    protected R transform(Multimap<K, Group> groups) {
+        return (R) groups;
+    }
+
+}

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GroupByTable.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GroupByTable.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group.guava;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.core.FetchableQuery;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.group.AbstractGroupByTransformer;
+import com.querydsl.core.group.Group;
+import com.querydsl.core.group.GroupExpression;
+import com.querydsl.core.group.GroupImpl;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.FactoryExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.util.ArrayUtils;
+
+/**
+ * Provides aggregated results as a table
+ *
+ * @author Jan-Willem Gmelig Meyling
+ *
+ * @param <R> row type
+ * @param <C> column type
+ * @param <V> value type
+ * @param <RES> table type
+ */
+public class GroupByTable<R, C, V, RES extends Table<R, C, V>> extends AbstractGroupByTransformer<R, RES> {
+
+    GroupByTable(Expression<R> rowKey, Expression<C> columnKey, Expression<?>... expressions) {
+        super(rowKey, ArrayUtils.combine(Expression.class, columnKey, expressions));
+    }
+
+    @Override
+    public RES transform(FetchableQuery<?,?> query) {
+        // TODO Table<Object, Object, Group> after support for it in https://github.com/querydsl/querydsl/issues/2644
+        Table<R, Object, Group> groups = HashBasedTable.create();
+
+        // create groups
+        FactoryExpression<Tuple> expr = FactoryExpressionUtils.wrap(Projections.tuple(expressions));
+        boolean hasGroups = false;
+        for (Expression<?> e : expr.getArgs()) {
+            hasGroups |= e instanceof GroupExpression;
+        }
+        if (hasGroups) {
+            expr = withoutGroupExpressions(expr);
+        }
+        CloseableIterator<Tuple> iter = query.select(expr).iterate();
+        try {
+            while (iter.hasNext()) {
+                @SuppressWarnings("unchecked") //This type is mandated by the key type
+                Object[] row = iter.next().toArray();
+                R groupId = (R) row[0];
+                Object rowId = row[1];
+                GroupImpl group = (GroupImpl) groups.get(groupId, rowId);
+                if (group == null) {
+                    group = new GroupImpl(groupExpressions, maps);
+                    groups.put(groupId, rowId, group);
+                }
+                group.add(row);
+            }
+        } finally {
+            iter.close();
+        }
+
+        // transform groups
+        return transform(groups);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    protected RES transform(Table<R, ?, Group> groups) {
+        return (RES) groups;
+    }
+
+}

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GuavaGroupBy.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GuavaGroupBy.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group.guava;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SortedSetMultimap;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeBasedTable;
+import com.mysema.commons.lang.Pair;
+import com.querydsl.core.ResultTransformer;
+import com.querydsl.core.group.AbstractGroupExpression;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.group.GroupExpression;
+import com.querydsl.core.group.QPair;
+import com.querydsl.core.types.Expression;
+
+import java.util.Comparator;
+
+/**
+ * {@code GuavaGroupBy} extends {@code GroupBy} with factory methods for creating {@link ResultTransformer} and {@link
+ * GroupExpression} instances for Guava Collection types.
+ *
+ * @author Jan-Willem Gmelig Meyling
+ */
+public final class GuavaGroupBy extends GroupBy {
+
+    /**
+     * Create a new GroupByBuilder for the given key expression
+     *
+     * @param key key for aggregation
+     * @return builder for further specification
+     */
+    public static <K> GuavaGroupByBuilder<K> groupBy(Expression<K> key) {
+        return new GuavaGroupByBuilder<K>(key);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K, V> AbstractGroupExpression<Pair<K, V>, Multimap<K, V>> multimap(Expression<K> key,
+                                                                                      Expression<V> value) {
+        return GMultimap.createLinked(QPair.create(key, value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K, V, T> AbstractGroupExpression<Pair<K, V>, Multimap<T, V>> multimap(GroupExpression<K, T> key,
+                                                                                         Expression<V> value) {
+        return multimap(key, new GOne<V>(value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K, V, U> AbstractGroupExpression<Pair<K, V>, Multimap<K, U>> multimap(Expression<K> key,
+                                                                                         GroupExpression<V, U> value) {
+        return multimap(new GOne<K>(key), value);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K, V, T, U> AbstractGroupExpression<Pair<K, V>, Multimap<T, U>> multimap(GroupExpression<K, T> key,
+                                                                                            GroupExpression<V, U> value) {
+        return new GMultimap.Mixin<K, V, T, U, Multimap<T, U>>(key, value, GMultimap.createLinked(QPair.create(key, value)));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K extends Comparable<? super K>, V extends Comparable<? super V>> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<K, V>> sortedSetMultimap(Expression<K> key,
+                                                                                                                                                                    Expression<V> value) {
+        return GMultimap.createSorted(QPair.create(key, value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K, V, T extends Comparable<? super T>> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<T, V>> sortedSetMultimap(GroupExpression<K, T> key,
+                                                                                                                                         Expression<V> value) {
+        return sortedSetMultimap(key, (GroupExpression) new GOne<V>(value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K extends Comparable<? super K>, V, U> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<K, U>> sortedSetMultimap(Expression<K> key,
+                                                                                                                                         GroupExpression<V, U> value) {
+        return sortedSetMultimap(new GOne<K>(key), (GroupExpression) value);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @return wrapper expression
+     */
+    public static <K, V, T extends Comparable<? super T>, U extends Comparable<? super U>> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<T, U>> sortedSetMultimap(GroupExpression<K, T> key,
+                                                                                                                                                                          GroupExpression<V, U> value) {
+        return new GMultimap.Mixin<K, V, T, U, SortedSetMultimap<T, U>>(key, value, GMultimap.createSorted(QPair.create(key, value)));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap using the given comparator
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @param keyComparator comparator for the created TreeMap instances
+     * @param valueComparator comparator for the created TreeMap instances
+     * @return wrapper expression
+     */
+    public static <K, V> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<K, V>> sortedSetMultimap(Expression<K> key,
+                                                                                                        Expression<V> value,
+                                                                                                        Comparator<? super K> keyComparator,
+                                                                                                        Comparator<? super V> valueComparator) {
+        return GMultimap.createSorted(QPair.create(key, value), keyComparator, valueComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap using the given comparator
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @param comparator comparator for the created TreeMap instances
+     * @param valueComparator comparator for the created TreeMap instances
+     * @return wrapper expression
+     */
+    public static <K, V, T> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<T, V>> sortedSetMultimap(GroupExpression<K, T> key,
+                                                                                                           Expression<V> value,
+                                                                                                           Comparator<? super T> comparator,
+                                                                                                           Comparator<? super V> valueComparator) {
+        return sortedSetMultimap(key, new GOne<V>(value), comparator, valueComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap using the given comparator
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @param keyComparator comparator for the created TreeMap instances
+     * @param valueComparator comparator for the created TreeMap instances
+     * @return wrapper expression
+     */
+    public static <K, V, U> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<K, U>> sortedSetMultimap(Expression<K> key,
+                                                                                                           GroupExpression<V, U> value,
+                                                                                                           Comparator<? super K> keyComparator,
+                                                                                                           Comparator<? super U> valueComparator) {
+        return sortedSetMultimap(new GOne<K>(key), value, keyComparator, valueComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing TreeMap using the given comparator
+     *
+     * @param key key for the map entries
+     * @param value value for the map entries
+     * @param keyComparator comparator for the created TreeMap instances
+     * @param valueComparator comparator for the created TreeMap instances
+     * @return wrapper expression
+     */
+    public static <K, V, T, U> AbstractGroupExpression<Pair<K, V>, SortedSetMultimap<T, U>> sortedSetMultimap(GroupExpression<K, T> key,
+                                                                                                              GroupExpression<V, U> value,
+                                                                                                              Comparator<? super T> keyComparator,
+                                                                                                              Comparator<? super U> valueComparator) {
+        return new GMultimap.Mixin<K, V, T, U, SortedSetMultimap<T, U>>(key, value, GMultimap.createSorted(QPair.create(key, value), keyComparator, valueComparator));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<R, C, V>> table(Expression<R> row,
+                                                                                               Expression<C> column,
+                                                                                               Expression<V> value) {
+        return GTable.create(QPair.create(QPair.create(row, column), value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<W, C, V>> table(GroupExpression<R, W> row,
+                                                                                                  Expression<C> column,
+                                                                                                  Expression<V> value) {
+        return table(row, new GOne<C>(column), new GOne<V>(value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W, X> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<W, X, V>> table(GroupExpression<R, W> row,
+                                                                                                     GroupExpression<C, X> column,
+                                                                                                     Expression<V> value) {
+        return table(row, column, new GOne<V>(value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<R, W, V>> table(Expression<R> row,
+                                                                                                  GroupExpression<C, W> column,
+                                                                                                  Expression<V> value) {
+        return table(new GOne<R>(row), column, new GOne<V>(value));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W, X> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<R, X, W>> table(Expression<R> row,
+                                                                                                     GroupExpression<C, X> column,
+                                                                                                     GroupExpression<V, W> value) {
+        return table(new GOne<R>(row), column, value);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W, X> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<X, C, W>> table(GroupExpression<R, X> row,
+                                                                                                     Expression<C> column,
+                                                                                                     GroupExpression<V, W> value) {
+        return table(row, new GOne<C>(column), value);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<R, C, W>> table(Expression<R> row,
+                                                                                                  Expression<C> column,
+                                                                                                  GroupExpression<V, W> value) {
+        return table(new GOne<R>(row), new GOne<C>(column), value);
+    }
+
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, T, U, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, Table<T, U, W>> table(GroupExpression<R, T> row,
+                                                                                                        GroupExpression<C, U> column,
+                                                                                                        GroupExpression<V, W> value) {
+        return new GTable.Mixin<R, C, V, T, U, W, Table<T, U, W>>(
+                row, column, value, GTable.create(QPair.create(QPair.create(row, column), value)));
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<R, C, V>> sortedTable(Expression<R> row,
+                                                                                                              Expression<C> column,
+                                                                                                              Expression<V> value,
+                                                                                                              Comparator<? super R> rowComparator,
+                                                                                                              Comparator<? super C> columnComparator) {
+        return GTable.createSorted(QPair.create(QPair.create(row, column), value), rowComparator, columnComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<W, C, V>> sortedTable(GroupExpression<R, W> row,
+                                                                                                                 Expression<C> column,
+                                                                                                                 Expression<V> value,
+                                                                                                                 Comparator<? super W> rowComparator,
+                                                                                                                 Comparator<? super C> columnComparator) {
+        return GuavaGroupBy.<R, C, V, W, C, V>sortedTable(row, new GOne<C>(column), new GOne<V>(value), rowComparator, columnComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W, X> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<W, X, V>> sortedTable(GroupExpression<R, W> row,
+                                                                                                                    GroupExpression<C, X> column,
+                                                                                                                    Expression<V> value,
+                                                                                                                    Comparator<? super W> rowComparator,
+                                                                                                                    Comparator<? super X> columnComparator) {
+        return GuavaGroupBy.<R, C, V, W, X, V> sortedTable(row, column, new GOne<V>(value), rowComparator, columnComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<R, W, V>> sortedTable(Expression<R> row,
+                                                                                                                 GroupExpression<C, W> column,
+                                                                                                                 Expression<V> value,
+                                                                                                                 Comparator<? super R> rowComparator,
+                                                                                                                 Comparator<? super W> columnComparator) {
+        return GuavaGroupBy.<R, C, V, R, W, V>sortedTable(new GOne<R>(row), column, new GOne<V>(value), rowComparator, columnComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W, X> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<R, X, W>> sortedTable(Expression<R> row,
+                                                                                                                    GroupExpression<C, X> column,
+                                                                                                                    GroupExpression<V, W> value,
+                                                                                                                    Comparator<? super R> rowComparator,
+                                                                                                                    Comparator<? super X> columnComparator) {
+        return GuavaGroupBy.<R, C, V, R, X, W>sortedTable(new GOne<R>(row), column, value, rowComparator, columnComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W, X> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<X, C, W>> sortedTable(GroupExpression<R, X> row,
+                                                                                                                    Expression<C> column,
+                                                                                                                    GroupExpression<V, W> value,
+                                                                                                                    Comparator<? super X> rowComparator,
+                                                                                                                    Comparator<? super C> columnComparator) {
+        return sortedTable(row, new GOne<C>(column), value, rowComparator, columnComparator);
+    }
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<R, C, W>> sortedTable(Expression<R> row,
+                                                                                                                 Expression<C> column,
+                                                                                                                 GroupExpression<V, W> value,
+                                                                                                                 Comparator<? super R> rowComparator,
+                                                                                                                 Comparator<? super C> columnComparator) {
+        return GuavaGroupBy.<R, C, V, R, C, W>sortedTable(new GOne<R>(row), new GOne<C>(column), value, rowComparator, columnComparator);
+    }
+
+
+    /**
+     * Create a new aggregating map expression using a backing LinkedHashMap
+     *
+     * @param row row for the table entries
+     * @param column column for the table entries
+     * @param value value for the table entries
+     * @return wrapper expression
+     */
+    public static <R, C, V, T, U, W> AbstractGroupExpression<Pair<Pair<R, C>, V>, TreeBasedTable<T, U, W>> sortedTable(GroupExpression<R, T> row,
+                                                                                                                       GroupExpression<C, U> column,
+                                                                                                                       GroupExpression<V, W> value,
+                                                                                                                       Comparator<? super T> rowComparator,
+                                                                                                                       Comparator<? super U> columnComparator) {
+        return new GTable.Mixin<R, C, V, T, U, W, TreeBasedTable<T, U, W>>(
+                row, column, value, GTable.createSorted(QPair.create(QPair.create(row, column), value), rowComparator, columnComparator));
+    }
+
+    private GuavaGroupBy() {
+    }
+
+}

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GuavaGroupByBuilder.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/GuavaGroupByBuilder.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.group.guava;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
+import com.google.common.collect.Table.Cell;
+import com.google.common.collect.TreeBasedTable;
+import com.google.common.collect.TreeMultimap;
+import com.querydsl.core.ResultTransformer;
+import com.querydsl.core.group.Group;
+import com.querydsl.core.group.GroupByBuilder;
+import com.querydsl.core.types.Expression;
+
+import java.util.Comparator;
+import java.util.Map;
+
+/**
+ * {@code GroupByBuilder} is a fluent builder for GroupBy transformer instances. This class is not to be used directly,
+ * but via {@link GuavaGroupBy}.
+ *
+ * @param <K>
+ * @author Jan-Willem Gmelig Melying
+ */
+public class GuavaGroupByBuilder<K> extends GroupByBuilder<K> {
+
+    /**
+     * Create a new GroupByBuilder for the given key expression
+     *
+     * @param key key for aggregating
+     */
+    public GuavaGroupByBuilder(Expression<K> key) {
+        super(key);
+    }
+
+    /**
+     * Get the results as multi map
+     *
+     * @param expression value expression
+     * @param <V> Value type
+     * @return new result transformer
+     */
+    public <V> ResultTransformer<Multimap<K, V>> asMultimap(Expression<V> expression) {
+        final Expression<V> lookup = getLookup(expression);
+        return new GroupByMultimap<K, V, Multimap<K, V>>(key, expression) {
+            @Override
+            protected Multimap<K, V> transform(Multimap<K, Group> groups) {
+                Multimap<K, V> results = LinkedHashMultimap.create();
+                for (Map.Entry<K, Group> entry : groups.entries()) {
+                    results.put(entry.getKey(), entry.getValue().getOne(lookup));
+                }
+                return results;
+            }
+        };
+    }
+
+    /**
+     * Get the results as multi map
+     *
+     * @param expression value expression
+     * @param <V> Value type
+     * @return new result transformer
+     */
+    public <V extends Comparable<? super V>> ResultTransformer<TreeMultimap<K, V>> asSortedSetMultimap(Expression<V> expression) {
+        final Expression<V> lookup = getLookup(expression);
+        return new GroupByMultimap<K, V, TreeMultimap<K, V>>(key, expression) {
+            @Override
+            protected TreeMultimap<K, V> transform(Multimap<K, Group> groups) {
+                TreeMultimap<K, V> results = (TreeMultimap) TreeMultimap.create();
+                for (Map.Entry<K, Group> entry : groups.entries()) {
+                    results.put(entry.getKey(), entry.getValue().getOne(lookup));
+                }
+                return results;
+            }
+        };
+    }
+
+    /**
+     * Get the results as multi map
+     *
+     * @param expression value expression
+     * @param comparator key comparator
+     * @param valueComparator value comparator
+     * @param <V> Value type
+     * @return new result transformer
+     */
+    public <V> ResultTransformer<TreeMultimap<K, V>> asSortedSetMultimap(Expression<V> expression,
+                                                                         final Comparator<? super K> comparator,
+                                                                         final Comparator<? super V> valueComparator) {
+        final Expression<V> lookup = getLookup(expression);
+        return new GroupByMultimap<K, V, TreeMultimap<K, V>>(key, expression) {
+            @Override
+            protected TreeMultimap<K, V> transform(Multimap<K, Group> groups) {
+                TreeMultimap<K, V> results = TreeMultimap.create(comparator, valueComparator);
+                for (Map.Entry<K, Group> entry : groups.entries()) {
+                    results.put(entry.getKey(), entry.getValue().getOne(lookup));
+                }
+                return results;
+            }
+        };
+    }
+
+    /**
+     * Get the results as sorted table
+     *
+     * @param column column expression
+     * @param expression value expression
+     * @param <C> Column type
+     * @param <V> Value type
+     * @return new result transformer
+     */
+    public <C, V> ResultTransformer<Table<K, C, V>> asTable(final Expression<C> column, final Expression<V> expression) {
+        final Expression<C> columnKeyLookup = getLookup(column);
+        final Expression<V> lookup = getLookup(expression);
+        return new GroupByTable<K, C, V, Table<K, C, V>>(key, column, expression) {
+            @Override
+            protected Table<K, C, V> transform(Table<K, ?, Group> groups) {
+                Table<K, C, V> results = HashBasedTable.create();
+                for (Cell<K, ?, Group> cell : groups.cellSet()) {
+                    K rowKey = cell.getRowKey();
+                    C columnKey = cell.getValue().getOne(columnKeyLookup);
+                    V value = cell.getValue().getOne(lookup);
+                    results.put(rowKey, columnKey, value);
+                }
+                return results;
+            }
+        };
+    }
+
+    /**
+     * Get the results as sorted table
+     *
+     * @param column column expression
+     * @param expression value expression
+     * @param <C> Column type
+     * @param <V> Value type
+     * @return new result transformer
+     */
+    public <C extends Comparable<? super C>, V> ResultTransformer<TreeBasedTable<K, C, V>> asSortedTable(final Expression<C> column, final Expression<V> expression) {
+        final Expression<C> columnKeyLookup = getLookup(column);
+        final Expression<V> lookup = getLookup(expression);
+        return new GroupByTable<K, C, V, TreeBasedTable<K, C, V>>(key, column, expression) {
+            @Override
+            protected TreeBasedTable<K, C, V> transform(Table<K, ?, Group> groups) {
+                TreeBasedTable<K, C, V> results = (TreeBasedTable) TreeBasedTable.create();
+                for (Cell<K, ?, Group> cell : groups.cellSet()) {
+                    K rowKey = cell.getRowKey();
+                    C columnKey = cell.getValue().getOne(columnKeyLookup);
+                    V value = cell.getValue().getOne(lookup);
+                    results.put(rowKey, columnKey, value);
+                }
+                return results;
+            }
+        };
+    }
+
+    /**
+     * Get the results as sorted table
+     *
+     * @param column column expression
+     * @param expression value expression
+     * @param rowComparator row comparator
+     * @param columnComparator column comparator
+     * @param <C> Column type
+     * @param <V> Value type
+     * @return new result transformer
+     */
+    public <C, V> ResultTransformer<TreeBasedTable<K, C, V>> asSortedTable(final Expression<C> column,
+                                                                           final Expression<V> expression,
+                                                                           final Comparator<? super K> rowComparator,
+                                                                           final Comparator<? super C> columnComparator) {
+        final Expression<C> columnKeyLookup = getLookup(column);
+        final Expression<V> lookup = getLookup(expression);
+        return new GroupByTable<K, C, V, TreeBasedTable<K, C, V>>(key, column, expression) {
+            @Override
+            protected TreeBasedTable<K, C, V> transform(Table<K, ?, Group> groups) {
+                TreeBasedTable<K, C, V> results = TreeBasedTable.create(rowComparator, columnComparator);
+                for (Cell<K, ?, Group> cell : groups.cellSet()) {
+                    K rowKey = cell.getRowKey();
+                    C columnKey = cell.getValue().getOne(columnKeyLookup);
+                    V value = cell.getValue().getOne(lookup);
+                    results.put(rowKey, columnKey, value);
+                }
+                return results;
+            }
+        };
+    }
+
+}

--- a/querydsl-guava/src/main/java/com/querydsl/core/group/guava/package-info.java
+++ b/querydsl-guava/src/main/java/com/querydsl/core/group/guava/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for creating group by factory expressions for Guava collection types
+ */
+package com.querydsl.core.group.guava;
+


### PR DESCRIPTION
This pull request implements `ResultTransformers` for [Guava collection types](https://github.com/google/guava/wiki/CollectionUtilitiesExplained) (`Multimap`, `Table`, `BiMap`). The [`ResultTransformers`](http://www.querydsl.com/static/querydsl/latest/reference/html/ch03s02.html) form a fantastic API to project tuples to a composition of collections, most notably `Map` and `List`. However, deep nested `Maps` of `Lists` or `Maps` of  `Maps` can lead to superfluous and erroneous code. The Guava collection types help with this, for example: `Multimap` forms a fluent API around a `Map<K, Set<V>` and `Table<R, C, V>` is basically a two-dimensional `Map`. This pull request adds factory methods in `GuavaGroupBy` to construct `ResultTransformers` for these Guava collection types.

Example use:

```java
Multimap<String, String> transform = CollQueryFactory
        .from(table, data)
        .transform(groupBy(table.col1).asMultimap(table.col2));
```

Guava is currently a compile time dependency of QueryDSL. It is on the roadmap to remove the dependency on Guava (#2324). Therefore I have developed this extension with optionality in mind. Rather than extending the existing `GroupBy` utility class, this code lives in `GuavaGroupBy`. That means that there are several paths going forward as to removing Guava as compile time transitive dependency:

1. If Guava becomes an [`optional`](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html) dependency in the `provided` scope and all other code is made Guava free, users who don't want to use this class, simply use the factory methods from `GroupBy` instead of `GuavaGroupBy`. Users that do want to use the Guava factory methods, import `GuavaGroupBy` instead and are mandated to provide a compatible Guava implementation.
2. If Guava gets removed entirely as dependency for `querydsl-core`, the 8 Guava related classes introduced with this pull request can be easily moved to a separate `querydsl-guava-extensions` module and still remain accessible.

If there's no interest in merging this, then I'll make this code available as Maven module on my Github page. However before going down that path I wanted to put this out here. There's probably a couple of Guava fans/users around here for which these utility methods may come in handy.