### PR TITLE
serialize BEFORE_FILTERS flags for update queries

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
@@ -651,6 +651,7 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
         }
         skipParent = false;
 
+        serialize(Position.BEFORE_FILTERS, metadata.getFlags());
         if (metadata.getWhere() != null) {
             serializeForWhere(metadata);
         }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/dml/SQLUpdateClauseTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/dml/SQLUpdateClauseTest.java
@@ -3,6 +3,7 @@ package com.querydsl.sql.dml;
 import static com.querydsl.sql.SQLExpressions.select;
 import static org.junit.Assert.assertEquals;
 
+import com.querydsl.core.QueryFlag.Position;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -76,6 +77,32 @@ public class SQLUpdateClauseTest {
                 "set SUPERIOR_ID = (select emp2.ID\n" +
                 "from EMPLOYEE emp2\n" +
                 "where emp2.ID = EMPLOYEE.ID)", sql.getSQL());
+    }
+
+    @Test
+    public void testBeforeFiltersFlag() {
+        QEmployee emp1 = new QEmployee("emp1");
+        QEmployee emp2 = new QEmployee("emp2");
+        SQLUpdateClause update = new SQLUpdateClause(null, SQLTemplates.DEFAULT, emp1)
+          .set(emp1.superiorId, emp2.id)
+          .addFlag(Position.BEFORE_FILTERS, String.format("\nfrom %s %s", emp2.getTableName(), emp2))
+          .where(emp2.id.eq(emp1.id));
+
+        SQLBindings sql = update.getSQL().get(0);
+        assertEquals("update EMPLOYEE\n" +
+                "set SUPERIOR_ID = emp2.ID\n" +
+                "from EMPLOYEE emp2\n" +
+                "where emp2.ID = EMPLOYEE.ID", sql.getSQL());
+
+        update = new SQLUpdateClause(null, SQLTemplates.DEFAULT, emp1)
+          .set(emp1.superiorId, emp2.id)
+          .addFlag(Position.BEFORE_FILTERS, " THE_FLAG")
+          .where(emp2.id.eq(emp1.id));
+
+        sql = update.getSQL().get(0);
+        assertEquals("update EMPLOYEE\n" +
+          "set SUPERIOR_ID = emp2.ID THE_FLAG\n" +
+          "where emp2.ID = EMPLOYEE.ID", sql.getSQL());
     }
 
     @Test


### PR DESCRIPTION
Enable developers to use Postgres update x set ...=... from syntax with BEFORE_FILTERS flag - for example:
```
 db.update(table)
      .set(table.f1, table2.f2)
      .addFlag(Position.BEFORE_FILTERS, table.getTableName() + " " + table + " from " + table2.getTableName() + " " + table2)
      .where(
        table.fkField.eq(table2.pkField)
        ...
      )
      .execute();
```