### PR TITLE
Downgrade mongo driver to 3.4 to solve dependency conflict

### DIFF
--- a/querydsl-mongodb/pom.xml
+++ b/querydsl-mongodb/pom.xml
@@ -16,7 +16,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <mongodb.version>3.5.0</mongodb.version>
+    <mongodb.version>3.4.0</mongodb.version>
     <osgi.import.package>
       com.mongodb;version="0.0.0",
       org.mongodb.morphia.*;version="1.3.2",


### PR DESCRIPTION
Fix the dependency conflict issue #2647 by Downgrade direct dependency version org.mongodb:mongo-java-driver from 3.5.0 to 3.4.0 in pom file.