### PR TITLE
Let TypeCategory.ENTITY take precedence over COMPARABLE, fixes #2572

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
@@ -352,11 +352,11 @@ public class ExtendedTypeFactory {
                 && isAssignable(typeElement.asType(), comparableType)) {
             typeCategory = TypeCategory.COMPARABLE;
 
-        } else if (typeCategory == TypeCategory.SIMPLE) {
-            for (Class<? extends Annotation> entityAnn : entityAnnotations) {
-                if (isSimpleTypeEntity(typeElement, entityAnn)) {
-                    typeCategory = TypeCategory.ENTITY;
-                }
+        }
+
+        for (Class<? extends Annotation> entityAnn : entityAnnotations) {
+            if (isSimpleTypeEntity(typeElement, entityAnn)) {
+                typeCategory = TypeCategory.ENTITY;
             }
         }
 

--- a/querydsl-apt/src/test/java/com/querydsl/apt/domain/ComparableTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/domain/ComparableTest.java
@@ -23,6 +23,35 @@ import com.querydsl.core.annotations.QueryEntity;
 public class ComparableTest {
 
     @QueryEntity
+    public static class CustomComparableHolder {
+
+        private CustomComparable customComparable;
+
+        public CustomComparable getCustomComparable() {
+            return customComparable;
+        }
+
+        public void setCustomComparable(CustomComparable customComparable) {
+            this.customComparable = customComparable;
+        }
+    }
+
+    @QueryEmbeddable
+    public static class CustomComparable2 {
+
+
+        private CustomComparable customComparable;
+
+        public CustomComparable getCustomComparable() {
+            return customComparable;
+        }
+
+        public void setCustomComparable(CustomComparable customComparable) {
+            this.customComparable = customComparable;
+        }
+
+    }
+
     public static class CustomComparable implements Comparable<CustomComparable> {
 
         @Override
@@ -36,23 +65,9 @@ public class ComparableTest {
 
     }
 
-    @QueryEmbeddable
-    public static class CustomComparable2 implements Comparable<CustomComparable2> {
-
-        @Override
-        public int compareTo(CustomComparable2 o) {
-            return 0;
-        }
-
-        public boolean equals(Object o) {
-            return o == this;
-        }
-
-    }
-
     @Test
     public void customComparable_is_properly_handled() {
-        assertNotNull(QComparableTest_CustomComparable.customComparable.asc());
+        assertNotNull(QComparableTest_CustomComparableHolder.customComparableHolder.customComparable.asc());
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/domain/SignatureTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/domain/SignatureTest.java
@@ -17,10 +17,10 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.Serializable;
 
+import com.querydsl.core.types.dsl.EntityPathBase;
 import org.junit.Test;
 
 import com.querydsl.core.annotations.QuerySupertype;
-import com.querydsl.core.types.dsl.ComparablePath;
 
 public class SignatureTest {
 
@@ -36,12 +36,12 @@ public class SignatureTest {
 
     @Test
     public void aPropertyChangeSupported() {
-        assertEquals(ComparablePath.class, QSignatureTest_APropertyChangeSupported.class.getSuperclass());
+        assertEquals(EntityPathBase.class, QSignatureTest_APropertyChangeSupported.class.getSuperclass());
     }
 
     @Test
     public void aValueObject() {
-        assertEquals(ComparablePath.class, QSignatureTest_AValueObject.class.getSuperclass());
+        assertEquals(EntityPathBase.class, QSignatureTest_AValueObject.class.getSuperclass());
     }
 
 }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/TypeFactory.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/TypeFactory.java
@@ -188,15 +188,15 @@ public final class TypeFactory {
         TypeCategory typeCategory = TypeCategory.get(cl.getName());
         if (annotationHelper != null) {
             typeCategory = annotationHelper.getTypeByAnnotation(cl, annotation);
-        } else if (!typeCategory.isSubCategoryOf(TypeCategory.COMPARABLE) && Comparable.class.isAssignableFrom(cl)
-                && !cl.equals(Comparable.class)) {
-            typeCategory = TypeCategory.COMPARABLE;
         } else if (embeddableTypes.contains(cl)) {
+            typeCategory = TypeCategory.CUSTOM;
+        } else if (unknownAsEntity && typeCategory == TypeCategory.SIMPLE && !cl.getName().startsWith("java")) {
             typeCategory = TypeCategory.CUSTOM;
         } else if (typeCategory == TypeCategory.SIMPLE && entity) {
             typeCategory = TypeCategory.ENTITY;
-        } else if (unknownAsEntity && typeCategory == TypeCategory.SIMPLE && !cl.getName().startsWith("java")) {
-            typeCategory = TypeCategory.CUSTOM;
+        } else if (!typeCategory.isSubCategoryOf(TypeCategory.COMPARABLE) && Comparable.class.isAssignableFrom(cl)
+                && !cl.equals(Comparable.class)) {
+            typeCategory = TypeCategory.COMPARABLE;
         }
 
         return new ClassType(typeCategory, cl, parameters);


### PR DESCRIPTION
This PR fixes an issue where EntityPaths for entities that implement Comparable were not initialized. This happened because these paths are treated as `TypeCategory.COMPARABLE` rather than `TypeCategory.ENTITY` in https://github.com/querydsl/querydsl/blob/master/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java#L355-L361 . This block of code also need to consider `TypeCategory.COMPARABLE`.

For example:

```java
@Entity
public class A implements Comparable<A> {
      private SomeAssociation someAssociation;
}

@Entity
public class B {
      @QueryInit({"*", "someAssociation.*"})
      private A someA;
}
```


Then accessing `Qb.b.someA.someAssociation.id` would still result in a `NullPointerException`, which shouldn't happen. With this fix, this path is now initialized.

Fixes #2572

As I have a couple of entities in my domain with natural ordering I suffer from this bug personally. Its not easy to work around so I have been using a privately released snapshot release lately.