### PR TITLE
Fix Flaky tests in SearchQueryTest

### DIFF
--- a/querydsl-hibernate-search/src/test/java/com/querydsl/hibernate/search/AbstractQueryTest.java
+++ b/querydsl-hibernate-search/src/test/java/com/querydsl/hibernate/search/AbstractQueryTest.java
@@ -38,7 +38,7 @@ public abstract class AbstractQueryTest {
     @BeforeClass
     public static void setUpClass() throws IOException {
         FileUtils.delete(new File("target/derbydb"));
-        FileUtils.delete(new File("target/lucene3"));
+        FileUtils.delete(new File("target/lucene"));
         AnnotationConfiguration cfg = new AnnotationConfiguration();
         cfg.addAnnotatedClass(User.class);
         Properties props = new Properties();


### PR DESCRIPTION
If `mvn test` is run consecutively in the querydsl-hibernate-search without `mvn clean` in between, the following unit tests will fail:

1. SearchQueryTest#count
2. SearchQueryTest#listResult
3. SearchQueryTest#paging

This occurs because the actual directory created by the unit tests is `target/lucene` not `target/lucene3`.