### PR TITLE
[fixes #2566] fix: fixed hibernate handler iterate & trasnform conditional statement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>3.0</version>
+      <version>3.6</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
@@ -52,8 +52,8 @@ class HibernateHandler implements QueryHandler {
     @SuppressWarnings("unchecked")
     @Override
     public <T> CloseableIterator<T> iterate(Query query, FactoryExpression<?> projection) {
-        if (query instanceof NativeQuery) {
-            NativeQuery hQuery = (NativeQuery) query;
+        if (query instanceof org.hibernate.query.Query) {
+            org.hibernate.query.Query hQuery = (org.hibernate.query.Query) query;
             ScrollableResults results = hQuery.scroll(ScrollMode.FORWARD_ONLY);
             CloseableIterator<T> iterator = new ScrollableResultsIterator<T>(results);
             if (projection != null) {
@@ -73,9 +73,9 @@ class HibernateHandler implements QueryHandler {
     @SuppressWarnings("deprecation")
     @Override
     public boolean transform(Query query, FactoryExpression<?> projection) {
-        if (query instanceof NativeQuery) {
+        if (query instanceof org.hibernate.query.Query) {
             ResultTransformer transformer = new FactoryExpressionTransformer(projection);
-            query.unwrap(NativeQuery.class).setResultTransformer(transformer);
+            query.unwrap(org.hibernate.query.Query.class).setResultTransformer(transformer);
             return true;
         } else {
             return false;


### PR DESCRIPTION
## Problem

HibernateHandler.iterate does not use scrolling issue.

Fixes #2566 

## Description

The main subjects that use Hibernate handlers are `JpaSQLQuery` and `JpaQuery`.

Using JpaSQLQuery, when you call `entityManager.createNaitiveQuery`, you get a `NativeQueryImpl`. 

On the other hand, when using JpaQuery, you get `QueryImpl` by calling` entityManager.createQuery`.

iterate func and transform func should be usable in both implementations. (NativeQueryImpl and QueryImpl)

So, I changed the instance check with `org.hibernate.query.Query`, the parent of both implementations.




