### PR TITLE
[#2504] [#2053] Fix fetchResults for GROUP BY and HAVING in JPQL

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
@@ -78,13 +78,20 @@ public interface Fetchable<T> {
      * {@link QueryResults#getLimit()}, because it will be more performant. Also, count queries cannot be
      * properly generated for all dialects. For example: in JPA count queries can't be generated for queries
      * that have multiple group by expressions or a having clause.
+     * Get the projection in {@link QueryResults} form.
+     *
+     * Use {@link #fetch()} instead if you do not need the total count of rows in the query result.
      *
      * @return results
+     * @see #fetch()
      */
     QueryResults<T> fetchResults();
 
     /**
      * Get the count of matched elements
+     *
+     * Note: not all QueryDSL modules might optimize fetchCount using a count query.
+     * An implementation is allowed to fall back to {@code fetch().size()}.
      *
      * @return row count
      */

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
@@ -29,6 +29,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 
+import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -278,5 +279,26 @@ public class JPABase extends AbstractJPATest implements JPATest {
         for (String row : rows) {
             assertNotNull(row);
         }
+    }
+
+    @Test
+    public void fetchCountResultsGroupByWithMultipleFields() {
+        QueryResults<Tuple> results = query().from(cat)
+                .groupBy(cat.alive, cat.breed)
+                .select(cat.alive, cat.breed, cat.id.sum())
+                .fetchResults();
+
+        assertEquals(1, results.getTotal());
+    }
+
+    @Test
+    public void fetchCountResultsGroupByWithHaving() {
+        QueryResults<Tuple> results = query().from(cat)
+                .groupBy(cat.alive)
+                .having(cat.id.sum().gt(5))
+                .select(cat.alive, cat.id.sum())
+                .fetchResults();
+
+        assertEquals(1, results.getTotal());
     }
 }


### PR DESCRIPTION
Fixes #2504 
Fixes #2053
Fixes #1614

Ideally JPA users should just use `fetch()` and not `fetchResults()` , particularly when the query involves a `GROUP BY` or `HAVING` clause. For `fetchCount()` there is no viable alternative to point users to, although users should be aware that `fetchCount()` for queries with a `GROUP BY` or `HAVING` clause is just as slow as fetching the entire query.

Also supersedes #1619. That patch naively moves the HAVING clause to the WHERE clause, but this will fail for some types of expressions (i.e. aggregate functions). As a result that patch still fails to resolve most of the issues.

See Slack: https://querydsl.slack.com/archives/C06KLG1BP/p1590961415105400