### PR TITLE
Handle unique null in SimpleExpression in / notIn

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
@@ -14,6 +14,7 @@
 package com.querydsl.core.types.dsl;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.annotation.Nullable;
 
@@ -189,10 +190,14 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      */
     public BooleanExpression in(Collection<? extends T> right) {
         if (right.size() == 1) {
-            return eq(right.iterator().next());
-        } else {
-            return Expressions.booleanOperation(Ops.IN, mixin, ConstantImpl.create(right));
+            T elem = right.iterator().next();
+
+            if (elem != null) {
+                return eq(elem);
+            }
         }
+
+        return Expressions.booleanOperation(Ops.IN, mixin, ConstantImpl.create(right));
     }
 
     /**
@@ -203,7 +208,11 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      */
     public BooleanExpression in(T... right) {
         if (right.length == 1) {
-            return eq(right[0]);
+            if (right[0] != null) {
+                return eq(right[0]);
+            } else {
+                return Expressions.booleanOperation(Ops.IN, mixin, ConstantImpl.create(Collections.singleton(null)));
+            }
         } else {
             return Expressions.booleanOperation(Ops.IN, mixin, ConstantImpl.create(ImmutableList.copyOf(right)));
         }
@@ -291,10 +300,14 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      */
     public BooleanExpression notIn(Collection<? extends T> right) {
         if (right.size() == 1) {
-            return ne(right.iterator().next());
-        } else {
-            return Expressions.booleanOperation(Ops.NOT_IN, mixin, ConstantImpl.create(right));
+            T elem = right.iterator().next();
+
+            if (elem != null) {
+                return ne(elem);
+            }
         }
+
+        return Expressions.booleanOperation(Ops.NOT_IN, mixin, ConstantImpl.create(right));
     }
 
     /**
@@ -305,7 +318,11 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      */
     public BooleanExpression notIn(T... right) {
         if (right.length == 1) {
-            return ne(right[0]);
+            if (right[0] != null) {
+                return ne(right[0]);
+            } else {
+                return Expressions.booleanOperation(Ops.NOT_IN, mixin, ConstantImpl.create(Collections.singleton(null)));
+            }
         } else {
             return Expressions.booleanOperation(Ops.NOT_IN, mixin, ConstantImpl.create(ImmutableList.copyOf(right)));
         }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
@@ -985,6 +985,16 @@ public abstract class AbstractJPATest {
     }
 
     @Test
+    public void in_unique_null_collection() {
+        assertEquals(0, query().from(cat).where(cat.name.in(Collections.singleton((String) null))).fetchCount());
+    }
+
+    @Test
+    public void in_unique_null_array() {
+        assertEquals(0, query().from(cat).where(cat.name.in(new String[] {null})).fetchCount());
+    }
+
+    @Test
     @NoOpenJPA
     public void indexOf() {
         assertEquals(Integer.valueOf(0), query().from(cat).where(cat.name.eq("Bob123"))
@@ -1268,6 +1278,16 @@ public abstract class AbstractJPATest {
     public void not_in_empty() {
         long count = query().from(cat).fetchCount();
         assertEquals(count, query().from(cat).where(cat.name.notIn(Collections.<String>emptyList())).fetchCount());
+    }
+
+    @Test
+    public void not_in_unique_null_collection() {
+        assertEquals(0, query().from(cat).where(cat.name.notIn(Collections.singleton((String) null))).fetchCount());
+    }
+
+    @Test
+    public void not_in_unique_null_array() {
+        assertEquals(0, query().from(cat).where(cat.name.notIn(new String[] {null})).fetchCount());
     }
 
     @Test

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractSQLTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractSQLTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -164,6 +165,18 @@ public abstract class AbstractSQLTest {
     @Test
     public void in() {
         assertEquals(6L, query().from(cat).where(cat.dtype.in("C", "CX")).fetchCount());
+    }
+
+    @Test
+    @ExcludeIn(Target.DERBY)
+    public void in_unique_null_collection() {
+        assertEquals(0, query().from(cat).where(cat.name.in(Collections.singleton((String) null))).fetchCount());
+    }
+
+    @Test
+    @ExcludeIn(Target.DERBY)
+    public void in_unique_null_array() {
+        assertEquals(0, query().from(cat).where(cat.name.in(new String[] {null})).fetchCount());
     }
 
     @Test


### PR DESCRIPTION
# Context

`SimpleExpression.in` and `SimpleExpression.notIn` will transform collection/array with a unique element into `eq(element)` and `ne(element)` respectively.
The problem is that when this unique element is `null`, it will throw an `IllegalArgumentException` with the following message:

```
eq(null) is not allowed. Use isNotNull() instead
```

or

```
ne(null) is not allowed. Use isNotNull() instead
```

The query should not be changed and fail because of this transformation, but instead let the backing datastore run the query.

# What was done

Changed the following methods from `SimpleExpression` to prevent failure from QueryDSL API:
- `in(Collection<? extends T> right)`
- `in(T... right)`
- `notIn(Collection<? extends T> right)`
- `notIn(T... right)`