### PR TITLE
Hibernate 5 Support

### DIFF
--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HQLTemplates.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HQLTemplates.java
@@ -28,8 +28,9 @@ import com.querydsl.core.types.Ops;
  * HQLTemplates extends {@link JPQLTemplates} with Hibernate specific extensions
  *
  * @author tiwe
- *
+ * @deprecated Most likely you want to use {@link Hibernate5Templates} instead
  */
+@Deprecated
 public class HQLTemplates extends JPQLTemplates {
 
     private static final QueryHandler QUERY_HANDLER;
@@ -86,16 +87,22 @@ public class HQLTemplates extends JPQLTemplates {
 
     @Override
     public boolean wrapElements(Operator operator) {
+        // For example: JPaIntegration.docoExamples98_12
         return wrapElements.contains(operator);
     }
 
     @Override
     public String getTypeForCast(Class<?> cl) {
-        return typeNames.get(cl);
+        String typeName = typeNames.get(cl);
+        if (typeName == null) {
+            return super.getTypeForCast(cl);
+        }
+        return typeName;
     }
 
     @Override
     public String getExistsProjection() {
+        // TODO Required / supported just for Hibernate?
         return "1";
     }
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/Hibernate5Templates.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/Hibernate5Templates.java
@@ -1,0 +1,32 @@
+package com.querydsl.jpa;
+
+/**
+ * Hibernate5Templates extends {@link JPQLTemplates} with Hibernate specific extensions
+ *
+ * @author Jan-Willem Gmelig Meyling
+ *
+ */
+public class Hibernate5Templates extends HQLTemplates {
+
+    public static final Hibernate5Templates DEFAULT = new Hibernate5Templates();
+
+    public Hibernate5Templates() {
+    }
+
+    public Hibernate5Templates(char escape) {
+        super(escape);
+    }
+
+    @Override
+    public boolean wrapConstant(Object constant) {
+        // HHH-6913 is fixed in 5.0, default to JPA behaviour
+        return false;
+    }
+
+    @Override
+    public boolean isWithForOn() {
+        // Hibernate supports the on-clause since 5.0, and the ON clause is actually mandatory for entity joins
+        return true;
+    }
+
+}

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateHandlerTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateHandlerTest.java
@@ -22,9 +22,11 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hibernate.ScrollMode.FORWARD_ONLY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class HibernateHandlerTest {
@@ -97,10 +99,11 @@ public class HibernateHandlerTest {
         ScrollableResultsImplementor scrollableResultsImplementor = createMock(ScrollableResultsImplementor.class);
         FactoryExpression<?> factoryExpression = createMock(FactoryExpression.class);
 
-        expect(nativeQuery.unwrap(NativeQuery.class)).andReturn(nativeQuery);
+        expect(nativeQuery.unwrap(org.hibernate.query.Query.class)).andReturn(nativeQuery);
         expect(nativeQuery.scroll(FORWARD_ONLY)).andReturn(scrollableResultsImplementor);
+        replay(nativeQuery);
 
-        assertEquals(TransformingIterator.class, hibernateHandler.iterate(nativeQuery, factoryExpression).getClass());
+        assertThat(hibernateHandler.iterate(nativeQuery, factoryExpression), instanceOf(TransformingIterator.class));
     }
 
     @Test
@@ -109,6 +112,7 @@ public class HibernateHandlerTest {
         List queryResultList = createMock(List.class);
         Iterator iterator = createMock(Iterator.class);
 
+        expect(query.unwrap(org.hibernate.query.Query.class)).andThrow(new PersistenceException("Cannot unwrap Query"));
         expect(query.getResultList()).andReturn(queryResultList);
         expect(queryResultList.iterator()).andReturn(iterator);
         replay(query);
@@ -123,6 +127,7 @@ public class HibernateHandlerTest {
         List queryResultList = createMock(List.class);
         Iterator iterator = createMock(Iterator.class);
 
+        expect(query.unwrap(org.hibernate.query.Query.class)).andThrow(new PersistenceException("Cannot unwrap Query"));
         expect(query.getResultList()).andReturn(queryResultList);
         expect(queryResultList.iterator()).andReturn(iterator);
         replay(query);
@@ -134,7 +139,7 @@ public class HibernateHandlerTest {
     public void should_transform() {
         FactoryExpression<?> projection = createMock(FactoryExpression.class);
 
-        expect(nativeQuery.unwrap(NativeQuery.class)).andReturn(nativeQuery);
+        expect(nativeQuery.unwrap(org.hibernate.query.Query.class)).andReturn(nativeQuery);
         expect(nativeQuery.setResultTransformer(anyObject(ResultTransformer.class))).andReturn(nativeQuery);
         replay(nativeQuery);
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
@@ -29,6 +29,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 
+import com.querydsl.core.Tuple;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -252,10 +253,10 @@ public class JPABase extends AbstractJPATest implements JPATest {
     @NoEclipseLink
     @NoBatooJPA
     public void createQuery() {
-        List<Object[]> rows = query().from(cat)
+        List<Tuple> rows = query().from(cat)
                 .select(cat.id, cat.name).createQuery().getResultList();
-        for (Object[] row : rows) {
-            assertEquals(2, row.length);
+        for (Tuple row : rows) {
+            assertEquals(2, row.size());
         }
     }
 
@@ -264,10 +265,10 @@ public class JPABase extends AbstractJPATest implements JPATest {
     @NoEclipseLink
     @NoBatooJPA
     public void createQuery2() {
-        List<Object[]> rows = query().from(cat)
+        List<Tuple> rows = query().from(cat)
                 .select(cat.id, cat.name).createQuery().getResultList();
-        for (Object[] row : rows) {
-            assertEquals(2, row.length);
+        for (Tuple row : rows) {
+            assertEquals(2, row.size());
         }
     }
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAProviderTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAProviderTest.java
@@ -38,7 +38,7 @@ public class JPAProviderTest {
         factory = Persistence.createEntityManagerFactory("h2");
         em = factory.createEntityManager();
         System.out.println(em.getDelegate().getClass());
-        assertEquals(HQLTemplates.DEFAULT, JPAProvider.getTemplates(em));
+        assertEquals(Hibernate5Templates.DEFAULT, JPAProvider.getTemplates(em));
     }
 
     @Test
@@ -55,7 +55,7 @@ public class JPAProviderTest {
                 Thread.currentThread().getContextClassLoader(),
                 new Class<?>[]{EntityManager.class},
                 handler);
-        assertEquals(HQLTemplates.DEFAULT, JPAProvider.getTemplates(proxy));
+        assertEquals(Hibernate5Templates.DEFAULT, JPAProvider.getTemplates(proxy));
     }
 
     @Test

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryFactoryTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryFactoryTest.java
@@ -76,7 +76,8 @@ public class JPAQueryFactoryTest {
     public void query3() {
         EasyMock.expect(mock.getEntityManagerFactory()).andReturn(factoryMock);
         EasyMock.expect(factoryMock.getProperties()).andReturn(properties);
-        EasyMock.expect(mock.getDelegate()).andReturn(mock).atLeastOnce();
+        EasyMock.expect(mock.unwrap(EasyMock.anyObject(Class.class))).andReturn(mock).atLeastOnce();
+
         EasyMock.replay(mock, factoryMock);
 
         queryFactory3.query().from(QAnimal.animal);
@@ -104,7 +105,7 @@ public class JPAQueryFactoryTest {
     public void delete3() {
         EasyMock.expect(mock.getEntityManagerFactory()).andReturn(factoryMock);
         EasyMock.expect(factoryMock.getProperties()).andReturn(properties);
-        EasyMock.expect(mock.getDelegate()).andReturn(mock).atLeastOnce();
+        EasyMock.expect(mock.unwrap(EasyMock.anyObject(Class.class))).andReturn(mock).atLeastOnce();
         EasyMock.replay(mock, factoryMock);
 
         assertNotNull(queryFactory3.delete(QAnimal.animal));
@@ -128,7 +129,7 @@ public class JPAQueryFactoryTest {
     public void update3() {
         EasyMock.expect(mock.getEntityManagerFactory()).andReturn(factoryMock);
         EasyMock.expect(factoryMock.getProperties()).andReturn(properties);
-        EasyMock.expect(mock.getDelegate()).andReturn(mock).atLeastOnce();
+        EasyMock.expect(mock.unwrap(EasyMock.anyObject(Class.class))).andReturn(mock).atLeastOnce();
         EasyMock.replay(mock, factoryMock);
 
         assertNotNull(queryFactory3.update(QAnimal.animal));
@@ -151,7 +152,7 @@ public class JPAQueryFactoryTest {
     public void insert3() {
         EasyMock.expect(mock.getEntityManagerFactory()).andReturn(factoryMock);
         EasyMock.expect(factoryMock.getProperties()).andReturn(properties);
-        EasyMock.expect(mock.getDelegate()).andReturn(mock).atLeastOnce();
+        EasyMock.expect(mock.unwrap(EasyMock.anyObject(Class.class))).andReturn(mock).atLeastOnce();
         EasyMock.replay(mock, factoryMock);
 
         assertNotNull(queryFactory3.insert(QAnimal.animal));


### PR DESCRIPTION
The last portion of Hibernate 5 support.

Supersedes #2578
Fixes #2566, the remaining issue for Hibernate 5.x support after #2264 (in #2510)
Also kind of fixes #2328, as the issue there was that the legacy `WITH` join type was still used for Hibernate, while this currently should use `ON`.