### PR TITLE
Target Java 8 for compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,15 @@
 * Java 8 minimal requirement. If you still rely on Java <7, please use the latest 4.x.x version.
 * Removed bridge method that were in place for backwards compatibility of legacy API's. This may lead to some breaking API changes.
 
+#### New features
+
+* Added `Fetchable#stream()` which returns a `Stream<T>`.
+  Make sure that the returned stream is always closed to free up resources, for example using _try-with-resources_.
+  It does not suffice to rely on a terminating operation on the stream for this (i.e. `forEach`, `collect`).
+
 #### Dependency updates
 
 * `cglib` to 3.3.0 for Java 8+ support
 * DataNucleus 5.2.x for Java 8+ support
   * JDO now uses `org.datanucleus:javax.jdo` instead of `javax.jdo:jdo-api`
-
-#### Plans
-
-- [x] Require Java 8
-- [ ] Optimize code for Java 8 (use new API's)
-- [ ] Support Java 8 date/time for `querydsl-sql`
-- [ ] Drop Guava dependency #2324 
-   - [ ] Support Java 8 Optional in favour of Guava's Optional
-- [ ] Assume Hibernate 5.3+ by default in Hibernate integration
-- [ ] Switch from`com.vividsolutions` to `org.locationtech` for JTS #2404. `hibernate-spatial` doesn't support the old artifact for a while now. If you still rely on `com.vividsolutions`, please use the lastest 4.x.x version.
-- [ ] Migrate off from jsr305 to https://github.com/JetBrains/java-annotations #2479
-- [ ] Consider breaking out some integrations (Hibernate, Datanucleus, OpenJPA) and extensions (Alias.*) to separate modules (if it helps with cleaning up dependencies, and in particular, not providing a false sense of support).
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+### 5.0.0
+
+#### Breaking changes
+
+* Java 8 minimal requirement. If you still rely on Java <7, please use the latest 4.x.x version.
+* Removed bridge method that were in place for backwards compatibility of legacy API's. This may lead to some breaking API changes.
+
+#### Dependency updates
+
+* `cglib` to 3.3.0 for Java 8+ support
+* DataNucleus 5.2.x for Java 8+ support
+  * JDO now uses `org.datanucleus:javax.jdo` instead of `javax.jdo:jdo-api`
+
+#### Plans
+
+- [x] Require Java 8
+- [ ] Optimize code for Java 8 (use new API's)
+- [ ] Support Java 8 date/time for `querydsl-sql`
+- [ ] Drop Guava dependency #2324 
+   - [ ] Support Java 8 Optional in favour of Guava's Optional
+- [ ] Assume Hibernate 5.3+ by default in Hibernate integration
+- [ ] Switch from`com.vividsolutions` to `org.locationtech` for JTS #2404. `hibernate-spatial` doesn't support the old artifact for a while now. If you still rely on `com.vividsolutions`, please use the lastest 4.x.x version.
+- [ ] Migrate off from jsr305 to https://github.com/JetBrains/java-annotations #2479
+- [ ] Consider breaking out some integrations (Hibernate, Datanucleus, OpenJPA) and extensions (Alias.*) to separate modules (if it helps with cleaning up dependencies, and in particular, not providing a false sense of support).

--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,10 @@
     <guava.version>18.0</guava.version>
     <codegen.version>0.6.8</codegen.version>
     <mysema.lang.version>0.2.4</mysema.lang.version>
-    <cglib.version>2.2.2</cglib.version>    
-    <findbugs.version>1.3.2</findbugs.version>
+    <cglib.version>3.3.0</cglib.version>
     <slf4j.version>1.6.1</slf4j.version>
-    <surefire.version>2.18</surefire.version>
+    <surefire.version>2.22.2</surefire.version>
     <animal-sniffer.version>1.18</animal-sniffer.version>
-
-    <jdo.version>3.0.1</jdo.version>
     <morphia.version>1.3.2</morphia.version>
     
     <!-- Import-Package definitions for maven-bundle-plugin -->
@@ -141,6 +138,11 @@
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
         <version>1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.datanucleus</groupId>
+        <artifactId>javax.jdo</artifactId>
+        <version>3.2.0-m13</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -221,12 +223,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.5.4</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
+          <version>3.8.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -414,8 +416,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <mysema.lang.version>0.2.4</mysema.lang.version>
     <cglib.version>3.3.0</cglib.version>
     <slf4j.version>1.6.1</slf4j.version>
-    <surefire.version>2.22.2</surefire.version>
+    <surefire.version>2.18</surefire.version>
     <animal-sniffer.version>1.18</animal-sniffer.version>
     <morphia.version>1.3.2</morphia.version>
     

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.4.1</version>
         <executions>
           <execution>
             <id>check</id>
@@ -286,10 +286,6 @@
             <configuration>
               <rules>
                 <requireBackwardCompatibility implementation="org.semver.enforcer.RequireBackwardCompatibility">
-                  <excludes>
-                    <exclude>com/querydsl/jpa/Hibernate5Templates</exclude>
-                    <exclude>com/querydsl/jpa/HibernateHandler</exclude>
-                  </excludes>
                   <compatibilityType>BACKWARD_COMPATIBLE_USER</compatibilityType>
                   <dumpDetails>true</dumpDetails>
                   <publicOnly>true</publicOnly>
@@ -302,7 +298,27 @@
           <dependency>
             <groupId>org.semver</groupId>
             <artifactId>enforcer-rule</artifactId>
-            <version>0.9.27</version>
+            <version>0.9.33</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>9.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -43,9 +43,8 @@
     
     <!-- provided -->
     <dependency>
-      <groupId>javax.jdo</groupId>
-      <artifactId>jdo-api</artifactId>
-      <version>${jdo.version}</version>
+      <groupId>org.datanucleus</groupId>
+      <artifactId>javax.jdo</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
@@ -176,16 +176,16 @@ public class DefaultConfiguration implements Configuration {
         boolean createDefaultVariable = true;
 
         if (options.containsKey(QUERYDSL_ENTITY_ACCESSORS)) {
-            entityAccessors = Boolean.valueOf(options.get(QUERYDSL_ENTITY_ACCESSORS));
+            entityAccessors = Boolean.parseBoolean(options.get(QUERYDSL_ENTITY_ACCESSORS));
         }
         if (options.containsKey(QUERYDSL_LIST_ACCESSORS)) {
-            listAccessors = Boolean.valueOf(options.get(QUERYDSL_LIST_ACCESSORS));
+            listAccessors = Boolean.parseBoolean(options.get(QUERYDSL_LIST_ACCESSORS));
         }
         if (options.containsKey(QUERYDSL_MAP_ACCESSORS)) {
-            mapAccessors = Boolean.valueOf(options.get(QUERYDSL_MAP_ACCESSORS));
+            mapAccessors = Boolean.parseBoolean(options.get(QUERYDSL_MAP_ACCESSORS));
         }
         if (options.containsKey(QUERYDSL_CREATE_DEFAULT_VARIABLE)) {
-            createDefaultVariable = Boolean.valueOf(options.get(QUERYDSL_CREATE_DEFAULT_VARIABLE));
+            createDefaultVariable = Boolean.parseBoolean(options.get(QUERYDSL_CREATE_DEFAULT_VARIABLE));
         }
         if (options.containsKey(QUERYDSL_PACKAGE_SUFFIX)) {
             module.bind(CodegenModule.PACKAGE_SUFFIX, Strings.nullToEmpty(options.get(QUERYDSL_PACKAGE_SUFFIX)));
@@ -197,7 +197,7 @@ public class DefaultConfiguration implements Configuration {
             module.bind(CodegenModule.SUFFIX, Strings.nullToEmpty(options.get(QUERYDSL_SUFFIX)));
         }
         if (options.containsKey(QUERYDSL_UNKNOWN_AS_EMBEDDABLE)) {
-            unknownAsEmbedded = Boolean.valueOf(options.get(QUERYDSL_UNKNOWN_AS_EMBEDDABLE));
+            unknownAsEmbedded = Boolean.parseBoolean(options.get(QUERYDSL_UNKNOWN_AS_EMBEDDABLE));
         }
 
         if (options.containsKey(QUERYDSL_EXCLUDED_PACKAGES)) {
@@ -233,11 +233,11 @@ public class DefaultConfiguration implements Configuration {
         }
 
         if (options.containsKey(QUERYDSL_USE_FIELDS)) {
-            useFields = Boolean.valueOf(options.get(QUERYDSL_USE_FIELDS));
+            useFields = Boolean.parseBoolean(options.get(QUERYDSL_USE_FIELDS));
         }
 
         if (options.containsKey(QUERYDSL_USE_GETTERS)) {
-            useGetters = Boolean.valueOf(options.get(QUERYDSL_USE_GETTERS));
+            useGetters = Boolean.parseBoolean(options.get(QUERYDSL_USE_GETTERS));
         }
 
         if (options.containsKey(QUERYDSL_VARIABLE_NAME_FUNCTION_CLASS)) {
@@ -363,10 +363,8 @@ public class DefaultConfiguration implements Configuration {
     public SerializerConfig getSerializerConfig(EntityType entityType) {
         if (typeToConfig.containsKey(entityType.getFullName())) {
             return typeToConfig.get(entityType.getFullName());
-        } else if (packageToConfig.containsKey(entityType.getPackageName())) {
-            return packageToConfig.get(entityType.getPackageName());
         } else {
-            return defaultSerializerConfig;
+            return packageToConfig.getOrDefault(entityType.getPackageName(), defaultSerializerConfig);
         }
     }
 

--- a/querydsl-apt/src/main/java/com/querydsl/apt/SimpleTypeVisitorAdapter.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/SimpleTypeVisitorAdapter.java
@@ -54,9 +54,7 @@ class SimpleTypeVisitorAdapter<R, P> extends SimpleTypeVisitor6<R, P> {
             try {
                 List<TypeMirror> bounds = (List<TypeMirror>) getBoundsMethod.invoke(t);
                 return bounds.get(0).accept(this, p);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e.getMessage(), e);
-            } catch (InvocationTargetException e) {
+            } catch (IllegalAccessException | InvocationTargetException e) {
                 throw new RuntimeException(e.getMessage(), e);
             }
         } else {

--- a/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateConfiguration.java
@@ -47,8 +47,7 @@ public class HibernateConfiguration extends JPAConfiguration {
     @Override
     protected List<Class<? extends Annotation>> getAnnotations() {
         try {
-            List<Class<? extends Annotation>> annotations = new ArrayList<Class<? extends Annotation>>();
-            annotations.addAll(super.getAnnotations());
+            List<Class<? extends Annotation>> annotations = new ArrayList<Class<? extends Annotation>>(super.getAnnotations());
             for (String simpleName : Arrays.asList("Type", "Cascade", "LazyCollection", "OnDelete")) {
                 annotations.add((Class<? extends Annotation>) Class.forName("org.hibernate.annotations." + simpleName));
             }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/AbstractProcessorTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/AbstractProcessorTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractProcessorTest {
 
         ByteArrayOutputStream out = getStdOut();
         ByteArrayOutputStream err = getStdErr();
-        int compilationResult = compiler.run(null, out, err, options.toArray(new String[options.size()]));
+        int compilationResult = compiler.run(null, out, err, options.toArray(new String[0]));
 
 //        Processor.elementCache.clear();
         if (compilationResult != 0) {

--- a/querydsl-apt/src/test/java/com/querydsl/apt/DateExtensionsTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/DateExtensionsTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Ignore;
@@ -66,7 +67,7 @@ public class DateExtensionsTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-AdefaultOverwrite=true");
+        return Collections.singletonList("-AdefaultOverwrite=true");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/EclipseCompilationTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/EclipseCompilationTest.java
@@ -72,7 +72,7 @@ public class EclipseCompilationTest {
         options.add("-verbose");
         options.addAll(classes);
 
-        int compilationResult = compiler.run(null, System.out, System.err, options.toArray(new String[options.size()]));
+        int compilationResult = compiler.run(null, System.out, System.err, options.toArray(new String[0]));
         if (compilationResult == 0) {
             System.out.println("Compilation is successful");
         } else {

--- a/querydsl-apt/src/test/java/com/querydsl/apt/EntityExtensionsTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/EntityExtensionsTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Ignore;
@@ -66,7 +67,7 @@ public class EntityExtensionsTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-AdefaultOverwrite=true");
+        return Collections.singletonList("-AdefaultOverwrite=true");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/ExcludedClassesTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/ExcludedClassesTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -37,7 +37,7 @@ public class ExcludedClassesTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-Aquerydsl.excludedClasses=com.querydsl.apt.domain.ArrayTest.ArrayTestEntity");
+        return Collections.singletonList("-Aquerydsl.excludedClasses=com.querydsl.apt.domain.ArrayTest.ArrayTestEntity");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/ExcludedPackagesTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/ExcludedPackagesTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -39,7 +39,7 @@ public class ExcludedPackagesTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-Aquerydsl.excludedPackages=com.querydsl.apt.domain.p1");
+        return Collections.singletonList("-Aquerydsl.excludedPackages=com.querydsl.apt.domain.p1");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/IncludedClassesTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/IncludedClassesTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -39,7 +39,7 @@ public class IncludedClassesTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-Aquerydsl.includedClasses=com.querydsl.apt.domain.ArrayTest.ArrayTestEntity");
+        return Collections.singletonList("-Aquerydsl.includedClasses=com.querydsl.apt.domain.ArrayTest.ArrayTestEntity");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/IncludedPackagesTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/IncludedPackagesTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -39,7 +39,7 @@ public class IncludedPackagesTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-Aquerydsl.includedPackages=com.querydsl.apt.domain.p2");
+        return Collections.singletonList("-Aquerydsl.includedPackages=com.querydsl.apt.domain.p2");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/NoteTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/NoteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -48,14 +47,14 @@ public class NoteTest extends AbstractProcessorTest {
 
     @Test
     public void processEnabled() throws IOException {
-        aptOptions = Arrays.asList("-Aquerydsl.logInfo=true");
+        aptOptions = Collections.singletonList("-Aquerydsl.logInfo=true");
         process();
         assertFalse(isStdErrEmpty());
     }
 
     @Test
     public void processDisabled() throws IOException {
-        aptOptions = Arrays.asList("-Aquerydsl.logInfo=false");
+        aptOptions = Collections.singletonList("-Aquerydsl.logInfo=false");
         process();
         assertTrue(isStdErrEmpty());
     }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/PackageSuffixTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/PackageSuffixTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -40,7 +40,7 @@ public class PackageSuffixTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-Aquerydsl.packageSuffix=.query");
+        return Collections.singletonList("-Aquerydsl.packageSuffix=.query");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/UnknownAsEmbeddableTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/UnknownAsEmbeddableTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -40,7 +40,7 @@ public class UnknownAsEmbeddableTest extends AbstractProcessorTest {
 
     @Override
     protected Collection<String> getAPTOptions() {
-        return Arrays.asList("-Aquerydsl.unknownAsEmbeddable=true");
+        return Collections.singletonList("-Aquerydsl.unknownAsEmbeddable=true");
     }
 
 }

--- a/querydsl-apt/src/test/java/com/querydsl/apt/domain/ExpressionTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/domain/ExpressionTest.java
@@ -61,10 +61,8 @@ public class ExpressionTest {
         exprs.add(ConstantImpl.create(true));
         exprs.add(ConstantImpl.create(false));
 
-        Set<Expression<?>> toVisit = new HashSet<Expression<?>>();
-
         // all entities
-        toVisit.addAll(exprs);
+        Set<Expression<?>> toVisit = new HashSet<Expression<?>>(exprs);
         // and all their direct properties
         for (Expression<?> expr : exprs) {
             for (Field field : expr.getClass().getFields()) {

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/AbstractModule.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/AbstractModule.java
@@ -123,9 +123,7 @@ public abstract class AbstractModule {
         if (constructor == null) {
             try {
                 constructor = implementation.getConstructor();
-            } catch (SecurityException e) {
-                throw new RuntimeException(e);
-            } catch (NoSuchMethodException e) {
+            } catch (SecurityException | NoSuchMethodException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -143,11 +141,7 @@ public abstract class AbstractModule {
             try {
                 return (T) constructor.newInstance(args);
                 // TODO : populate fields as well?!?
-            } catch (InstantiationException e) {
-                throw new RuntimeException(e);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            } catch (InvocationTargetException e) {
+            } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
 

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/BeanSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/BeanSerializer.java
@@ -118,7 +118,7 @@ public class BeanSerializer implements Serializer {
         if (addToString && model.hasArrays()) {
             importedClasses.add(Arrays.class.getName());
         }
-        writer.importClasses(importedClasses.toArray(new String[importedClasses.size()]));
+        writer.importClasses(importedClasses.toArray(new String[0]));
 
         // javadoc
         writer.javadoc(simpleName + javadocSuffix);
@@ -135,7 +135,7 @@ public class BeanSerializer implements Serializer {
             if (printSupertype && model.getSuperType() != null) {
                 superType = model.getSuperType().getType();
             }
-            Type[] ifaces = interfaces.toArray(new Type[interfaces.size()]);
+            Type[] ifaces = interfaces.toArray(new Type[0]);
             writer.beginClass(model, superType, ifaces);
         } else if (printSupertype && model.getSuperType() != null) {
             writer.beginClass(model, model.getSuperType().getType());
@@ -207,9 +207,9 @@ public class BeanSerializer implements Serializer {
             } else {
                 builder.append("\"");
             }
-            builder.append(propertyName + " = \" + ");
+            builder.append(propertyName).append(" = \" + ");
             if (property.getType().getCategory() == TypeCategory.ARRAY) {
-                builder.append("Arrays.toString(" + propertyName + ")");
+                builder.append("Arrays.toString(").append(propertyName).append(")");
             } else {
                 builder.append(propertyName);
             }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/ClassPathUtils.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/ClassPathUtils.java
@@ -80,9 +80,7 @@ public final class ClassPathUtils {
             } else {
                 return Class.forName(className, true, classLoader);
             }
-        } catch (ClassNotFoundException e) {
-            return null;
-        } catch (NoClassDefFoundError e) {
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
             return null;
         }
     }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EntitySerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EntitySerializer.java
@@ -387,7 +387,7 @@ public class EntitySerializer implements Serializer {
             writer.append("}");
 
             for (Parameter p : c.getParameters()) {
-                writer.append(COMMA + p.getName());
+                writer.append(COMMA).append(p.getName());
             }
 
             // end
@@ -444,7 +444,7 @@ public class EntitySerializer implements Serializer {
         if (inits) {
             classes.add(PathInits.class);
         }
-        writer.imports(classes.toArray(new Class<?>[classes.size()]));
+        writer.imports(classes.toArray(new Class<?>[0]));
     }
 
     private Set<String> getUsedClassNames(EntityType model) {
@@ -490,7 +490,7 @@ public class EntitySerializer implements Serializer {
                 packages.add(delegate.getDelegateType().getPackageName());
             }
         }
-        writer.importPackages(packages.toArray(new String[packages.size()]));
+        writer.importPackages(packages.toArray(new String[0]));
     }
 
     protected void introInits(CodeWriter writer, EntityType model) throws IOException {
@@ -558,7 +558,7 @@ public class EntitySerializer implements Serializer {
 
     private void delegate(final EntityType model, Delegate delegate, SerializerConfig config,
             CodeWriter writer) throws IOException {
-        Parameter[] params = delegate.getParameters().toArray(new Parameter[delegate.getParameters().size()]);
+        Parameter[] params = delegate.getParameters().toArray(new Parameter[0]);
         writer.beginPublicMethod(delegate.getReturnType(), delegate.getName(), params);
 
         // body start
@@ -576,7 +576,7 @@ public class EntitySerializer implements Serializer {
             }
         }
         for (Parameter parameter : delegate.getParameters()) {
-            writer.append(COMMA + parameter.getName());
+            writer.append(COMMA).append(parameter.getName());
         }
         writer.append(");\n");
 
@@ -625,12 +625,12 @@ public class EntitySerializer implements Serializer {
         StringBuilder value = new StringBuilder();
         if (field.isInherited() && superType != null) {
             if (!superType.getEntityType().hasEntityFields()) {
-                value.append("_super." + field.getEscapedName());
+                value.append("_super.").append(field.getEscapedName());
             }
         } else {
-            value.append(factoryMethod + "(\"" + field.getName() + QUOTE);
+            value.append(factoryMethod).append("(\"").append(field.getName()).append(QUOTE);
             for (String arg : args) {
-                value.append(COMMA + arg);
+                value.append(COMMA).append(arg);
             }
             value.append(")");
         }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
@@ -558,12 +558,9 @@ public class GenericExporter {
             EntityType type) throws IOException {
         File targetFile = new File(targetFolder, path);
         generatedFiles.add(targetFile);
-        Writer w = writerFor(targetFile);
-        try {
+        try (Writer w = writerFor(targetFile)) {
             CodeWriter writer = createScalaSources ? new ScalaWriter(w) : new JavaWriter(w);
             serializer.serialize(type, serializerConfig, writer);
-        } finally {
-            w.close();
         }
     }
 

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GroovyBeanSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GroovyBeanSerializer.java
@@ -94,7 +94,7 @@ public class GroovyBeanSerializer implements Serializer {
         if (model.hasMaps()) {
             importedClasses.add(Map.class.getName());
         }
-        writer.importClasses(importedClasses.toArray(new String[importedClasses.size()]));
+        writer.importClasses(importedClasses.toArray(new String[0]));
 
         // javadoc
         writer.javadoc(simpleName + javadocSuffix);

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/ProjectionSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/ProjectionSerializer.java
@@ -133,7 +133,7 @@ public final class ProjectionSerializer implements Serializer {
             writer.append("}");
 
             for (Parameter p : c.getParameters()) {
-                writer.append(", " + p.getName());
+                writer.append(", ").append(p.getName());
             }
 
             // end

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/ScalaTypeDump.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/ScalaTypeDump.java
@@ -60,7 +60,7 @@ public class ScalaTypeDump {
                     params.add(new Parameter("arg" + params.size(), new ClassType(paramType)));
                 }
                 Type returnType = new ClassType(m.getReturnType());
-                writer.beginPublicMethod(returnType, ":" + m.getName(), params.toArray(new Parameter[params.size()]));
+                writer.beginPublicMethod(returnType, ":" + m.getName(), params.toArray(new Parameter[0]));
                 writer.end();
             }
             writer.end();

--- a/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
@@ -172,7 +173,12 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
     public CloseableIterator<T> iterate() {
         @SuppressWarnings("unchecked") // This is the built type
         Expression<T> projection = (Expression<T>) queryMixin.getMetadata().getProjection();
-        return new IteratorAdapter<T>(queryEngine.list(getMetadata(), iterables, projection).iterator());
+        return new IteratorAdapter<T>(fetch().iterator());
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return fetch().stream();
     }
 
     @Override

--- a/querydsl-collections/src/main/java/com/querydsl/collections/CollQueryFunctions.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/CollQueryFunctions.java
@@ -78,7 +78,7 @@ public final class CollQueryFunctions {
         }
     };
 
-    private static final List<Object> nullList = Arrays.asList((Object) null);
+    private static final List<Object> nullList = Collections.singletonList((Object) null);
 
     public static boolean equals(Object o1, Object o2) {
         return Objects.equal(o1, o2);

--- a/querydsl-collections/src/main/java/com/querydsl/collections/DefaultEvaluatorFactory.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/DefaultEvaluatorFactory.java
@@ -262,9 +262,9 @@ public class DefaultEvaluatorFactory {
         return factory.createEvaluator(
                 ser.toString(),
                 projectionType,
-                sourceNames.toArray(new String[sourceNames.size()]),
-                sourceTypes.toArray(new Type[sourceTypes.size()]),
-                sourceClasses.toArray(new Class<?>[sourceClasses.size()]),
+                sourceNames.toArray(new String[0]),
+                sourceTypes.toArray(new Type[0]),
+                sourceClasses.toArray(new Class<?>[0]),
                 constants);
     }
 

--- a/querydsl-collections/src/main/java/com/querydsl/collections/DefaultQueryEngine.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/DefaultQueryEngine.java
@@ -209,7 +209,7 @@ public class DefaultQueryEngine implements QueryEngine {
         }
         Expression<?> expr = new ArrayConstructorExpression<Object>(Object[].class, orderByExpr);
         Evaluator orderEvaluator = evaluatorFactory.create(metadata, sources, expr);
-        Collections.sort(list, new MultiComparator(orderEvaluator, directions));
+        list.sort(new MultiComparator(orderEvaluator, directions));
     }
 
     private List<?> project(QueryMetadata metadata, List<Expression<?>> sources, List<?> list) {

--- a/querydsl-collections/src/test/java/com/querydsl/collections/AbstractQueryTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/AbstractQueryTest.java
@@ -84,9 +84,7 @@ public abstract class AbstractQueryTest {
         @Override
         public List<T> fetch() {
             List<T> rv = super.fetch();
-            for (T o : rv) {
-                res.add(o);
-            }
+            res.addAll(rv);
             return rv;
         }
 

--- a/querydsl-collections/src/test/java/com/querydsl/collections/AggregationTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/AggregationTest.java
@@ -24,7 +24,7 @@ public class AggregationTest extends AbstractQueryTest {
         cat3.setWeight(4);
         Cat cat4 = new Cat();
         cat4.setWeight(5);
-        query = CollQueryFactory.from(cat, Arrays.asList(cat1, cat2, cat3, cat4));
+        query = CollQueryFactory.<Cat> from(cat, Arrays.asList(cat1, cat2, cat3, cat4));
     }
 
     @Test

--- a/querydsl-collections/src/test/java/com/querydsl/collections/AliasTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/AliasTest.java
@@ -18,6 +18,7 @@ import static com.querydsl.core.alias.Alias.*;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 
 import org.junit.Before;
@@ -57,12 +58,12 @@ public class AliasTest extends AbstractQueryTest {
     public void aliasVariations2() {
         // 1st
         QCat cat = new QCat("cat");
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 from(cat, cats).where(cat.name.matches("fri.*")).select(cat.name).fetch());
 
         // 2nd
         Cat c = alias(Cat.class, "cat");
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 from(c, cats).where($(c.getName()).matches("fri.*")).select($(c.getName())).fetch());
     }
 

--- a/querydsl-collections/src/test/java/com/querydsl/collections/BigDecimalTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/BigDecimalTest.java
@@ -15,15 +15,15 @@ public class BigDecimalTest {
     @Test
     public void arithmetic() {
         NumberPath<BigDecimal> num = Expressions.numberPath(BigDecimal.class, "num");
-        CollQuery<?> query = CollQueryFactory.from(num, Arrays.asList(BigDecimal.ONE, BigDecimal.valueOf(2)));
+        CollQuery<BigDecimal> query = CollQueryFactory.<BigDecimal> from(num, Arrays.<BigDecimal> asList(BigDecimal.ONE, BigDecimal.valueOf(2)));
         assertEquals(Arrays.asList(BigDecimal.valueOf(11), BigDecimal.valueOf(12)),
-                query.select(num.add(BigDecimal.TEN)).fetch());
+                query.<BigDecimal> select(num.add(BigDecimal.TEN)).fetch());
         assertEquals(Arrays.asList(BigDecimal.valueOf(-9), BigDecimal.valueOf(-8)),
-                query.select(num.subtract(BigDecimal.TEN)).fetch());
+                query.<BigDecimal> select(num.subtract(BigDecimal.TEN)).fetch());
         assertEquals(Arrays.asList(BigDecimal.valueOf(10), BigDecimal.valueOf(20)),
-                query.select(num.multiply(BigDecimal.TEN)).fetch());
+                query.<BigDecimal> select(num.multiply(BigDecimal.TEN)).fetch());
         assertEquals(Arrays.asList(new BigDecimal("0.1"), new BigDecimal("0.2")),
-                query.select(num.divide(BigDecimal.TEN)).fetch());
+                query.<BigDecimal> select(num.divide(BigDecimal.TEN)).fetch());
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/Cat.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/Cat.java
@@ -53,7 +53,7 @@ public class Cat extends Animal {
 
     public Cat(String name) {
         Cat kitten = new Cat();
-        this.kittens = Arrays.asList(kitten);
+        this.kittens = Collections.singletonList(kitten);
         this.kittenArray = new Cat[]{kitten};
         this.kittensByName = Collections.singletonMap("Kitty", kitten);
         this.name = name;

--- a/querydsl-collections/src/test/java/com/querydsl/collections/CollectionAnyTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/CollectionAnyTest.java
@@ -3,6 +3,7 @@ package com.querydsl.collections;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -14,7 +15,7 @@ public class CollectionAnyTest extends AbstractQueryTest {
         Cat a = new Cat("a");
         a.setKittens(null);
 
-        assertEquals(0, CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(a))
+        assertEquals(0, CollQueryFactory.<Cat> from(cat, Collections.<Cat>singletonList(a))
                 .where(cat.kittens.any().name.startsWith("a")).fetchCount());
     }
 

--- a/querydsl-collections/src/test/java/com/querydsl/collections/CollectionAnyTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/CollectionAnyTest.java
@@ -14,7 +14,7 @@ public class CollectionAnyTest extends AbstractQueryTest {
         Cat a = new Cat("a");
         a.setKittens(null);
 
-        assertEquals(0, CollQueryFactory.from(cat, Arrays.asList(a))
+        assertEquals(0, CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(a))
                 .where(cat.kittens.any().name.startsWith("a")).fetchCount());
     }
 
@@ -32,7 +32,7 @@ public class CollectionAnyTest extends AbstractQueryTest {
         b.setKittens(Arrays.asList(ba, bb));
 
         QCat cat = QCat.cat;
-        List<Cat> kittens = CollQueryFactory.from(cat, Arrays.asList(a,b)).select(cat.kittens.any()).fetch();
+        List<Cat> kittens = CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(a,b)).<Cat> select(cat.kittens.any()).fetch();
         assertEquals(Arrays.asList(aa,ab,ac,ba,bb), kittens);
     }
 
@@ -50,7 +50,7 @@ public class CollectionAnyTest extends AbstractQueryTest {
         b.setKittens(Arrays.asList(ba, bb));
 
         QCat cat = QCat.cat;
-        List<String> kittens = CollQueryFactory.from(cat, Arrays.asList(a,b))
+        List<String> kittens = CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(a,b))
                 .select(cat.kittens.any().name).fetch();
         assertEquals(Arrays.asList("aa","ab","ac","ba","bb"), kittens);
     }
@@ -69,7 +69,7 @@ public class CollectionAnyTest extends AbstractQueryTest {
         b.setKittens(Arrays.asList(ba, bb));
 
         QCat cat = QCat.cat;
-        List<Cat> kittens = CollQueryFactory.from(cat, Arrays.asList(a,b))
+        List<Cat> kittens = CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(a,b))
                 .where(cat.kittens.any().name.startsWith("a"))
                 .select(cat.kittens.any()).fetch();
 
@@ -90,7 +90,7 @@ public class CollectionAnyTest extends AbstractQueryTest {
         b.setKittens(Arrays.asList(ba, bb));
 
         QCat cat = QCat.cat;
-        List<String> kittens = CollQueryFactory.from(cat, Arrays.asList(a,b))
+        List<String> kittens = CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(a,b))
                 .where(cat.kittens.any().name.startsWith("a"))
                 .select(cat.kittens.any().name).fetch();
 

--- a/querydsl-collections/src/test/java/com/querydsl/collections/CollectionTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/CollectionTest.java
@@ -16,6 +16,7 @@ package com.querydsl.collections;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -32,7 +33,7 @@ public class CollectionTest {
     @Before
     public void setUp() {
         Cat cat1 = new Cat("1");
-        cat1.setKittens(Arrays.asList(cat1));
+        cat1.setKittens(Collections.singletonList(cat1));
         Cat cat2 = new Cat("2");
         cat2.setKittens(Arrays.asList(cat1, cat2));
         Cat cat3 = new Cat("3");

--- a/querydsl-collections/src/test/java/com/querydsl/collections/DistinctTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/DistinctTest.java
@@ -59,7 +59,7 @@ public class DistinctTest extends AbstractQueryTest {
     @Test
     public void null_() {
         assertEquals(Arrays.asList(null, 1),
-            CollQueryFactory.from(intVar1, Arrays.asList(null, 1)).distinct().fetch());
+            CollQueryFactory.<Integer> from(intVar1, Arrays.asList(null, 1)).distinct().fetch());
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/GroupByTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/GroupByTest.java
@@ -124,7 +124,7 @@ public class GroupByTest {
         assertEquals(toInt(1), group.getOne(post.id));
         assertEquals("Post 1", group.getOne(post.name));
         assertEquals(toSet(1), group.getSet(comment.id));
-        assertEquals(Arrays.asList("Comment 1"), group.getList(comment.text));
+        assertEquals(Collections.singletonList("Comment 1"), group.getList(comment.text));
     }
 
     @Test
@@ -185,7 +185,7 @@ public class GroupByTest {
         assertEquals(toInt(1), array[0]);
         assertEquals("Post 1", array[1]);
         assertEquals(toSet(1), array[2]);
-        assertEquals(Arrays.asList("Comment 1"), array[3]);
+        assertEquals(Collections.singletonList("Comment 1"), array[3]);
     }
 
     @Test

--- a/querydsl-collections/src/test/java/com/querydsl/collections/InnerClassTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/InnerClassTest.java
@@ -18,7 +18,7 @@ import static com.querydsl.core.alias.Alias.alias;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -34,10 +34,10 @@ public class InnerClassTest {
     @Test
     public void query() {
         Example example = alias(Example.class);
-        assertFalse(CollQueryFactory.<Example> from($(example), Arrays.<Example> asList(new Example()))
+        assertFalse(CollQueryFactory.<Example> from($(example), Collections.<Example>singletonList(new Example()))
                 .where($(example.getId()).isNull())
                 .fetch().isEmpty());
-        assertTrue(CollQueryFactory.<Example> from($(example), Arrays.<Example> asList(new Example()))
+        assertTrue(CollQueryFactory.<Example> from($(example), Collections.<Example>singletonList(new Example()))
                 .where($(example.getId()).isNotNull())
                 .fetch().isEmpty());
     }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/InnerClassTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/InnerClassTest.java
@@ -34,10 +34,10 @@ public class InnerClassTest {
     @Test
     public void query() {
         Example example = alias(Example.class);
-        assertFalse(CollQueryFactory.from($(example), Arrays.asList(new Example()))
+        assertFalse(CollQueryFactory.<Example> from($(example), Arrays.<Example> asList(new Example()))
                 .where($(example.getId()).isNull())
                 .fetch().isEmpty());
-        assertTrue(CollQueryFactory.from($(example), Arrays.asList(new Example()))
+        assertTrue(CollQueryFactory.<Example> from($(example), Arrays.<Example> asList(new Example()))
                 .where($(example.getId()).isNotNull())
                 .fetch().isEmpty());
     }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/IterationTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/IterationTest.java
@@ -47,7 +47,7 @@ public class IterationTest {
 
     @Test
     public void test2() {
-        assertEquals(expected, CollQueryFactory.from($(lt), Arrays.asList(allData.toArray())).select($(lt.getData())).fetch());
+        assertEquals(expected, CollQueryFactory.<Data> from($(lt), Arrays.<Data> asList(allData.toArray(new Data[0]))).select($(lt.getData())).fetch());
     }
 
     @Test
@@ -57,6 +57,6 @@ public class IterationTest {
 
     @Test
     public void test4() {
-        assertEquals(expected, CollQueryFactory.from(lt, Arrays.asList(allData.toArray())).select($(lt.getData())).fetch());
+        assertEquals(expected, CollQueryFactory.<Data> from(lt, Arrays.<Data> asList(allData.toArray(new Data[0]))).select($(lt.getData())).fetch());
     }
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/MathTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/MathTest.java
@@ -63,7 +63,7 @@ public class MathTest {
 
     private <T> T unique(Expression<T> expr) {
         //return query().fetchOne(expr);
-        return CollQueryFactory.from(num, Arrays.asList(0.5)).select(expr).fetchOne();
+        return CollQueryFactory.<Double> from(num, Arrays.asList(0.5)).select(expr).fetchOne();
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/MathTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/MathTest.java
@@ -2,7 +2,7 @@ package com.querydsl.collections;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -63,7 +63,7 @@ public class MathTest {
 
     private <T> T unique(Expression<T> expr) {
         //return query().fetchOne(expr);
-        return CollQueryFactory.<Double> from(num, Arrays.asList(0.5)).select(expr).fetchOne();
+        return CollQueryFactory.<Double> from(num, Collections.singletonList(0.5)).select(expr).fetchOne();
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/NullSafetyTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/NullSafetyTest.java
@@ -11,7 +11,7 @@ public class NullSafetyTest extends AbstractQueryTest {
     @Test
     public void filters() {
         QCat cat = QCat.cat;
-        CollQuery<Cat> query = CollQueryFactory.from(cat, Arrays.asList(new Cat(), new Cat("Bob")));
+        CollQuery<Cat> query = CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(new Cat(), new Cat("Bob")));
         assertEquals(1L, query.where(cat.name.eq("Bob")).fetchCount());
     }
 
@@ -25,7 +25,7 @@ public class NullSafetyTest extends AbstractQueryTest {
 
         QCat cat = QCat.cat;
         QCat kitten = new QCat("kitten");
-        CollQuery<Cat> query = CollQueryFactory.from(cat, Arrays.asList(cat1, cat2)).innerJoin(cat.kittens, kitten);
+        CollQuery<Cat> query = CollQueryFactory.<Cat> from(cat, Arrays.<Cat> asList(cat1, cat2)).innerJoin(cat.kittens, kitten);
         assertEquals(1, query.where(kitten.name.eq("Bob")).fetchCount());
     }
 

--- a/querydsl-collections/src/test/java/com/querydsl/collections/NumberTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/NumberTest.java
@@ -15,8 +15,8 @@ public class NumberTest {
     @Test
     public void sum() throws Exception {
         NumberPath<BigDecimal> num = Expressions.numberPath(BigDecimal.class, "num");
-        CollQuery<?> query = CollQueryFactory.from(num, Arrays.asList(new BigDecimal("1.6"), new BigDecimal("1.3")));
+        CollQuery<BigDecimal> query = CollQueryFactory.<BigDecimal> from(num, Arrays.<BigDecimal> asList(new BigDecimal("1.6"), new BigDecimal("1.3")));
 
-        assertEquals(new BigDecimal("2.9"), query.select(num.sum()).fetchOne());
+        assertEquals(new BigDecimal("2.9"), query.<BigDecimal> select(num.sum()).fetchOne());
     }
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/QueryMetadataTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/QueryMetadataTest.java
@@ -15,7 +15,7 @@ package com.querydsl.collections;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -33,7 +33,7 @@ public class QueryMetadataTest extends AbstractQueryTest {
 
         CollQuery<?> query = new CollQuery<Void>(metadata);
         query.bind(cat, cats);
-        assertEquals(Arrays.asList(c3), query.select(cat).fetch());
+        assertEquals(Collections.singletonList(c3), query.select(cat).fetch());
     }
 
 }

--- a/querydsl-core/pom.xml
+++ b/querydsl-core/pom.xml
@@ -49,17 +49,6 @@
     
      <!-- backwards compatibility -->
     <dependency>
-      <groupId>com.infradna.tool</groupId>
-      <artifactId>bridge-method-annotation</artifactId>
-      <version>${bridge-method.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>annotation-indexer</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jvnet.hudson</groupId>
       <artifactId>annotation-indexer</artifactId>
       <version>1.2</version>
@@ -80,37 +69,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>com.infradna.tool</groupId>
-        <artifactId>bridge-method-injector</artifactId>
-        <version>${bridge-method.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.infradna.tool</groupId>
-            <artifactId>bridge-method-annotation</artifactId>
-            <version>${bridge-method.version}</version>
-            <optional>true</optional>
-            <exclusions>
-              <exclusion>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>annotation-indexer</artifactId>
-              </exclusion>
-            </exclusions>
-          </dependency>
-          <dependency>
-            <groupId>org.jvnet.hudson</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.2</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -137,8 +95,4 @@
       </plugin>
     </plugins>
   </build>
-  
-  <properties>
-    <bridge-method.version>1.13</bridge-method.version>
-  </properties>
 </project>

--- a/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
@@ -14,6 +14,10 @@
 package com.querydsl.core;
 
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import com.mysema.commons.lang.CloseableIterator;
 
@@ -56,7 +60,24 @@ public interface Fetchable<T> {
     CloseableIterator<T> iterate();
 
     /**
-     * Get the projection in {@link QueryResults} form
+     * Get the projection as a typed closeable Stream.
+     *
+     * @return closeable stream
+     */
+    default Stream<T> stream() {
+        final CloseableIterator<T> iterator = iterate();
+        final Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED);
+        return StreamSupport.stream(spliterator, false)
+                .onClose(iterator::close);
+    }
+
+    /**
+     * Get the projection in {@link QueryResults} form.
+     *
+     * Make sure to use {@link #fetch()} instead if you do not rely on the {@link QueryResults#getOffset()} or
+     * {@link QueryResults#getLimit()}, because it will be more performant. Also, count queries cannot be
+     * properly generated for all dialects. For example: in JPA count queries can't be generated for queries
+     * that have multiple group by expressions or a having clause.
      *
      * @return results
      */

--- a/querydsl-core/src/main/java/com/querydsl/core/group/AbstractGroupByTransformer.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/AbstractGroupByTransformer.java
@@ -88,7 +88,7 @@ abstract class AbstractGroupByTransformer<K, T> implements ResultTransformer<T> 
             }
         }
 
-        this.expressions = projection.toArray(new Expression[projection.size()]);
+        this.expressions = projection.toArray(new Expression[0]);
     }
 
     protected static FactoryExpression<Tuple> withoutGroupExpressions(final FactoryExpression<Tuple> expr) {

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
@@ -147,7 +147,7 @@ public class GroupByBuilder<K> {
     public <V> ResultTransformer<Map<K, V>> as(FactoryExpression<V> expression) {
         final FactoryExpression<?> transformation = FactoryExpressionUtils.wrap(expression);
         List<Expression<?>> args = transformation.getArgs();
-        return new GroupByMap<K, V>(key, args.toArray(new Expression<?>[args.size()])) {
+        return new GroupByMap<K, V>(key, args.toArray(new Expression<?>[0])) {
 
             @Override
             protected Map<K, V> transform(Map<K, Group> groups) {
@@ -180,7 +180,7 @@ public class GroupByBuilder<K> {
     public <V> ResultTransformer<CloseableIterator<V>> iterate(FactoryExpression<V> expression) {
         final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
         List<Expression<?>> args = transformation.getArgs();
-        return new GroupByIterate<K, V>(key, args.toArray(new Expression<?>[args.size()])) {
+        return new GroupByIterate<K, V>(key, args.toArray(new Expression<?>[0])) {
             @Override
             protected V transform(Group group) {
                 // XXX Isn't group.toArray() suitable here?
@@ -202,7 +202,7 @@ public class GroupByBuilder<K> {
     public <V> ResultTransformer<List<V>> list(FactoryExpression<V> expression) {
         final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
         List<Expression<?>> args = transformation.getArgs();
-        return new GroupByList<K, V>(key, args.toArray(new Expression<?>[args.size()])) {
+        return new GroupByList<K, V>(key, args.toArray(new Expression<?>[0])) {
             @Override
             protected V transform(Group group) {
                 // XXX Isn't group.toArray() suitable here?

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupByMap.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupByMap.java
@@ -51,8 +51,7 @@ public class GroupByMap<K,V> extends AbstractGroupByTransformer<K, Map<K,V>> {
         if (hasGroups) {
             expr = withoutGroupExpressions(expr);
         }
-        CloseableIterator<Tuple> iter = query.select(expr).iterate();
-        try {
+        try (CloseableIterator<Tuple> iter = query.select(expr).iterate()) {
             while (iter.hasNext()) {
                 @SuppressWarnings("unchecked") //This type is mandated by the key type
                 K[] row = (K[]) iter.next().toArray();
@@ -64,8 +63,6 @@ public class GroupByMap<K,V> extends AbstractGroupByTransformer<K, Map<K,V>> {
                 }
                 group.add(row);
             }
-        } finally {
-            iter.close();
         }
 
         // transform groups

--- a/querydsl-core/src/main/java/com/querydsl/core/group/GroupImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/group/GroupImpl.java
@@ -39,9 +39,8 @@ class GroupImpl implements Group {
     public GroupImpl(List<GroupExpression<?, ?>> columnDefinitions,  List<QPair<?, ?>> maps) {
         this.groupExpressions = columnDefinitions;
         this.maps = maps;
-        for (int i = 0; i < columnDefinitions.size(); i++) {
-            GroupExpression<?, ?> coldef = columnDefinitions.get(i);
-            GroupCollector<?,?> collector = groupCollectorMap.get(coldef.getExpression());
+        for (GroupExpression<?, ?> coldef : columnDefinitions) {
+            GroupCollector<?, ?> collector = groupCollectorMap.get(coldef.getExpression());
             if (collector == null) {
                 collector = coldef.createGroupCollector();
                 Expression<?> coldefExpr = coldef.getExpression();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ConstructorExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ConstructorExpression.java
@@ -139,13 +139,7 @@ public class ConstructorExpression<T> extends FactoryExpressionBase<T> {
                 args = transformer.apply(args);
             }
             return (T) constructor.newInstance(args);
-        } catch (SecurityException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (InstantiationException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (IllegalAccessException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (InvocationTargetException e) {
+        } catch (SecurityException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
             throw new ExpressionException(e.getMessage(), e);
         }
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionUtils.java
@@ -88,7 +88,7 @@ public final class FactoryExpressionUtils {
         }
         if (usesFactoryExpressions) {
             return wrap(new ArrayConstructorExpression<Object>(
-                    projection.toArray(new Expression<?>[projection.size()])));
+                    projection.toArray(new Expression<?>[0])));
         } else {
             return null;
         }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/QBean.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/QBean.java
@@ -242,11 +242,7 @@ public class QBean<T> extends FactoryExpressionBase<T> {
                 }
             }
             return rv;
-        } catch (InstantiationException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (IllegalAccessException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (InvocationTargetException e) {
+        } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
             throw new ExpressionException(e.getMessage(), e);
         }
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BeanPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BeanPath.java
@@ -94,13 +94,7 @@ public class BeanPath<T> extends SimpleExpression<T> implements Path<T> {
                 return (U) casts.get(clazz);
             }
 
-        } catch (InstantiationException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (IllegalAccessException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (InvocationTargetException e) {
-            throw new ExpressionException(e.getMessage(), e);
-        } catch (NoSuchMethodException e) {
+        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new ExpressionException(e.getMessage(), e);
         }
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Coalesce.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Coalesce.java
@@ -49,7 +49,7 @@ public class Coalesce<T extends Comparable> extends MutableExpressionBase<T> {
 
     public Coalesce(Expression... exprs) {
         // NOTE : type parameters for the varargs, would result in compiler warnings
-        this((exprs.length > 0 ? exprs[0].getType() : Object.class), exprs);
+        this((Class) (exprs.length > 0 ? exprs[0].getType() : Object.class), exprs);
     }
 
     @Override

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionPathBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionPathBase.java
@@ -92,13 +92,7 @@ public abstract class CollectionPathBase<C extends Collection<E>, E, Q extends S
                     return (Q) constructor.newInstance(pm);
                 }
             }
-        } catch (NoSuchMethodException e) {
-            throw new ExpressionException(e);
-        } catch (InstantiationException e) {
-            throw new ExpressionException(e);
-        } catch (IllegalAccessException e) {
-            throw new ExpressionException(e);
-        } catch (InvocationTargetException e) {
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
             throw new ExpressionException(e);
         }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/MapPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/MapPath.java
@@ -81,13 +81,7 @@ public class MapPath<K, V, E extends SimpleExpression<? super V>> extends MapExp
         try {
             PathMetadata md =  forMapAccess(key);
             return newInstance(md);
-        } catch (NoSuchMethodException e) {
-            throw new ExpressionException(e);
-        } catch (InstantiationException e) {
-            throw new ExpressionException(e);
-        } catch (IllegalAccessException e) {
-            throw new ExpressionException(e);
-        } catch (InvocationTargetException e) {
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
             throw new ExpressionException(e);
         }
     }
@@ -97,13 +91,7 @@ public class MapPath<K, V, E extends SimpleExpression<? super V>> extends MapExp
         try {
             PathMetadata md =  forMapAccess(key);
             return newInstance(md);
-        } catch (NoSuchMethodException e) {
-            throw new ExpressionException(e);
-        } catch (InstantiationException e) {
-            throw new ExpressionException(e);
-        } catch (IllegalAccessException e) {
-            throw new ExpressionException(e);
-        } catch (InvocationTargetException e) {
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
             throw new ExpressionException(e);
         }
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -776,8 +776,8 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
 
     private List<T> convert(Number... numbers) {
         List<T> list = new ArrayList<T>(numbers.length);
-        for (int i = 0; i < numbers.length; i++) {
-            list.add(MathUtils.cast(numbers[i], getType()));
+        for (Number number : numbers) {
+            list.add(MathUtils.cast(number, getType()));
         }
         return list;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/PathInits.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/PathInits.java
@@ -62,11 +62,7 @@ public class PathInits implements Serializable {
                     key = initStr.substring(0, initStr.indexOf('.'));
                     inits = ImmutableList.of(initStr.substring(key.length() + 1));
                 }
-                Collection<String> values = properties.get(key);
-                if (values == null) {
-                    values = new ArrayList<String>();
-                    properties.put(key, values);
-                }
+                Collection<String> values = properties.computeIfAbsent(key, k -> new ArrayList<String>());
                 values.addAll(inits);
             }
         }

--- a/querydsl-core/src/main/java/com/querydsl/core/util/Annotations.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/Annotations.java
@@ -44,7 +44,7 @@ public class Annotations implements AnnotatedElement {
 
     @Override
     public Annotation[] getAnnotations() {
-        return annotations.values().toArray(new Annotation[annotations.values().size()]);
+        return annotations.values().toArray(new Annotation[0]);
     }
 
     @Override

--- a/querydsl-core/src/main/java/com/querydsl/core/util/BeanMap.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/BeanMap.java
@@ -284,10 +284,7 @@ public class BeanMap extends AbstractMap<String, Object> implements Cloneable {
             if (method != null) {
                 try {
                     return method.invoke(bean, NULL_ARGUMENTS);
-                } catch (IllegalAccessException e) {
-                } catch (IllegalArgumentException e) {
-                } catch (InvocationTargetException e) {
-                } catch (NullPointerException e) {
+                } catch (IllegalAccessException | NullPointerException | InvocationTargetException | IllegalArgumentException e) {
                 }
             }
         }
@@ -315,9 +312,7 @@ public class BeanMap extends AbstractMap<String, Object> implements Cloneable {
 
                 Object newValue = get(name);
                 firePropertyChange(name, oldValue, newValue);
-            } catch (InvocationTargetException e) {
-                throw new IllegalArgumentException(e.getMessage());
-            } catch (IllegalAccessException e) {
+            } catch (InvocationTargetException | IllegalAccessException e) {
                 throw new IllegalArgumentException(e.getMessage());
             }
             return oldValue;
@@ -655,9 +650,7 @@ public class BeanMap extends AbstractMap<String, Object> implements Cloneable {
                 }
             }
             return new Object[]{value};
-        } catch (InvocationTargetException e) {
-            throw new IllegalArgumentException(e.getMessage());
-        } catch (InstantiationException e) {
+        } catch (InvocationTargetException | InstantiationException e) {
             throw new IllegalArgumentException(e.getMessage());
         }
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/util/ReflectionUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/ReflectionUtils.java
@@ -48,9 +48,7 @@ public final class ReflectionUtils {
         while (beanClass != null && !beanClass.equals(Object.class)) {
             try {
                 return beanClass.getDeclaredField(propertyName);
-            } catch (SecurityException e) {
-                // skip
-            } catch (NoSuchFieldException e) {
+            } catch (SecurityException | NoSuchFieldException e) {
                 // skip
             }
             beanClass = beanClass.getSuperclass();
@@ -74,8 +72,7 @@ public final class ReflectionUtils {
         while (beanClass != null && !beanClass.equals(Object.class)) {
             try {
                 return beanClass.getDeclaredMethod(methodName);
-            } catch (SecurityException e) { // skip
-            } catch (NoSuchMethodException e) { // skip
+            } catch (SecurityException | NoSuchMethodException e) { // skip
             }
             beanClass = beanClass.getSuperclass();
         }

--- a/querydsl-core/src/test/java/com/querydsl/core/CycleClassInitDependencyTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/CycleClassInitDependencyTest.java
@@ -19,7 +19,7 @@ public class CycleClassInitDependencyTest {
     public static void overrideClassLoader() {
         loader = Thread.currentThread().getContextClassLoader();
         Collection<URL> urls = ClasspathHelper.forClassLoader();
-        ClassLoader cl = URLClassLoader.newInstance(urls.toArray(new URL[urls.size()]), null/*no delegation*/);
+        ClassLoader cl = URLClassLoader.newInstance(urls.toArray(new URL[0]), null/*no delegation*/);
         Thread.currentThread().setContextClassLoader(cl);
     }
 

--- a/querydsl-core/src/test/java/com/querydsl/core/DefaultQueryMetadataTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/DefaultQueryMetadataTest.java
@@ -16,6 +16,7 @@ package com.querydsl.core;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -78,7 +79,7 @@ public class DefaultQueryMetadataTest {
     public void getGroupBy() {
         metadata.addJoin(JoinType.DEFAULT, str);
         metadata.addGroupBy(str);
-        assertEquals(Arrays.asList(str), metadata.getGroupBy());
+        assertEquals(Collections.singletonList(str), metadata.getGroupBy());
     }
 
     @Test
@@ -91,21 +92,21 @@ public class DefaultQueryMetadataTest {
     @Test
     public void getJoins() {
         metadata.addJoin(JoinType.DEFAULT, str);
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, str)), metadata.getJoins());
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, str)), metadata.getJoins());
     }
 
     @Test
     public void getJoins2() {
         metadata.addJoin(JoinType.DEFAULT, str);
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, str)), metadata.getJoins());
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, str)), metadata.getJoins());
     }
 
     @Test
     public void getJoins3() {
         metadata.addJoin(JoinType.DEFAULT, str);
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, str)), metadata.getJoins());
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, str)), metadata.getJoins());
         metadata.addJoinCondition(str.isNull());
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, str, str.isNull(), ImmutableSet.<JoinFlag>of())),
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, str, str.isNull(), ImmutableSet.<JoinFlag>of())),
                 metadata.getJoins());
         metadata.addJoin(JoinType.DEFAULT, str2);
         assertEquals(Arrays.asList(

--- a/querydsl-core/src/test/java/com/querydsl/core/FilterFactory.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/FilterFactory.java
@@ -74,8 +74,7 @@ public class FilterFactory {
 
     private <A extends Comparable<A>> Collection<Predicate> comparable(ComparableExpression<A> expr,
             ComparableExpression<A> other, A knownValue) {
-        List<Predicate> rv = new ArrayList<Predicate>();
-        rv.addAll(exprFilters(expr, other, knownValue));
+        List<Predicate> rv = new ArrayList<Predicate>(exprFilters(expr, other, knownValue));
         rv.add(expr.gt(other));
         rv.add(expr.gt(knownValue));
         rv.add(expr.goe(other));
@@ -167,8 +166,7 @@ public class FilterFactory {
 
     public <A, Q extends SimpleExpression<A>> Collection<Predicate> list(ListPath<A, Q> expr,
             ListExpression<A, Q> other, A knownElement) {
-        List<Predicate> rv = new ArrayList<Predicate>();
-        rv.addAll(collection(expr, other, knownElement));
+        List<Predicate> rv = new ArrayList<Predicate>(collection(expr, other, knownElement));
         rv.add(expr.get(0).eq(knownElement));
         return ImmutableList.copyOf(rv);
     }
@@ -268,7 +266,7 @@ public class FilterFactory {
         rv.add(expr.equalsIgnoreCase(other));
         rv.add(expr.equalsIgnoreCase(knownValue));
 
-        rv.add(expr.in(Arrays.asList(knownValue)));
+        rv.add(expr.in(Collections.singletonList(knownValue)));
 
         rv.add(expr.indexOf(other).gt(0));
         rv.add(expr.indexOf("X", 1).gt(0));

--- a/querydsl-core/src/test/java/com/querydsl/core/MatchingFiltersFactory.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/MatchingFiltersFactory.java
@@ -70,8 +70,7 @@ public class MatchingFiltersFactory {
 
     public Collection<Predicate> date(DateExpression<java.sql.Date> expr,
             DateExpression<java.sql.Date> other) {
-        HashSet<Predicate> rv = new HashSet<Predicate>();
-        rv.addAll(comparable(expr, other));
+        HashSet<Predicate> rv = new HashSet<Predicate>(comparable(expr, other));
         rv.add(expr.dayOfMonth().eq(other.dayOfMonth()));
 
         if (!target.equals(Target.DERBY) && !module.equals(Module.JDO) && !target.equals(Target.ORACLE)
@@ -103,8 +102,7 @@ public class MatchingFiltersFactory {
 
     public Collection<Predicate> dateTime(DateTimeExpression<java.util.Date> expr,
             DateTimeExpression<java.util.Date> other) {
-        HashSet<Predicate> rv = new HashSet<Predicate>();
-        rv.addAll(comparable(expr, other));
+        HashSet<Predicate> rv = new HashSet<Predicate>(comparable(expr, other));
         rv.add(expr.milliSecond().eq(other.milliSecond()));
         rv.add(expr.second().eq(other.second()));
         rv.add(expr.minute().eq(other.minute()));
@@ -295,8 +293,7 @@ public class MatchingFiltersFactory {
 
     public Collection<Predicate> time(TimeExpression<java.sql.Time> expr,
             TimeExpression<java.sql.Time> other) {
-        HashSet<Predicate> rv = new HashSet<Predicate>();
-        rv.addAll(comparable(expr, other));
+        HashSet<Predicate> rv = new HashSet<Predicate>(comparable(expr, other));
         rv.add(expr.milliSecond().eq(other.milliSecond()));
         rv.add(expr.second().eq(other.second()));
         rv.add(expr.minute().eq(other.minute()));

--- a/querydsl-core/src/test/java/com/querydsl/core/QueryExecution.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/QueryExecution.java
@@ -91,11 +91,11 @@ public abstract class QueryExecution {
 
     private Throwable addError(Expression<?> expr, Throwable throwable) {
         StringBuilder error = new StringBuilder();
-        error.append(expr + " failed : \n");
-        error.append(" " + throwable.getClass().getName() + " : " + throwable.getMessage() + "\n");
+        error.append(expr).append(" failed : \n");
+        error.append(" ").append(throwable.getClass().getName()).append(" : ").append(throwable.getMessage()).append("\n");
         if (throwable.getCause() != null) {
             throwable = throwable.getCause();
-            error.append(" " + throwable.getClass().getName() + " : " + throwable.getMessage() + "\n");
+            error.append(" ").append(throwable.getClass().getName()).append(" : ").append(throwable.getMessage()).append("\n");
         }
         errors.add(error.toString());
         return throwable;
@@ -219,7 +219,7 @@ public abstract class QueryExecution {
             }
 
             // construct String for Assert.fail()
-            StringBuffer buffer = new StringBuffer("Failed with ");
+            StringBuilder buffer = new StringBuilder("Failed with ");
             if (!failures.isEmpty()) {
                 buffer.append(failures.size()).append(" failure(s) ");
                 if (!errors.isEmpty()) {
@@ -231,10 +231,10 @@ public abstract class QueryExecution {
             }
             buffer.append("of ").append(total).append(" tests\n");
             for (String f : failures) {
-                buffer.append(f + "\n");
+                buffer.append(f).append("\n");
             }
             for (String e : errors) {
-                buffer.append(e + "\n");
+                buffer.append(e).append("\n");
             }
             Assert.fail(buffer.toString());
         } else {

--- a/querydsl-core/src/test/java/com/querydsl/core/QueryMetadaSerializationTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/QueryMetadaSerializationTest.java
@@ -63,8 +63,7 @@ public class QueryMetadaSerializationTest {
     @SuppressWarnings("unchecked")
     @Test
     public void fullySerializable() {
-        Set<Class<?>> checked = new HashSet<Class<?>>();
-        checked.addAll(Arrays.asList(Collection.class, List.class, Set.class, Map.class,
+        Set<Class<?>> checked = new HashSet<Class<?>>(Arrays.asList(Collection.class, List.class, Set.class, Map.class,
                 Object.class, String.class, Class.class));
         Stack<Class<?>> classes = new Stack<Class<?>>();
         classes.addAll(Arrays.<Class<?>>asList(NumberPath.class, NumberOperation.class,

--- a/querydsl-core/src/test/java/com/querydsl/core/group/GroupByIterateTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/group/GroupByIterateTest.java
@@ -166,11 +166,7 @@ public class GroupByIterateTest extends AbstractGroupByTest {
             @SuppressWarnings("unchecked")
             Pair<Integer, Pair<Integer, String>> pair = (Pair<Integer, Pair<Integer, String>>) array[1];
             Integer first = pair.getFirst();
-            Map<Integer, String> comments = posts.get(first);
-            if (comments == null) {
-                comments = new LinkedHashMap<Integer, String>();
-                posts.put(first, comments);
-            }
+            Map<Integer, String> comments = posts.computeIfAbsent(first, k -> new LinkedHashMap<Integer, String>());
             Pair<Integer, String> second = pair.getSecond();
             comments.put(second.getFirst(), second.getSecond());
         }

--- a/querydsl-core/src/test/java/com/querydsl/core/group/GroupByListTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/group/GroupByListTest.java
@@ -132,11 +132,7 @@ public class GroupByListTest extends AbstractGroupByTest {
             @SuppressWarnings("unchecked")
             Pair<Integer, Pair<Integer, String>> pair = (Pair<Integer, Pair<Integer, String>>) array[1];
             Integer first = pair.getFirst();
-            Map<Integer, String> comments = posts.get(first);
-            if (comments == null) {
-                comments = new LinkedHashMap<Integer, String>();
-                posts.put(first, comments);
-            }
+            Map<Integer, String> comments = posts.computeIfAbsent(first, k -> new LinkedHashMap<Integer, String>());
             Pair<Integer, String> second = pair.getSecond();
             comments.put(second.getFirst(), second.getSecond());
         }

--- a/querydsl-core/src/test/java/com/querydsl/core/group/GroupByMapTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/group/GroupByMapTest.java
@@ -182,11 +182,7 @@ public class GroupByMapTest extends AbstractGroupByTest {
             @SuppressWarnings("unchecked")
             Pair<Integer, Pair<Integer, String>> pair = (Pair<Integer, Pair<Integer, String>>) array[1];
             Integer first = pair.getFirst();
-            Map<Integer, String> comments = posts.get(first);
-            if (comments == null) {
-                comments = new LinkedHashMap<Integer, String>();
-                posts.put(first, comments);
-            }
+            Map<Integer, String> comments = posts.computeIfAbsent(first, k -> new LinkedHashMap<Integer, String>());
             Pair<Integer, String> second = pair.getSecond();
             comments.put(second.getFirst(), second.getSecond());
         }

--- a/querydsl-core/src/test/java/com/querydsl/core/support/NumberConversionsTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/NumberConversionsTest.java
@@ -48,7 +48,7 @@ public class NumberConversionsTest {
         NumberPath<Integer> intPath = Expressions.numberPath(Integer.class, "intPath");
         QTuple qTuple = Projections.tuple(strPath, intPath);
         NumberConversions<Tuple> conversions = new NumberConversions<Tuple>(qTuple);
-        Tuple tuple = conversions.newInstance("a", Long.valueOf(3));
+        Tuple tuple = conversions.newInstance("a", 3L);
         assertEquals("a", tuple.get(strPath));
         assertEquals(Integer.valueOf(3), tuple.get(intPath));
     }

--- a/querydsl-core/src/test/java/com/querydsl/core/testutil/Serialization.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/testutil/Serialization.java
@@ -21,9 +21,7 @@ public final class Serialization {
             T rv = (T) in.readObject();
             in.close();
             return rv;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (ClassNotFoundException e) {
+        } catch (IOException | ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }

--- a/querydsl-core/src/test/java/com/querydsl/core/types/SignatureTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/SignatureTest.java
@@ -35,7 +35,7 @@ public class SignatureTest {
 
     @Before
     public void setUp() throws ClassNotFoundException {
-        for (String folder : Arrays.asList("com/querydsl/core/types/dsl")) {
+        for (String folder : Collections.singletonList("com/querydsl/core/types/dsl")) {
             for (String file : new File("src/main/java",folder).list()) {
                 if (file.endsWith(".java") && !file.equals("package-info.java")) {
                     String className = (folder + "." + file.substring(0, file.length() - 5)).replace('/', '.');

--- a/querydsl-core/src/test/java/com/querydsl/core/util/MultiIteratorTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/util/MultiIteratorTest.java
@@ -44,7 +44,7 @@ public class MultiIteratorTest {
 
     @Test
     public void oneLevel() {
-        it = new MultiIterator(Arrays.asList(list1));
+        it = new MultiIterator(Collections.singletonList(list1));
         assertIteratorEquals(Arrays.asList(row(1), row(2)).iterator(), it);
     }
 

--- a/querydsl-examples/querydsl-example-jpa-guice/src/test/java/com/querydsl/example/jpa/repository/AbstractPersistenceTest.java
+++ b/querydsl-examples/querydsl-example-jpa-guice/src/test/java/com/querydsl/example/jpa/repository/AbstractPersistenceTest.java
@@ -43,15 +43,12 @@ public abstract class AbstractPersistenceTest {
                     rs.close();
                 }
 
-                java.sql.Statement stmt = connection.createStatement();
-                try {
+                try (java.sql.Statement stmt = connection.createStatement()) {
                     stmt.execute("SET REFERENTIAL_INTEGRITY FALSE");
                     for (String table : tables) {
                         stmt.execute("TRUNCATE TABLE " + table);
                     }
                     stmt.execute("SET REFERENTIAL_INTEGRITY TRUE");
-                } finally {
-                    stmt.close();
                 }
 
             }

--- a/querydsl-hibernate-search/src/main/java/com/querydsl/hibernate/search/AbstractSearchQuery.java
+++ b/querydsl-hibernate-search/src/main/java/com/querydsl/hibernate/search/AbstractSearchQuery.java
@@ -86,10 +86,10 @@ public abstract class AbstractSearchQuery<T, Q extends AbstractSearchQuery<T,Q>>
             Integer limit = modifiers.getLimitAsInteger();
             Integer offset = modifiers.getOffsetAsInteger();
             if (limit != null) {
-                fullTextQuery.setMaxResults(limit.intValue());
+                fullTextQuery.setMaxResults(limit);
             }
             if (offset != null) {
-                fullTextQuery.setFirstResult(offset.intValue());
+                fullTextQuery.setFirstResult(offset);
             }
         }
         return fullTextQuery;

--- a/querydsl-hibernate-search/src/test/java/com/querydsl/hibernate/search/AbstractQueryTest.java
+++ b/querydsl-hibernate-search/src/test/java/com/querydsl/hibernate/search/AbstractQueryTest.java
@@ -42,11 +42,8 @@ public abstract class AbstractQueryTest {
         AnnotationConfiguration cfg = new AnnotationConfiguration();
         cfg.addAnnotatedClass(User.class);
         Properties props = new Properties();
-        InputStream is = SearchQueryTest.class.getResourceAsStream("/derby.properties");
-        try {
+        try (InputStream is = SearchQueryTest.class.getResourceAsStream("/derby.properties")) {
             props.load(is);
-        } finally {
-            is.close();
         }
         cfg.setProperties(props);
         sessionFactory = cfg.buildSessionFactory();

--- a/querydsl-jdo/pom.xml
+++ b/querydsl-jdo/pom.xml
@@ -23,24 +23,17 @@
   </scm>
 
   <properties>   
-    <dn.version>3.2.0-release</dn.version>
-    <dn.plugin.version>3.2.0-release</dn.plugin.version>
+    <dn.version>5.2.4</dn.version>
+    <dn.plugin.version>5.2.1</dn.plugin.version>
   </properties>
 
   <dependencies>
-  
+
+
     <dependency>
-      <groupId>javax.jdo</groupId>
-      <artifactId>jdo-api</artifactId>
-      <version>${jdo.version}</version>
+      <groupId>org.datanucleus</groupId>
+      <artifactId>javax.jdo</artifactId>
     </dependency>
-    <!-- 
-    <dependency>
-      <groupId>javax.jdo</groupId>
-      <artifactId>jdo2-api</artifactId>
-      <version>2.3-eb</version>
-   </dependency>
-     -->        
     <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.jdo;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.jdo.JDOUserException;
@@ -240,6 +241,11 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
     @Override
     public CloseableIterator<T> iterate() {
         return new IteratorAdapter<T>(fetch().iterator(), closeable);
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return fetch().stream().onClose(this::close);
     }
 
     @Override

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -226,7 +226,7 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
 
     @Override
     public <U> Q from(CollectionExpression<?, U> path, Path<U> alias) {
-        return queryMixin.from(ExpressionUtils.as((Path) path, alias));
+        return (Q) queryMixin.from((Expression) ExpressionUtils.as((Path) path, alias));
     }
 
     public JDOQLTemplates getTemplates() {

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQLSerializer.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQLSerializer.java
@@ -224,7 +224,7 @@ public final class JDOQLSerializer extends SerializerBase<JDOQLSerializer> {
         b.append(PARAMETERS);
         boolean first = true;
         final List<Map.Entry<Object, String>> entries = new ArrayList<Map.Entry<Object, String>>(getConstantToAllLabels().entrySet());
-        Collections.sort(entries, comparator);
+        entries.sort(comparator);
         for (Map.Entry<Object, String> entry : entries) {
             if (!first) {
                 b.append(COMMA);

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/FetchPlanTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/FetchPlanTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -78,7 +79,7 @@ public class FetchPlanTest extends AbstractJDOTest {
         queriesField.setAccessible(true);
         List<Query> queries = (List<Query>) queriesField.get(query);
         Query jdoQuery = queries.get(0);
-        assertEquals(new HashSet<String>(Arrays.asList("products")),
+        assertEquals(new HashSet<String>(Collections.singletonList("products")),
                 jdoQuery.getFetchPlan().getGroups());
         assertEquals(1, jdoQuery.getFetchPlan().getMaxFetchDepth());
     }

--- a/querydsl-jdo/src/test/resources/datanucleus.properties
+++ b/querydsl-jdo/src/test/resources/datanucleus.properties
@@ -7,7 +7,10 @@ javax.jdo.option.ConnectionPassword=
 #javax.jdo.option.Mapping=h2
 
 datanucleus.metadata.validate=false
-datanucleus.autoCreateSchema=true
-datanucleus.autoCreateTables=true
-datanucleus.validateTables=true
-datanucleus.validateConstraints=true
+datanucleus.schema.autoCreateAll=true
+datanucleus.schema.autoCreateDatabase=true
+datanucleus.schema.autoCreateSchema=true
+datanucleus.schema.autoCreateTables=true
+datanucleus.schema.autoCreateColumns=true
+datanucleus.schema.validateTables=true
+datanucleus.schema.validateConstraints=true

--- a/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/AbstractDomainExporter.java
+++ b/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/AbstractDomainExporter.java
@@ -311,16 +311,13 @@ public abstract class AbstractDomainExporter {
     private void write(Serializer serializer, String path, EntityType type) throws IOException {
         File targetFile = new File(targetFolder, path);
         generatedFiles.add(targetFile);
-        Writer w = writerFor(targetFile);
-        try {
+        try (Writer w = writerFor(targetFile)) {
             CodeWriter writer = new JavaWriter(w);
             if (typeToConfig.containsKey(type.getJavaClass())) {
                 serializer.serialize(type, typeToConfig.get(type.getJavaClass()), writer);
             } else {
                 serializer.serialize(type, serializerConfig, writer);
             }
-        } finally {
-            w.close();
         }
     }
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/DefaultQueryHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/DefaultQueryHandler.java
@@ -14,6 +14,7 @@
 package com.querydsl.jpa;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.persistence.Query;
@@ -56,6 +57,15 @@ public final class DefaultQueryHandler implements QueryHandler {
         } else {
             return new IteratorAdapter<T>(iterator);
         }
+    }
+
+    @Override
+    public <T> Stream<T> stream(Query query, @Nullable FactoryExpression<?> projection) {
+        final Stream resultStream = query.getResultStream();
+        if (projection != null) {
+            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] { element })));
+        }
+        return resultStream;
     }
 
     @Override

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/DefaultQueryHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/DefaultQueryHandler.java
@@ -63,7 +63,7 @@ public final class DefaultQueryHandler implements QueryHandler {
     public <T> Stream<T> stream(Query query, @Nullable FactoryExpression<?> projection) {
         final Stream resultStream = query.getResultStream();
         if (projection != null) {
-            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] { element })));
+            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] {element})));
         }
         return resultStream;
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
@@ -105,7 +105,7 @@ class EclipseLinkHandler implements QueryHandler {
     public <T> Stream<T> stream(Query query, @Nullable FactoryExpression<?> projection) {
         final Stream resultStream = query.getResultStream();
         if (projection != null) {
-            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] { element })));
+            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] {element})));
         }
         return resultStream;
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
@@ -16,7 +16,9 @@ package com.querydsl.jpa;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
 import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
@@ -97,6 +99,15 @@ class EclipseLinkHandler implements QueryHandler {
         } else {
             return new IteratorAdapter<T>(iterator, closeable);
         }
+    }
+
+    @Override
+    public <T> Stream<T> stream(Query query, @Nullable FactoryExpression<?> projection) {
+        final Stream resultStream = query.getResultStream();
+        if (projection != null) {
+            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] { element })));
+        }
+        return resultStream;
     }
 
     @Override

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkTemplates.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkTemplates.java
@@ -34,9 +34,7 @@ public class EclipseLinkTemplates extends JPQLTemplates {
         QueryHandler instance;
         try {
             instance = (QueryHandler) Class.forName("com.querydsl.jpa.EclipseLinkHandler").newInstance();
-        } catch (NoClassDefFoundError e) {
-            instance = DefaultQueryHandler.DEFAULT;
-        } catch (Exception e) {
+        } catch (NoClassDefFoundError | Exception e) {
             instance = DefaultQueryHandler.DEFAULT;
         }
         QUERY_HANDLER = instance;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HQLTemplates.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HQLTemplates.java
@@ -37,9 +37,7 @@ public class HQLTemplates extends JPQLTemplates {
         QueryHandler instance;
         try {
             instance = (QueryHandler) Class.forName("com.querydsl.jpa.HibernateHandler").newInstance();
-        } catch (NoClassDefFoundError e) {
-            instance = DefaultQueryHandler.DEFAULT;
-        } catch (Exception e) {
+        } catch (NoClassDefFoundError | Exception e) {
             instance = DefaultQueryHandler.DEFAULT;
         }
         QUERY_HANDLER = instance;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
@@ -14,7 +14,9 @@
 package com.querydsl.jpa;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
 import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
@@ -69,6 +71,15 @@ public class HibernateHandler implements QueryHandler {
                 return new IteratorAdapter<T>(iterator);
             }
         }
+    }
+
+    @Override
+    public <T> Stream<T> stream(Query query, @Nullable FactoryExpression<?> projection) {
+        final Stream resultStream = query.getResultStream();
+        if (projection != null) {
+            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] { element })));
+        }
+        return resultStream;
     }
 
     @SuppressWarnings("deprecation")

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
@@ -77,7 +77,7 @@ public class HibernateHandler implements QueryHandler {
     public <T> Stream<T> stream(Query query, @Nullable FactoryExpression<?> projection) {
         final Stream resultStream = query.getResultStream();
         if (projection != null) {
-            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] { element })));
+            return resultStream.map(element -> projection.newInstance((Object[]) (element.getClass().isArray() ? element : new Object[] {element})));
         }
         return resultStream;
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryBase.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryBase.java
@@ -85,7 +85,7 @@ public abstract class JPAQueryBase<T, Q extends JPAQueryBase<T, Q>> extends Fetc
     @SuppressWarnings("unchecked")
     @Override
     public <P> Q from(CollectionExpression<?,P> target, Path<P> alias) {
-        return queryMixin.from(Expressions.as((Path) target, alias));
+        return (Q) queryMixin.from((Expression) Expressions.as((Path) target, alias));
     }
 
     @Override

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/QueryHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/QueryHandler.java
@@ -19,6 +19,8 @@ import javax.persistence.Query;
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.types.FactoryExpression;
 
+import java.util.stream.Stream;
+
 /**
  * {@code QueryHandle}r provides injection of provider specific functionality into the query logic
  *
@@ -41,6 +43,14 @@ public interface QueryHandler {
      * @return iterator
      */
     <T> CloseableIterator<T> iterate(Query query, @Nullable FactoryExpression<?> projection);
+
+    /**
+     * Stream the results with the optional projection
+     *
+     * @param query query
+     * @return stream
+     */
+    <T> Stream<T> stream(Query query, @Nullable FactoryExpression<?> projection);
 
     /**
      * Add the given scalar to the given native query

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.jpa.hibernate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -163,6 +164,16 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
             Query query = createQuery();
             ScrollableResults results = query.scroll(ScrollMode.FORWARD_ONLY);
             return new ScrollableResultsIterator<T>(results);
+        } finally {
+            reset();
+        }
+    }
+
+    @Override
+    public Stream<T> stream() {
+        try {
+            Query query = createQuery();
+            return query.getResultStream();
         } finally {
             reset();
         }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.jpa.hibernate.sql;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -167,6 +168,16 @@ public abstract class AbstractHibernateSQLQuery<T, Q extends AbstractHibernateSQ
             Query query = createQuery();
             ScrollableResults results = query.scroll(ScrollMode.FORWARD_ONLY);
             return new ScrollableResultsIterator<T>(results);
+        } finally {
+            reset();
+        }
+    }
+
+    @Override
+    public Stream<T> stream() {
+        try {
+            Query query = createQuery();
+            return query.getResultStream();
         } finally {
             reset();
         }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.jpa.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.persistence.EntityManager;
@@ -189,6 +190,16 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
         try {
             Query query = createQuery();
             return queryHandler.iterate(query, projection);
+        } finally {
+            reset();
+        }
+    }
+
+    @Override
+    public Stream<T> stream() {
+        try {
+            Query query = createQuery();
+            return queryHandler.stream(query, projection);
         } finally {
             reset();
         }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAProvider.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAProvider.java
@@ -52,8 +52,8 @@ public final class JPAProvider {
             String[] versionParts = version.split("\\.");
             int major = Integer.parseInt(versionParts[0]);
             hibernate5 = major >= 5;
-        } catch (ClassNotFoundException e) {
-            hibernate5 = false;
+        } catch (Exception e) {
+            hibernate5 = true;
         }
 
         JPQLTemplates hibernateTemplates = hibernate5 ? Hibernate5Templates.DEFAULT : HQLTemplates.DEFAULT;
@@ -70,8 +70,8 @@ public final class JPAProvider {
 
         templatesByName.put("batoo", BatooTemplates.DEFAULT);
         templatesByName.put("eclipselink", EclipseLinkTemplates.DEFAULT);
-        templatesByName.put("hibernate", HQLTemplates.DEFAULT);
-        templatesByName.put("hibernate5", Hibernate5Templates.DEFAULT);
+        templatesByName.put("hibernate4", HQLTemplates.DEFAULT);
+        templatesByName.put("hibernate", Hibernate5Templates.DEFAULT);
         templatesByName.put("openjpa", OpenJPATemplates.DEFAULT);
         templatesByName.put("datanucleus", DataNucleusTemplates.DEFAULT);
     }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAUtil.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAUtil.java
@@ -53,7 +53,7 @@ public final class JPAUtil {
                     }
                 }
             }
-            query.setParameter(Integer.valueOf(key), val);
+            query.setParameter(Integer.parseInt(key), val);
         }
     }
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.persistence.EntityManager;
@@ -246,6 +247,17 @@ public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>
         try {
             Query query = createQuery();
             return queryHandler.iterate(query, null);
+        } finally {
+            reset();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Stream<T> stream() {
+        try {
+            Query query = createQuery();
+            return query.getResultStream();
         } finally {
             reset();
         }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
@@ -185,7 +185,7 @@ public abstract class AbstractJPATest {
         NumberPath<BigDecimal> bigd1 = entity.bigDecimal;
         NumberPath<BigDecimal> bigd2 = entity2.bigDecimal;
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                         .where(bigd1.add(bigd2).loe(new BigDecimal("1.00")))
                         .select(entity).fetch());
@@ -473,15 +473,14 @@ public abstract class AbstractJPATest {
     @Test
     public void collection_predicates() {
         ListPath<Cat, QCat> path = cat.kittens;
-        List<Predicate> predicates = Arrays.asList(
-//            path.eq(savedCats),
-//            path.in(savedCats),
-//            path.isNotNull(),
-//            path.isNull(),
-//            path.ne(savedCats),
-//            path.notIn(savedCats)
-//            path.when(other)
-        );
+        //            path.eq(savedCats),
+        //            path.in(savedCats),
+        //            path.isNotNull(),
+        //            path.isNull(),
+        //            path.ne(savedCats),
+        //            path.notIn(savedCats)
+        //            path.when(other)
+        List<Predicate> predicates = Collections.emptyList();
         for (Predicate pred : predicates) {
             System.err.println(pred);
             query().from(cat).where(pred).select(cat).fetch();
@@ -491,10 +490,9 @@ public abstract class AbstractJPATest {
     @Test
     public void collection_projections() {
         ListPath<Cat, QCat> path = cat.kittens;
-        List<Expression<?>> projections = Arrays.asList(
-//            path.fetchCount(),
-//            path.countDistinct()
-        );
+        //            path.fetchCount(),
+        //            path.countDistinct()
+        List<Expression<?>> projections = Collections.emptyList();
         for (Expression<?> proj : projections) {
             System.err.println(proj);
             query().from(cat).select(proj).fetch();
@@ -570,7 +568,7 @@ public abstract class AbstractJPATest {
     @Test
     public void contains4() {
         QEmployee employee = QEmployee.employee;
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(employee)
                         .where(
                                 employee.jobFunctions.contains(JobFunction.CODER),
@@ -701,22 +699,22 @@ public abstract class AbstractJPATest {
         QSimpleTypes entity = new QSimpleTypes("entity1");
         QSimpleTypes entity2 = new QSimpleTypes("entity2");
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                 .where(entity.ddouble.divide(entity2.ddouble).loe(2.0))
                 .select(entity).fetch());
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                 .where(entity.ddouble.divide(entity2.iint).loe(2.0))
                 .select(entity).fetch());
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                 .where(entity.iint.divide(entity2.ddouble).loe(2.0))
                 .select(entity).fetch());
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                         .where(entity.iint.divide(entity2.iint).loe(2))
                         .select(entity).fetch());
@@ -730,17 +728,17 @@ public abstract class AbstractJPATest {
         NumberPath<BigDecimal> bigd1 = entity.bigDecimal;
         NumberPath<BigDecimal> bigd2 = entity2.bigDecimal;
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                         .where(bigd1.divide(bigd2).loe(new BigDecimal("1.00")))
                         .select(entity).fetch());
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                 .where(entity.ddouble.divide(bigd2).loe(new BigDecimal("1.00")))
                 .select(entity).fetch());
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                 .where(bigd1.divide(entity.ddouble).loe(new BigDecimal("1.00")))
                 .select(entity).fetch());
@@ -959,7 +957,7 @@ public abstract class AbstractJPATest {
     @Test
     public void in4() {
         //$.parameterRelease.id.eq(releaseId).and($.parameterGroups.any().id.in(filter.getGroups()));
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(cat).where(cat.id.eq(1), cat.kittens.any().id.in(1, 2, 3)).select(cat).fetch());
     }
 
@@ -1039,7 +1037,7 @@ public abstract class AbstractJPATest {
         QBookVersion bookVersion = QBookVersion.bookVersion;
         QBookMark bookMark = QBookMark.bookMark;
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(bookVersion)
                         .join(bookVersion.definition.bookMarks, bookMark)
                         .where(
@@ -1122,7 +1120,7 @@ public abstract class AbstractJPATest {
     @Test
     public void map_get() {
         QShow show = QShow.show;
-        assertEquals(Arrays.asList("A"), query().from(show).select(show.acts.get("a")).fetch());
+        assertEquals(Collections.singletonList("A"), query().from(show).select(show.acts.get("a")).fetch());
     }
 
     @Test
@@ -1203,7 +1201,7 @@ public abstract class AbstractJPATest {
         //select m.text from Show s join s.acts a where key(a) = 'B'
         QShow show = QShow.show;
         StringPath act = Expressions.stringPath("act");
-        assertEquals(Arrays.asList(), query().from(show).join(show.acts, act).select(act).fetch());
+        assertEquals(Collections.emptyList(), query().from(show).join(show.acts, act).select(act).fetch());
     }
 
     @Test
@@ -1222,7 +1220,7 @@ public abstract class AbstractJPATest {
         QSimpleTypes entity = new QSimpleTypes("entity1");
         QSimpleTypes entity2 = new QSimpleTypes("entity2");
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                         .where(entity.ddouble.multiply(entity2.ddouble).loe(2.0))
                         .select(entity).fetch());
@@ -1236,7 +1234,7 @@ public abstract class AbstractJPATest {
         NumberPath<BigDecimal> bigd1 = entity.bigDecimal;
         NumberPath<BigDecimal> bigd2 = entity2.bigDecimal;
 
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(entity, entity2)
                         .where(bigd1.multiply(bigd2).loe(new BigDecimal("1.00")))
                         .select(entity).fetch());
@@ -1543,7 +1541,7 @@ public abstract class AbstractJPATest {
     @Ignore // FIXME
     @ExcludeIn(DERBY)
     public void substring_from_right() {
-        assertEquals(Arrays.asList(), query().from(cat)
+        assertEquals(Collections.emptyList(), query().from(cat)
                 .where(cat.name.substring(-1, 1).eq(cat.name.substring(-2, 1)))
                 .select(cat).fetch());
     }
@@ -1551,7 +1549,7 @@ public abstract class AbstractJPATest {
     @Test
     @ExcludeIn({HSQLDB, DERBY})
     public void substring_from_right2() {
-        assertEquals(Arrays.asList(), query().from(cat)
+        assertEquals(Collections.emptyList(), query().from(cat)
                 .where(cat.name.substring(cat.name.length().subtract(1), cat.name.length())
                         .eq(cat.name.substring(cat.name.length().subtract(2), cat.name.length().subtract(1))))
                 .select(cat).fetch());
@@ -1565,7 +1563,7 @@ public abstract class AbstractJPATest {
         NumberPath<BigDecimal> bigd1 = entity.bigDecimal;
         NumberPath<BigDecimal> bigd2 = entity2.bigDecimal;
 
-        assertEquals(Arrays.asList(), query().from(entity, entity2)
+        assertEquals(Collections.emptyList(), query().from(entity, entity2)
                 .where(bigd1.subtract(bigd2).loe(new BigDecimal("1.00")))
                 .select(entity).fetch());
     }
@@ -1613,7 +1611,7 @@ public abstract class AbstractJPATest {
     @Test
     public void sum_of_integer() {
         QCat cat2 = new QCat("cat2");
-        assertEquals(Arrays.asList(), query().from(cat)
+        assertEquals(Collections.emptyList(), query().from(cat)
                 .where(select(cat2.breed.sum())
                         .from(cat2).where(cat2.eq(cat.mate)).gt(0))
                 .select(cat).fetch());

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractSQLTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractSQLTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -157,7 +158,7 @@ public abstract class AbstractSQLTest {
     @Test
     public void entityQueries7() {
         QCompany company = QCompany.company;
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(company).select(company.officialName).fetch());
     }
 
@@ -321,7 +322,7 @@ public abstract class AbstractSQLTest {
         assertEquals(12, rows.size());
         int nulls = 0;
         for (Tuple row : rows) {
-            System.err.println(Arrays.asList(row));
+            System.err.println(Collections.singletonList(row));
             if (row.get(1, Object.class) == null) {
                 nulls++;
             }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryMixinTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryMixinTest.java
@@ -3,6 +3,7 @@ package com.querydsl.jpa;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -40,7 +41,7 @@ public class JPAQueryMixinTest {
                 new JoinExpression(JoinType.DEFAULT, cat),
                 new JoinExpression(JoinType.LEFTJOIN, cat.mate.as(catMate))),
                 md.getJoins());
-        assertEquals(Arrays.asList(catMate.name.asc()),
+        assertEquals(Collections.singletonList(catMate.name.asc()),
                 md.getOrderBy());
     }
 
@@ -70,8 +71,8 @@ public class JPAQueryMixinTest {
         mixin.orderBy(cat.mate.name.asc());
 
         QueryMetadata md = mixin.getMetadata();
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, cat)), md.getJoins());
-        assertEquals(Arrays.asList(cat.mate.name.asc()), md.getOrderBy());
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, cat)), md.getJoins());
+        assertEquals(Collections.singletonList(cat.mate.name.asc()), md.getOrderBy());
     }
 
     @Test
@@ -82,8 +83,8 @@ public class JPAQueryMixinTest {
         mixin.orderBy(cat.mate.name.asc());
 
         QueryMetadata md = mixin.getMetadata();
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, cat)), md.getJoins());
-        assertEquals(Arrays.asList(cat.mate.name.asc()), md.getOrderBy());
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, cat)), md.getJoins());
+        assertEquals(Collections.singletonList(cat.mate.name.asc()), md.getOrderBy());
     }
 
     @Test
@@ -98,7 +99,7 @@ public class JPAQueryMixinTest {
                         new JoinExpression(JoinType.DEFAULT, cat),
                         new JoinExpression(JoinType.LEFTJOIN, cat.mate.as(catMate))),
                 md.getJoins());
-        assertEquals(Arrays.asList(catMate.name.lower().asc()),
+        assertEquals(Collections.singletonList(catMate.name.lower().asc()),
                 md.getOrderBy());
     }
 
@@ -116,7 +117,7 @@ public class JPAQueryMixinTest {
                 new JoinExpression(JoinType.LEFTJOIN, cat.mate.as(catMate)),
                 new JoinExpression(JoinType.LEFTJOIN, catMate.mate.as(catMateMate))),
                 md.getJoins());
-        assertEquals(Arrays.asList(catMateMate.name.asc()),
+        assertEquals(Collections.singletonList(catMateMate.name.asc()),
                 md.getOrderBy());
     }
 
@@ -133,7 +134,7 @@ public class JPAQueryMixinTest {
                 new JoinExpression(JoinType.DEFAULT, cat),
                 new JoinExpression(JoinType.LEFTJOIN, cat.mate.as(mate))),
                 md.getJoins());
-        assertEquals(Arrays.asList(mate.name.asc()),
+        assertEquals(Collections.singletonList(mate.name.asc()),
                 md.getOrderBy());
     }
 
@@ -152,7 +153,7 @@ public class JPAQueryMixinTest {
                 new JoinExpression(JoinType.LEFTJOIN, cat.mate.as(mate)),
                 new JoinExpression(JoinType.LEFTJOIN, mate.mate.as(mateMate))),
                 md.getJoins());
-        assertEquals(Arrays.asList(mateMate.name.asc()),
+        assertEquals(Collections.singletonList(mateMate.name.asc()),
                 md.getOrderBy());
     }
 
@@ -168,7 +169,7 @@ public class JPAQueryMixinTest {
                 new JoinExpression(JoinType.DEFAULT, cat),
                 new JoinExpression(JoinType.LEFTJOIN, cat.kittens.as(catKittens))),
                 md.getJoins());
-        assertEquals(Arrays.asList(catKittens.name.asc()),
+        assertEquals(Collections.singletonList(catKittens.name.asc()),
                 md.getOrderBy());
     }
 
@@ -179,9 +180,9 @@ public class JPAQueryMixinTest {
         mixin.orderBy(bookVersion.definition.name.asc());
 
         QueryMetadata md = mixin.getMetadata();
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, bookVersion)),
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, bookVersion)),
                 md.getJoins());
-        assertEquals(Arrays.asList(bookVersion.definition.name.asc()),
+        assertEquals(Collections.singletonList(bookVersion.definition.name.asc()),
                 md.getOrderBy());
     }
 
@@ -198,7 +199,7 @@ public class JPAQueryMixinTest {
                 new JoinExpression(JoinType.DEFAULT, article),
                 new JoinExpression(JoinType.LEFTJOIN, article.content.article.as(articleContentArticle))),
                 md.getJoins());
-        assertEquals(Arrays.asList(articleContentArticle.name.asc()),
+        assertEquals(Collections.singletonList(articleContentArticle.name.asc()),
                 md.getOrderBy());
     }
 
@@ -211,9 +212,9 @@ public class JPAQueryMixinTest {
         mixin.orderBy(bookVersion.definition.bookMarks.any().comment.asc());
 
         QueryMetadata md = mixin.getMetadata();
-        assertEquals(Arrays.asList(new JoinExpression(JoinType.DEFAULT, bookVersion)),
+        assertEquals(Collections.singletonList(new JoinExpression(JoinType.DEFAULT, bookVersion)),
                 md.getJoins());
-        assertEquals(Arrays.asList(Expressions.stringPath(bookVersion.definition.bookMarks, "comment").asc()),
+        assertEquals(Collections.singletonList(Expressions.stringPath(bookVersion.definition.bookMarks, "comment").asc()),
                 md.getOrderBy());
     }
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/support/TeradataDialect.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/support/TeradataDialect.java
@@ -320,13 +320,13 @@ public class TeradataDialect extends Dialect {
 
         java.util.StringTokenizer st = new java.util.StringTokenizer(dropSql);
         if (alterStr.equalsIgnoreCase(st.nextToken()) && tableStr.equalsIgnoreCase(st.nextToken())) {
-            String tableName = st.nextToken();
+            StringBuilder tableName = new StringBuilder(st.nextToken());
 
-            if ((tableName.startsWith("\"")) && (!tableName.endsWith("\""))) {
+            if ((tableName.toString().startsWith("\"")) && (!tableName.toString().endsWith("\""))) {
                 String next = null;
                 while (true) {
                     next = st.nextToken();
-                    tableName += " " + next;
+                    tableName.append(" ").append(next);
                     if (next.endsWith("\\\"")) {
                         continue;
                     }
@@ -346,10 +346,10 @@ public class TeradataDialect extends Dialect {
 
                 int idxStart = dropSql.indexOf(tableStr, 0) + 5;
                 int idxEnd = dropSql.lastIndexOf(dropStr);
-                tableName = dropSql.substring(idxStart, idxEnd).trim();
+                tableName = new StringBuilder(dropSql.substring(idxStart, idxEnd).trim());
 
-                if (tableName.startsWith("\"") && tableName.endsWith("\"")) {
-                    tableName = tableName.substring(1, tableName.length() - 1);
+                if (tableName.toString().startsWith("\"") && tableName.toString().endsWith("\"")) {
+                    tableName = new StringBuilder(tableName.substring(1, tableName.length() - 1));
                 }
 
                 String arrStr = null;

--- a/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
+++ b/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
@@ -89,9 +89,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
             TotalHitCountCollector collector = new TotalHitCountCollector();
             searcher.search(createQuery(), getFilter(), collector);
             return collector.getTotalHits();
-        } catch (IOException e) {
-            throw new QueryException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
     }
@@ -155,7 +153,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
 
     private Filter getFilter() {
         if (filter == null && !filters.isEmpty()) {
-            filter = new ChainedFilter(filters.toArray(new Filter[filters.size()]));
+            filter = new ChainedFilter(filters.toArray(new Filter[0]));
         }
         return filter;
     }
@@ -179,9 +177,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
             if (limit == 0) {
                 return new EmptyCloseableIterator<T>();
             }
-        } catch (IOException e) {
-            throw new QueryException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
         if (queryLimit != null && queryLimit < limit) {
@@ -317,9 +313,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
             } else {
                 return null;
             }
-        } catch (IOException e) {
-            throw new QueryException(e);
-        }  catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
     }

--- a/querydsl-lucene3/src/main/java/com/querydsl/lucene3/LuceneSerializer.java
+++ b/querydsl-lucene3/src/main/java/com/querydsl/lucene3/LuceneSerializer.java
@@ -560,7 +560,7 @@ public class LuceneSerializer {
             }
         }
         Sort sort = new Sort();
-        sort.setSort(sorts.toArray(new SortField[sorts.size()]));
+        sort.setSort(sorts.toArray(new SortField[0]));
         return sort;
     }
 }

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
@@ -91,9 +91,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
             TotalHitCountCollector collector = new TotalHitCountCollector();
             searcher.search(createQuery(), getFilter(), collector);
             return collector.getTotalHits();
-        } catch (IOException e) {
-            throw new QueryException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
     }
@@ -157,7 +155,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
 
     private Filter getFilter() {
         if (filter == null && !filters.isEmpty()) {
-            filter = new ChainedFilter(filters.toArray(new Filter[filters.size()]));
+            filter = new ChainedFilter(filters.toArray(new Filter[0]));
         }
         return filter;
     }
@@ -181,9 +179,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
             if (limit == 0) {
                 return new EmptyCloseableIterator<T>();
             }
-        } catch (IOException e) {
-            throw new QueryException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
         if (queryLimit != null && queryLimit < limit) {
@@ -319,9 +315,7 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
             } else {
                 return null;
             }
-        } catch (IOException e) {
-            throw new QueryException(e);
-        }  catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
     }

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/LuceneSerializer.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/LuceneSerializer.java
@@ -563,7 +563,7 @@ public class LuceneSerializer {
             }
         }
         Sort sort = new Sort();
-        sort.setSort(sorts.toArray(new SortField[sorts.size()]));
+        sort.setSort(sorts.toArray(new SortField[0]));
         return sort;
     }
 }

--- a/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
+++ b/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
@@ -96,9 +96,7 @@ public abstract class AbstractLuceneQuery<T, Q extends AbstractLuceneQuery<T, Q>
             TotalHitCountCollector collector = new TotalHitCountCollector();
             searcher.search(createQuery(), getFilter(), collector);
             return collector.getTotalHits();
-        } catch (IOException e) {
-            throw new QueryException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
     }
@@ -208,9 +206,7 @@ public abstract class AbstractLuceneQuery<T, Q extends AbstractLuceneQuery<T, Q>
             if (limit == 0) {
                 return new EmptyCloseableIterator<T>();
             }
-        } catch (IOException e) {
-            throw new QueryException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
         if (queryLimit != null && queryLimit < limit) {
@@ -359,9 +355,7 @@ public abstract class AbstractLuceneQuery<T, Q extends AbstractLuceneQuery<T, Q>
             } else {
                 return null;
             }
-        } catch (IOException e) {
-            throw new QueryException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
         }
     }

--- a/querydsl-lucene5/src/main/java/com/querydsl/lucene5/LuceneSerializer.java
+++ b/querydsl-lucene5/src/main/java/com/querydsl/lucene5/LuceneSerializer.java
@@ -610,7 +610,7 @@ public class LuceneSerializer {
             }
         }
         Sort sort = new Sort();
-        sort.setSort(sorts.toArray(new SortField[sorts.size()]));
+        sort.setSort(sorts.toArray(new SortField[0]));
         return sort;
     }
 }

--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractExporterMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractExporterMojo.java
@@ -136,9 +136,7 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
         ClassLoader classLoader = null;
         try {
             classLoader = getProjectClassLoader();
-        } catch (MalformedURLException e) {
-            throw new MojoFailureException(e.getMessage(), e);
-        } catch (DependencyResolutionRequiredException e) {
+        } catch (MalformedURLException | DependencyResolutionRequiredException e) {
             throw new MojoFailureException(e.getMessage(), e);
         }
 
@@ -187,7 +185,7 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
                 urls.add(file.toURI().toURL());
             }
         }
-        return new URLClassLoader(urls.toArray(new URL[urls.size()]), getClass().getClassLoader());
+        return new URLClassLoader(urls.toArray(new URL[0]), getClass().getClassLoader());
     }
 
     @SuppressWarnings("rawtypes")

--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
@@ -543,21 +543,10 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
                     throw new MojoExecutionException("Missing password from server " + server);
                 }
             }
-            Connection conn = DriverManager.getConnection(jdbcUrl, user, password);
-            try {
+            try (Connection conn = DriverManager.getConnection(jdbcUrl, user, password)) {
                 exporter.export(conn.getMetaData());
-            } finally {
-                if (conn != null) {
-                    conn.close();
-                }
             }
-        } catch (ClassNotFoundException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
-        } catch (SQLException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
-        } catch (InstantiationException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
-        } catch (IllegalAccessException e) {
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | SQLException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
 

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
@@ -497,7 +497,7 @@ public class MongodbQueryTest {
                 list.add(u);
             }
         }
-        return list.toArray(new User[list.size()]);
+        return list.toArray(new User[0]);
     }
 
     @Test

--- a/querydsl-spatial/pom.xml
+++ b/querydsl-spatial/pom.xml
@@ -94,8 +94,4 @@
       </plugin>
     </plugins>
   </build>
-  
-  <properties>
-    <bridge-method.version>1.11</bridge-method.version>
-  </properties>
 </project>

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ExtendedBeanSerializer.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ExtendedBeanSerializer.java
@@ -65,10 +65,10 @@ public class ExtendedBeanSerializer extends BeanSerializer {
                     columnEquals.append(" && ");
                     toString.append("+ \";\" + ");
                 } else {
-                    toString.append("\"" + model.getSimpleName() + "#\" + ");
+                    toString.append("\"").append(model.getSimpleName()).append("#\" + ");
                 }
-                anyColumnIsNull.append(propName + " == null");
-                columnEquals.append(propName + ".equals(obj." + propName + ")");
+                anyColumnIsNull.append(propName).append(" == null");
+                columnEquals.append(propName).append(".equals(obj.").append(propName).append(")");
                 toString.append(propName);
                 properties.add(propName);
             }

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/KeyDataFactory.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/KeyDataFactory.java
@@ -71,9 +71,8 @@ public class KeyDataFactory {
 
     public Map<String, InverseForeignKeyData> getExportedKeys(DatabaseMetaData md,
             String catalog, String schema, String tableName) throws SQLException {
-        ResultSet foreignKeys = md.getExportedKeys(catalog, schema, tableName);
-        Map<String,InverseForeignKeyData> inverseForeignKeyData = new TreeMap<String,InverseForeignKeyData>();
-        try {
+        try (ResultSet foreignKeys = md.getExportedKeys(catalog, schema, tableName)) {
+            Map<String, InverseForeignKeyData> inverseForeignKeyData = new TreeMap<String, InverseForeignKeyData>();
             while (foreignKeys.next()) {
                 String name = foreignKeys.getString(FK_NAME);
                 String parentColumnName = namingStrategy.normalizeColumnName(foreignKeys.getString(FK_PARENT_COLUMN_NAME));
@@ -93,16 +92,13 @@ public class KeyDataFactory {
                 data.add(parentColumnName, foreignColumn);
             }
             return inverseForeignKeyData;
-        } finally {
-            foreignKeys.close();
         }
     }
 
     public Map<String, ForeignKeyData> getImportedKeys(DatabaseMetaData md,
             String catalog, String schema, String tableName) throws SQLException {
-        ResultSet foreignKeys = md.getImportedKeys(catalog, schema, tableName);
-        Map<String,ForeignKeyData> foreignKeyData = new TreeMap<String,ForeignKeyData>();
-        try {
+        try (ResultSet foreignKeys = md.getImportedKeys(catalog, schema, tableName)) {
+            Map<String, ForeignKeyData> foreignKeyData = new TreeMap<String, ForeignKeyData>();
             while (foreignKeys.next()) {
                 String name = foreignKeys.getString(FK_NAME);
                 String parentSchemaName = namingStrategy.normalizeSchemaName(foreignKeys.getString(FK_PARENT_SCHEMA_NAME));
@@ -122,16 +118,13 @@ public class KeyDataFactory {
                 data.add(foreignColumn, parentColumnName);
             }
             return foreignKeyData;
-        } finally {
-            foreignKeys.close();
         }
     }
 
     public Map<String, PrimaryKeyData> getPrimaryKeys(DatabaseMetaData md,
             String catalog, String schema, String tableName) throws SQLException {
-        ResultSet primaryKeys = md.getPrimaryKeys(catalog, schema, tableName);
-        Map<String,PrimaryKeyData> primaryKeyData = new TreeMap<String,PrimaryKeyData>();
-        try {
+        try (ResultSet primaryKeys = md.getPrimaryKeys(catalog, schema, tableName)) {
+            Map<String, PrimaryKeyData> primaryKeyData = new TreeMap<String, PrimaryKeyData>();
             while (primaryKeys.next()) {
                 String name = primaryKeys.getString(PK_NAME);
                 String columnName = primaryKeys.getString(PK_COLUMN_NAME);
@@ -147,8 +140,6 @@ public class KeyDataFactory {
                 data.add(columnName);
             }
             return primaryKeyData;
-        } finally {
-            primaryKeys.close();
         }
     }
 

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
@@ -223,7 +223,7 @@ public class MetaDataExporter {
             for (String tableType : tableTypesToExport.split(",")) {
                 types.add(tableType.trim());
             }
-            typesArray = types.toArray(new String[types.size()]);
+            typesArray = types.toArray(new String[0]);
         } else if (!exportAll) {
             List<String> types = new ArrayList<String>(2);
             if (exportTables) {
@@ -232,7 +232,7 @@ public class MetaDataExporter {
             if (exportViews) {
                 types.add("VIEW");
             }
-            typesArray = types.toArray(new String[types.size()]);
+            typesArray = types.toArray(new String[0]);
         }
 
         List<String> catalogs = patternAsList(catalogPattern);
@@ -268,13 +268,10 @@ public class MetaDataExporter {
     }
 
     private void handleTables(DatabaseMetaData md, String catalogPattern, String schemaPattern, String tablePattern, String[] types) throws SQLException {
-        ResultSet tables = md.getTables(catalogPattern, schemaPattern, tablePattern, types);
-        try {
+        try (ResultSet tables = md.getTables(catalogPattern, schemaPattern, tablePattern, types)) {
             while (tables.next()) {
                 handleTable(md, tables);
             }
-        } finally {
-            tables.close();
         }
     }
 
@@ -395,13 +392,10 @@ public class MetaDataExporter {
         }
 
         // collect columns
-        ResultSet columns = md.getColumns(catalog, schema, tableName.replace("/", "//"), null);
-        try {
+        try (ResultSet columns = md.getColumns(catalog, schema, tableName.replace("/", "//"), null)) {
             while (columns.next()) {
                 handleColumn(classModel, tableName, columns);
             }
-        } finally {
-            columns.close();
         }
 
         // serialize model

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
@@ -175,6 +175,7 @@ public class MetaDataSerializer extends EntitySerializer {
             for (ForeignKeyData keyData : foreignKeys) {
                 if (keyData.getForeignColumns().size() > 1) {
                     addJavaUtilImport = true;
+                    break;
                 }
             }
         }
@@ -182,6 +183,7 @@ public class MetaDataSerializer extends EntitySerializer {
             for (InverseForeignKeyData keyData : inverseForeignKeys) {
                 if (keyData.getForeignColumns().size() > 1) {
                     addJavaUtilImport = true;
+                    break;
                 }
             }
         }
@@ -223,27 +225,27 @@ public class MetaDataSerializer extends EntitySerializer {
         writer.beginPublicMethod(Types.VOID,"addMetadata");
         List<Property> properties = Lists.newArrayList(model.getProperties());
         if (columnComparator != null) {
-            Collections.sort(properties, columnComparator);
+            properties.sort(columnComparator);
         }
         for (Property property : properties) {
             String name = property.getEscapedName();
             ColumnMetadata metadata = (ColumnMetadata) property.getData().get("COLUMN");
             StringBuilder columnMeta = new StringBuilder();
             columnMeta.append("ColumnMetadata");
-            columnMeta.append(".named(\"" + metadata.getName() + "\")");
-            columnMeta.append(".withIndex(" + metadata.getIndex() + ")");
+            columnMeta.append(".named(\"").append(metadata.getName()).append("\")");
+            columnMeta.append(".withIndex(").append(metadata.getIndex()).append(")");
             if (metadata.hasJdbcType()) {
                 String type = String.valueOf(metadata.getJdbcType());
                 if (typeConstants.containsKey(metadata.getJdbcType())) {
                     type = "Types." + typeConstants.get(metadata.getJdbcType());
                 }
-                columnMeta.append(".ofType(" + type + ")");
+                columnMeta.append(".ofType(").append(type).append(")");
             }
             if (metadata.hasSize()) {
-                columnMeta.append(".withSize(" + metadata.getSize() + ")");
+                columnMeta.append(".withSize(").append(metadata.getSize()).append(")");
             }
             if (metadata.getDigits() > 0) {
-                columnMeta.append(".withDigits(" + metadata.getDigits() + ")");
+                columnMeta.append(".withDigits(").append(metadata.getDigits()).append(")");
             }
             if (!metadata.isNullable()) {
                 columnMeta.append(".notNull()");
@@ -377,7 +379,7 @@ public class MetaDataSerializer extends EntitySerializer {
             }
             if (foreignKey.getForeignColumns().size() == 1) {
                 value.append(namingStrategy.getPropertyName(foreignKey.getForeignColumns().get(0), model));
-                value.append(", \"" + foreignKey.getParentColumns().get(0) + "\"");
+                value.append(", \"").append(foreignKey.getParentColumns().get(0)).append("\"");
             } else {
                 StringBuilder local = new StringBuilder();
                 StringBuilder foreign = new StringBuilder();
@@ -387,9 +389,9 @@ public class MetaDataSerializer extends EntitySerializer {
                         foreign.append(", ");
                     }
                     local.append(namingStrategy.getPropertyName(foreignKey.getForeignColumns().get(i), model));
-                    foreign.append("\"" + foreignKey.getParentColumns().get(i) + "\"");
+                    foreign.append("\"").append(foreignKey.getParentColumns().get(i)).append("\"");
                 }
-                value.append("Arrays.asList(" + local + "), Arrays.asList(" + foreign + ")");
+                value.append("Arrays.asList(").append(local).append("), Arrays.asList(").append(foreign).append(")");
             }
             value.append(")");
             Type type = new ClassType(ForeignKey.class, foreignKey.getType());

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ant/AntMetaDataExporter.java
@@ -379,15 +379,7 @@ public class AntMetaDataExporter extends Task {
 
             exporter.export(dbConn.getMetaData());
 
-        } catch (RuntimeException e) {
-            throw new BuildException(e);
-        } catch (InstantiationException e) {
-            throw new BuildException(e);
-        } catch (IllegalAccessException e) {
-            throw new BuildException(e);
-        } catch (ClassNotFoundException e) {
-            throw new BuildException(e);
-        } catch (SQLException e) {
+        } catch (RuntimeException | SQLException | ClassNotFoundException | IllegalAccessException | InstantiationException e) {
             throw new BuildException(e);
         } finally {
             if (dbConn != null) {

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/TypeMapping.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/TypeMapping.java
@@ -35,11 +35,7 @@ public class TypeMapping implements Mapping {
             } else {
                 configuration.register(table, column, typeClass);
             }
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        } catch (InstantiationException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
             throw new RuntimeException(e);
         }
     }

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataExporterAllTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataExporterAllTest.java
@@ -153,7 +153,7 @@ public class MetaDataExporterAllTest {
 
         Set<String> classes = exporter.getClasses();
         int compilationResult = compiler.run(null, System.out, System.err,
-                classes.toArray(new String[classes.size()]));
+                classes.toArray(new String[0]));
         if (compilationResult != 0) {
             Assert.fail("Compilation Failed for " + folder.getRoot().getPath());
         }

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataExporterTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataExporterTest.java
@@ -62,9 +62,8 @@ public class MetaDataExporterTest {
     }
 
     static void createTables(Connection connection) throws SQLException {
-        Statement stmt = connection.createStatement();
 
-        try {
+        try (Statement stmt = connection.createStatement()) {
             // reserved words
             stmt.execute("create table reserved (id int, while int)");
 
@@ -119,8 +118,6 @@ public class MetaDataExporterTest {
                     + "m_product_bom_id int, "
                     + "m_productbom_id int, "
                     + "constraint product_bom foreign key (m_productbom_id) references product(id))");
-        } finally {
-            stmt.close();
         }
     }
 
@@ -455,7 +452,7 @@ public class MetaDataExporterTest {
 
         Set<String> classes = exporter.getClasses();
         int compilationResult = compiler.run(null, System.out, System.err,
-                classes.toArray(new String[classes.size()]));
+                classes.toArray(new String[0]));
         if (compilationResult != 0) {
             Assert.fail("Compilation Failed for " + targetDir.getAbsolutePath());
         }

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataSerializerTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/MetaDataSerializerTest.java
@@ -167,7 +167,7 @@ public class MetaDataSerializerTest extends AbstractJDBCTest {
     private void compile(MetaDataExporter exporter) {
         JavaCompiler compiler = new SimpleCompiler();
         Set<String> classes = exporter.getClasses();
-        int compilationResult = compiler.run(null, null, null, classes.toArray(new String[classes.size()]));
+        int compilationResult = compiler.run(null, null, null, classes.toArray(new String[0]));
         if (compilationResult == 0) {
             System.out.println("Compilation is successful");
         } else {

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ant/AntMetaDataExporterTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/ant/AntMetaDataExporterTest.java
@@ -32,17 +32,11 @@ public class AntMetaDataExporterTest {
 
     @BeforeClass
     public static void setUp() throws SQLException {
-        Connection conn = DriverManager.getConnection(url, "sa", "");
-        try {
-          Statement stmt = conn.createStatement();
-          try {
-              stmt.execute("drop table test if exists");
-              stmt.execute("create table test (id int)");
-          } finally {
-              stmt.close();
-          }
-        } finally {
-            conn.close();
+        try (Connection conn = DriverManager.getConnection(url, "sa", "")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("drop table test if exists");
+                stmt.execute("create table test (id int)");
+            }
         }
     }
 

--- a/querydsl-sql-spatial/pom.xml
+++ b/querydsl-sql-spatial/pom.xml
@@ -16,7 +16,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <bridge-method.version>1.13</bridge-method.version>
     <osgi.import.package>
       org.joda.time.*;version="[1.6,3)",
       ${osgi.import.package.root}
@@ -167,17 +166,6 @@
 
     <!-- backwards compatibility -->
     <dependency>
-      <groupId>com.infradna.tool</groupId>
-      <artifactId>bridge-method-annotation</artifactId>
-      <version>${bridge-method.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>annotation-indexer</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jvnet.hudson</groupId>
       <artifactId>annotation-indexer</artifactId>
       <version>1.2</version>
@@ -187,37 +175,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.infradna.tool</groupId>
-        <artifactId>bridge-method-injector</artifactId>
-        <version>${bridge-method.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.infradna.tool</groupId>
-            <artifactId>bridge-method-annotation</artifactId>
-            <version>${bridge-method.version}</version>
-            <optional>true</optional>
-            <exclusions>
-              <exclusion>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>annotation-indexer</artifactId>
-              </exclusion>
-            </exclusions>
-          </dependency>
-          <dependency>
-            <groupId>org.jvnet.hudson</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.2</version>
-          </dependency>
-        </dependencies>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/PGgeometryConverter.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/PGgeometryConverter.java
@@ -188,8 +188,8 @@ final class PGgeometryConverter {
         CrsId crs = CrsId.valueOf(first.srid);
         DimensionalFlag flag = DimensionalFlag.valueOf(first.dimension == 3, first.haveMeasure);
         PointSequenceBuilder pointSequence = PointSequenceBuilders.variableSized(flag, crs);
-        for (int i = 0; i < points.length; i++) {
-            pointSequence.add(convert(points[i]));
+        for (org.postgis.Point point : points) {
+            pointSequence.add(convert(point));
         }
         return pointSequence.toPointSequence();
     }

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SpatialTemplatesSupport.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SpatialTemplatesSupport.java
@@ -41,7 +41,7 @@ public final class SpatialTemplatesSupport {
             if (i > start) {
                 result.append(", ");
             }
-            result.append("{" + i + "}");
+            result.append("{").append(i).append("}");
         }
         result.append(")");
         return result.toString();

--- a/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/SpatialTest.java
+++ b/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/suites/SpatialTest.java
@@ -29,16 +29,13 @@ public class SpatialTest {
     @Test
     public void test() throws SQLException {
         Statement stmt = Connections.getStatement();
-        ResultSet rs = stmt.executeQuery("select \"GEOMETRY\" from \"SHAPES\"");
-        try {
+        try (ResultSet rs = stmt.executeQuery("select \"GEOMETRY\" from \"SHAPES\"")) {
             while (rs.next()) {
                 System.err.println(rs.getObject(1).getClass().getName());
                 System.err.println(rs.getString(1));
 //                Clob clob = rs.getClob(1);
 //                System.err.println(clob.getSubString(1, (int) clob.length()));
             }
-        } finally {
-            rs.close();
         }
     }
 
@@ -46,14 +43,11 @@ public class SpatialTest {
     public void metadata() throws SQLException {
         Connection conn = Connections.getConnection();
         DatabaseMetaData md = conn.getMetaData();
-        ResultSet rs = md.getColumns(null, null, "SHAPES", "GEOMETRY");
-        try {
+        try (ResultSet rs = md.getColumns(null, null, "SHAPES", "GEOMETRY")) {
             rs.next();
             int type = rs.getInt("DATA_TYPE");
             String typeName = rs.getString("TYPE_NAME");
             System.err.println(type + " " + typeName);
-        } finally {
-            rs.close();
         }
     }
 

--- a/querydsl-sql/pom.xml
+++ b/querydsl-sql/pom.xml
@@ -16,7 +16,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <bridge-method.version>1.13</bridge-method.version>
     <osgi.import.package>
       org.joda.time.*;version="[1.6,3)",
       ${osgi.import.package.root}
@@ -176,17 +175,6 @@
 
     <!-- backwards compatibility -->
     <dependency>
-      <groupId>com.infradna.tool</groupId>
-      <artifactId>bridge-method-annotation</artifactId>
-      <version>${bridge-method.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>annotation-indexer</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jvnet.hudson</groupId>
       <artifactId>annotation-indexer</artifactId>
       <version>1.2</version>
@@ -196,37 +184,6 @@
   
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.infradna.tool</groupId>
-        <artifactId>bridge-method-injector</artifactId>
-        <version>${bridge-method.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.infradna.tool</groupId>
-            <artifactId>bridge-method-annotation</artifactId>
-            <version>${bridge-method.version}</version>
-            <optional>true</optional>
-            <exclusions>
-              <exclusion>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>annotation-indexer</artifactId>
-              </exclusion>
-            </exclusions>
-          </dependency>
-          <dependency>
-            <groupId>org.jvnet.hudson</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.2</version>
-          </dependency>
-        </dependencies>
-      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/querydsl-sql/src/main/java/com/querydsl/sql/JavaTypeMapping.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/JavaTypeMapping.java
@@ -79,9 +79,7 @@ class JavaTypeMapping {
             registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310ZonedDateTimeType").newInstance());
         } catch (ClassNotFoundException e) {
             // converters for JSR 310 are not loaded
-        } catch (InstantiationException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }
@@ -160,11 +158,7 @@ class JavaTypeMapping {
     }
 
     public void setType(String table, String column, Type<?> type) {
-        Map<String,Type<?>> columns = typeByColumn.get(table);
-        if (columns == null) {
-            columns = new HashMap<String, Type<?>>();
-            typeByColumn.put(table, columns);
-        }
+        Map<String, Type<?>> columns = typeByColumn.computeIfAbsent(table, k -> new HashMap<String, Type<?>>());
         columns.put(column, type);
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -165,7 +165,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Q from(SubQueryExpression<?> subQuery, Path<?> alias) {
-        return queryMixin.from(ExpressionUtils.as((Expression) subQuery, alias));
+        return queryMixin.from((Expression) ExpressionUtils.as((Expression) subQuery, alias));
     }
 
     @Override
@@ -350,7 +350,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
      */
     @SuppressWarnings("unchecked")
     public <RT> Q union(Path<?> alias, SubQueryExpression<RT>... sq) {
-        return from(UnionUtils.union(ImmutableList.copyOf(sq), (Path) alias, false));
+        return from((Expression) UnionUtils.union(ImmutableList.copyOf(sq), (Path) alias, false));
     }
 
     /**
@@ -388,7 +388,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
      */
     @SuppressWarnings("unchecked")
     public <RT> Q unionAll(Path<?> alias, SubQueryExpression<RT>... sq) {
-        return from(UnionUtils.union(ImmutableList.copyOf(sq), (Path) alias, true));
+        return from((Expression) UnionUtils.union(ImmutableList.copyOf(sq), (Path) alias, true));
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/RelationalFunctionCall.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/RelationalFunctionCall.java
@@ -37,7 +37,7 @@ public class RelationalFunctionCall<T> extends SimpleExpression<T> implements Te
             if (i > 0) {
                 builder.append(", ");
             }
-            builder.append("{" + i + "}");
+            builder.append("{").append(i).append("}");
         }
         builder.append(")");
         return TemplateFactory.DEFAULT.create(builder.toString());

--- a/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathBase.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathBase.java
@@ -216,7 +216,7 @@ public class RelationalPathBase<T> extends BeanPath<T> implements RelationalPath
     }
 
     public Path<?>[] all() {
-        return columnMetadata.keySet().toArray(new Path<?>[columnMetadata.size()]);
+        return columnMetadata.keySet().toArray(new Path<?>[0]);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathUtils.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathUtils.java
@@ -45,7 +45,7 @@ public final class RelationalPathUtils {
     }
 
     private static <T> FactoryExpression<T> createConstructorProjection(RelationalPath<T> path) {
-        Expression<?>[] exprs = path.getColumns().toArray(new Expression[path.getColumns().size()]);
+        Expression<?>[] exprs = path.getColumns().toArray(new Expression[0]);
         return Projections.<T>constructor((Class) path.getType(), exprs);
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerContextImpl.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerContextImpl.java
@@ -18,10 +18,10 @@ import java.sql.PreparedStatement;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.base.Function;
 import com.querydsl.core.QueryMetadata;
 
 /**
@@ -104,12 +104,7 @@ public class SQLListenerContextImpl implements SQLListenerContext {
 
     @Override
     public Collection<String> getSQLStatements() {
-        return Lists.transform(sqlStatements, new Function<SQLBindings, String>() {
-            @Override
-            public String apply(SQLBindings sqlBindings) {
-                return sqlBindings.getSQL();
-            }
-        });
+        return sqlStatements.stream().map(SQLBindings::getSQL).collect(Collectors.toList());
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -63,6 +64,11 @@ public class UnionImpl<T, Q extends ProjectableSQLQuery<T, Q> & Query<Q>>  imple
     @Override
     public CloseableIterator<T> iterate() {
         return query.iterate();
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return query.stream();
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/WindowFunction.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/WindowFunction.java
@@ -74,7 +74,7 @@ public class WindowFunction<A> extends MutableExpressionBase<A> {
                     if (!first) {
                         builder.append(", ");
                     }
-                    builder.append("{" + size + "}");
+                    builder.append("{").append(size).append("}");
                     args.add(expr);
                     size++;
                     first = false;
@@ -86,7 +86,7 @@ public class WindowFunction<A> extends MutableExpressionBase<A> {
                     builder.append(" ");
                 }
                 builder.append(ORDER_BY);
-                builder.append("{" + size + "}");
+                builder.append("{").append(size).append("}");
                 args.add(ExpressionUtils.orderBy(orderBy));
                 size++;
             }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/WindowRows.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/WindowRows.java
@@ -59,7 +59,7 @@ public class WindowRows<A> {
         public BetweenAnd preceding(Expression<Integer> expr) {
             args.add(expr);
             str.append(PRECEDING);
-            str.append(" {" + (offset++) + "}");
+            str.append(" {").append(offset++).append("}");
             return new BetweenAnd();
         }
 
@@ -70,7 +70,7 @@ public class WindowRows<A> {
         public BetweenAnd following(Expression<Integer> expr) {
             args.add(expr);
             str.append(FOLLOWING);
-            str.append(" {" + (offset++) + "}");
+            str.append(" {").append(offset++).append("}");
             return new BetweenAnd();
         }
 
@@ -102,7 +102,7 @@ public class WindowRows<A> {
         public WindowFunction<A> preceding(Expression<Integer> expr) {
             args.add(expr);
             str.append(PRECEDING);
-            str.append(" {" + (offset++) + "}");
+            str.append(" {").append(offset++).append("}");
             return rv.withRowsOrRange(str.toString(), args);
         }
 
@@ -113,7 +113,7 @@ public class WindowRows<A> {
         public WindowFunction<A> following(Expression<Integer> expr) {
             args.add(expr);
             str.append(FOLLOWING);
-            str.append(" {" + (offset++) + "}");
+            str.append(" {").append(offset++).append("}");
             return rv.withRowsOrRange(str.toString(), args);
         }
 
@@ -155,7 +155,7 @@ public class WindowRows<A> {
     public WindowFunction<A> preceding(Expression<Integer> expr) {
         args.add(expr);
         str.append(PRECEDING);
-        str.append(" {" + (offset++) + "}");
+        str.append(" {").append(offset++).append("}");
         return rv.withRowsOrRange(str.toString(), args);
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/WithinGroup.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/WithinGroup.java
@@ -74,7 +74,7 @@ public class WithinGroup<T> extends SimpleOperation<T> {
                 size++;
                 if (!orderBy.isEmpty()) {
                     builder.append(ORDER_BY);
-                    builder.append("{" + size + "}");
+                    builder.append("{").append(size).append("}");
                     args.add(ExpressionUtils.orderBy(orderBy));
                 }
                 builder.append(")");

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLDeleteClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLDeleteClause.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.querydsl.core.*;
 import com.querydsl.core.QueryFlag.Position;
 import com.querydsl.core.dml.DeleteClause;
@@ -84,7 +83,6 @@ public abstract class AbstractSQLDeleteClause<C extends AbstractSQLDeleteClause<
      * @param flag query flag
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLDeleteClause.class, castRequired = true)
     public C addFlag(Position position, String flag) {
         metadata.addFlag(new QueryFlag(position, flag));
         return (C) this;
@@ -97,7 +95,6 @@ public abstract class AbstractSQLDeleteClause<C extends AbstractSQLDeleteClause<
      * @param flag query flag
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLDeleteClause.class, castRequired = true)
     public C addFlag(Position position, Expression<?> flag) {
         metadata.addFlag(new QueryFlag(position, flag));
         return (C) this;
@@ -108,7 +105,6 @@ public abstract class AbstractSQLDeleteClause<C extends AbstractSQLDeleteClause<
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLDeleteClause.class, castRequired =  true)
     public C addBatch() {
         batches.add(metadata);
         metadata = new DefaultQueryMetadata();
@@ -250,14 +246,12 @@ public abstract class AbstractSQLDeleteClause<C extends AbstractSQLDeleteClause<
         }
     }
 
-    @WithBridgeMethods(value = SQLDeleteClause.class, castRequired = true)
     public C where(Predicate p) {
         metadata.addWhere(p);
         return (C) this;
     }
 
     @Override
-    @WithBridgeMethods(value = SQLDeleteClause.class, castRequired = true)
     public C where(Predicate... o) {
         for (Predicate p : o) {
             metadata.addWhere(p);
@@ -265,7 +259,6 @@ public abstract class AbstractSQLDeleteClause<C extends AbstractSQLDeleteClause<
         return (C) this;
     }
 
-    @WithBridgeMethods(value = SQLDeleteClause.class, castRequired = true)
     public C limit(@Nonnegative long limit) {
         metadata.setModifiers(QueryModifiers.limit(limit));
         return (C) this;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
@@ -121,7 +121,7 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
      */
     public C addBatch() {
         if (subQueryBuilder != null) {
-            subQuery = subQueryBuilder.select(values.toArray(new Expression[values.size()])).clone();
+            subQuery = subQueryBuilder.select(values.toArray(new Expression[0])).clone();
             values.clear();
         }
         batches.add(new SQLInsertBatch(columns, values, subQuery));
@@ -242,7 +242,7 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
         listeners.preRender(context);
         SQLSerializer serializer = createSerializer();
         if (subQueryBuilder != null) {
-            subQuery = subQueryBuilder.select(values.toArray(new Expression[values.size()])).clone();
+            subQuery = subQueryBuilder.select(values.toArray(new Expression[0])).clone();
             values.clear();
         }
 
@@ -261,7 +261,7 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
         listeners.preRender(context);
 
         if (subQueryBuilder != null) {
-            subQuery = subQueryBuilder.select(values.toArray(new Expression[values.size()])).clone();
+            subQuery = subQueryBuilder.select(values.toArray(new Expression[0])).clone();
             values.clear();
         }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.querydsl.core.DefaultQueryMetadata;
 import com.querydsl.core.JoinType;
 import com.querydsl.core.QueryFlag;
@@ -98,7 +97,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
      * @param flag query flag
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public C addFlag(Position position, String flag) {
         metadata.addFlag(new QueryFlag(position, flag));
         return (C) this;
@@ -111,7 +109,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
      * @param flag query flag
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public C addFlag(Position position, Expression<?> flag) {
         metadata.addFlag(new QueryFlag(position, flag));
         return (C) this;
@@ -122,7 +119,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public C addBatch() {
         if (subQueryBuilder != null) {
             subQuery = subQueryBuilder.select(values.toArray(new Expression[values.size()])).clone();
@@ -152,7 +148,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public C columns(Path<?>... columns) {
         this.columns.addAll(Arrays.asList(columns));
         return (C) this;
@@ -469,7 +464,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public C select(SubQueryExpression<?> sq) {
         subQuery = sq;
         for (Map.Entry<ParamExpression<?>, Object> entry : sq.getMetadata().getParams().entrySet()) {
@@ -479,7 +473,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public <T> C set(Path<T> path, T value) {
         columns.add(path);
         if (value instanceof Expression<?>) {
@@ -493,7 +486,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public <T> C set(Path<T> path, Expression<? extends T> expression) {
         columns.add(path);
         values.add(expression);
@@ -501,7 +493,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public <T> C setNull(Path<T> path) {
         columns.add(path);
         values.add(Null.CONSTANT);
@@ -509,7 +500,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public C values(Object... v) {
         for (Object value : v) {
             if (value instanceof Expression<?>) {
@@ -541,7 +531,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
      * @param bean bean to use for population
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public C populate(Object bean) {
         return populate(bean, DefaultMapper.DEFAULT);
     }
@@ -555,7 +544,6 @@ public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<
      * @return the current object
      */
     @SuppressWarnings("rawtypes")
-    @WithBridgeMethods(value = SQLInsertClause.class, castRequired = true)
     public <T> C populate(T obj, Mapper<T> mapper) {
         Map<Path<?>, Object> values = mapper.createMap(entity, obj);
         for (Map.Entry<Path<?>, Object> entry : values.entrySet()) {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLUpdateClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLUpdateClause.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.querydsl.core.*;
 import com.querydsl.core.QueryFlag.Position;
 import com.querydsl.core.dml.UpdateClause;
@@ -82,7 +81,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
      * @param flag query flag
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C addFlag(Position position, String flag) {
         metadata.addFlag(new QueryFlag(position, flag));
         return (C) this;
@@ -95,7 +93,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
      * @param flag query flag
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C addFlag(Position position, Expression<?> flag) {
         metadata.addFlag(new QueryFlag(position, flag));
         return (C) this;
@@ -106,7 +103,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C addBatch() {
         batches.add(new SQLUpdateBatch(metadata, updates));
         updates = Maps.newLinkedHashMap();
@@ -249,7 +245,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public <T> C set(Path<T> path, T value) {
         if (value instanceof Expression<?>) {
             updates.put(path, (Expression<?>) value);
@@ -262,7 +257,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public <T> C set(Path<T> path, Expression<? extends T> expression) {
         if (expression != null) {
             updates.put(path, expression);
@@ -273,14 +267,12 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
     }
 
     @Override
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public <T> C setNull(Path<T> path) {
         updates.put(path, Null.CONSTANT);
         return (C) this;
     }
 
     @Override
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C set(List<? extends Path<?>> paths, List<?> values) {
         for (int i = 0; i < paths.size(); i++) {
             if (values.get(i) instanceof Expression) {
@@ -294,14 +286,12 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
         return (C) this;
     }
 
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C where(Predicate p) {
         metadata.addWhere(p);
         return (C) this;
     }
 
     @Override
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C where(Predicate... o) {
         for (Predicate p : o) {
             metadata.addWhere(p);
@@ -309,7 +299,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
         return (C) this;
     }
 
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C limit(@Nonnegative long limit) {
         metadata.setModifiers(QueryModifiers.limit(limit));
         return (C) this;
@@ -331,7 +320,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
      * @return the current object
      */
     @SuppressWarnings("unchecked")
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public C populate(Object bean) {
         return populate(bean, DefaultMapper.DEFAULT);
     }
@@ -344,7 +332,6 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
      * @return the current object
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    @WithBridgeMethods(value = SQLUpdateClause.class, castRequired = true)
     public <T> C populate(T obj, Mapper<T> mapper) {
         Collection<? extends Path<?>> primaryKeyColumns = entity.getPrimaryKey() != null
                 ? entity.getPrimaryKey().getLocalColumns()

--- a/querydsl-sql/src/main/java/com/querydsl/sql/mssql/AbstractSQLServerQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/mssql/AbstractSQLServerQuery.java
@@ -17,7 +17,6 @@ import java.sql.Connection;
 
 import javax.inject.Provider;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.querydsl.core.JoinFlag;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.sql.AbstractSQLQuery;
@@ -46,7 +45,6 @@ public abstract class AbstractSQLServerQuery<T, C extends AbstractSQLServerQuery
      * @param tableHints table hints
      * @return the current object
      */
-    @WithBridgeMethods(value = SQLServerQuery.class, castRequired = true)
     public C tableHints(SQLServerTableHints... tableHints) {
         if (tableHints.length > 0) {
             String hints = SQLServerGrammar.tableHints(tableHints);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/mysql/AbstractMySQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/mysql/AbstractMySQLQuery.java
@@ -19,7 +19,6 @@ import java.sql.Connection;
 import javax.inject.Provider;
 
 import com.google.common.base.Joiner;
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.querydsl.core.JoinFlag;
 import com.querydsl.core.QueryFlag.Position;
 import com.querydsl.core.QueryMetadata;
@@ -73,7 +72,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C bigResult() {
         return addFlag(Position.AFTER_SELECT, SQL_BIG_RESULT);
     }
@@ -86,7 +84,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C bufferResult() {
         return addFlag(Position.AFTER_SELECT, SQL_BUFFER_RESULT);
     }
@@ -97,7 +94,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C cache() {
         return addFlag(Position.AFTER_SELECT, SQL_CACHE);
     }
@@ -108,7 +104,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C calcFoundRows() {
         return addFlag(Position.AFTER_SELECT, SQL_CALC_FOUND_ROWS);
     }
@@ -119,7 +114,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C highPriority() {
         return addFlag(Position.AFTER_SELECT, HIGH_PRIORITY);
     }
@@ -130,7 +124,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      * @param var variable name
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C into(String var) {
         return addFlag(Position.END, "\ninto " + var);
     }
@@ -141,7 +134,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      * @param file file to write to
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C intoDumpfile(File file) {
         return addFlag(Position.END, "\ninto dumpfile '" + file.getPath() + "'");
     }
@@ -153,7 +145,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      * @param file file to write to
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C intoOutfile(File file) {
         return addFlag(Position.END, "\ninto outfile '" + file.getPath() + "'");
     }
@@ -164,7 +155,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C lockInShareMode() {
         return addFlag(Position.END, LOCK_IN_SHARE_MODE);
     }
@@ -175,7 +165,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C noCache() {
         return addFlag(Position.AFTER_SELECT, SQL_NO_CACHE);
     }
@@ -186,7 +175,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C smallResult() {
         return addFlag(Position.AFTER_SELECT, SQL_SMALL_RESULT);
     }
@@ -198,7 +186,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C straightJoin() {
         return addFlag(Position.AFTER_SELECT, STRAIGHT_JOIN);
     }
@@ -211,7 +198,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      * @param indexes index names
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C forceIndex(String... indexes) {
         return addJoinFlag(" force index (" + JOINER.join(indexes) + ")", JoinFlag.Position.END);
     }
@@ -223,7 +209,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      * @param indexes index names
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C ignoreIndex(String... indexes) {
         return addJoinFlag(" ignore index (" + JOINER.join(indexes) + ")", JoinFlag.Position.END);
     }
@@ -235,7 +220,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      * @param indexes index names
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C useIndex(String... indexes) {
         return addJoinFlag(" use index (" + JOINER.join(indexes) + ")", JoinFlag.Position.END);
     }
@@ -248,7 +232,6 @@ public abstract class AbstractMySQLQuery<T, C extends AbstractMySQLQuery<T, C>> 
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = MySQLQuery.class, castRequired = true)
     public C withRollup() {
         return addFlag(Position.AFTER_GROUP_BY, WITH_ROLLUP);
     }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/mysql/MySQLQueryFactory.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/mysql/MySQLQueryFactory.java
@@ -94,7 +94,7 @@ public class MySQLQueryFactory extends AbstractSQLQueryFactory<MySQLQuery<?>> {
         SQLInsertClause insert = insert(entity);
         StringBuilder flag = new StringBuilder(" on duplicate key update ");
         for (int i = 0; i < clauses.length; i++) {
-            flag.append(i > 0 ? ", " : "").append("{" + i + "}");
+            flag.append(i > 0 ? ", " : "").append("{").append(i).append("}");
         }
         insert.addFlag(Position.END, ExpressionUtils.template(String.class, flag.toString(), clauses));
         return insert;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/namemapping/PreConfiguredNameMapping.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/namemapping/PreConfiguredNameMapping.java
@@ -71,20 +71,12 @@ public class PreConfiguredNameMapping implements NameMapping {
 
     public String registerColumnOverride(String schema, String table, String oldColumn, String newColumn) {
         SchemaAndTable key = new SchemaAndTable(schema, table);
-        Map<String, String> columnOverrides = schemaTableColumns.get(key);
-        if (columnOverrides == null) {
-            columnOverrides = new HashMap<String, String>();
-            schemaTableColumns.put(key, columnOverrides);
-        }
+        Map<String, String> columnOverrides = schemaTableColumns.computeIfAbsent(key, k -> new HashMap<String, String>());
         return columnOverrides.put(oldColumn, newColumn);
     }
 
     public String registerColumnOverride(String table, String oldColumn, String newColumn) {
-        Map<String, String> columnOverrides = tableColumns.get(table);
-        if (columnOverrides == null) {
-            columnOverrides = new HashMap<String, String>();
-            tableColumns.put(table, columnOverrides);
-        }
+        Map<String, String> columnOverrides = tableColumns.computeIfAbsent(table, k -> new HashMap<String, String>());
         return columnOverrides.put(oldColumn, newColumn);
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/oracle/AbstractOracleQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/oracle/AbstractOracleQuery.java
@@ -17,7 +17,6 @@ import java.sql.Connection;
 
 import javax.inject.Provider;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.querydsl.core.QueryFlag.Position;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.types.Expression;
@@ -58,7 +57,6 @@ public abstract class AbstractOracleQuery<T, C extends AbstractOracleQuery<T, C>
      * @param cond condition
      * @return the current object
      */
-    @WithBridgeMethods(value = OracleQuery.class, castRequired = true)
     public C connectByPrior(Predicate cond) {
         return addFlag(Position.BEFORE_ORDER, CONNECT_BY_PRIOR, cond);
     }
@@ -69,7 +67,6 @@ public abstract class AbstractOracleQuery<T, C extends AbstractOracleQuery<T, C>
      * @param cond condition
      * @return the current object
      */
-    @WithBridgeMethods(value = OracleQuery.class, castRequired = true)
     public C connectBy(Predicate cond) {
         return addFlag(Position.BEFORE_ORDER, CONNECT_BY, cond);
     }
@@ -80,7 +77,6 @@ public abstract class AbstractOracleQuery<T, C extends AbstractOracleQuery<T, C>
      * @param cond condition
      * @return the current object
      */
-    @WithBridgeMethods(value = OracleQuery.class, castRequired = true)
     public C connectByNocyclePrior(Predicate cond) {
         return addFlag(Position.BEFORE_ORDER, CONNECT_BY_NOCYCLE_PRIOR, cond);
     }
@@ -91,7 +87,6 @@ public abstract class AbstractOracleQuery<T, C extends AbstractOracleQuery<T, C>
      * @param cond condition
      * @return the current object
      */
-    @WithBridgeMethods(value = OracleQuery.class, castRequired = true)
     public <A> C startWith(Predicate cond) {
         return addFlag(Position.BEFORE_ORDER, START_WITH, cond);
     }
@@ -103,7 +98,6 @@ public abstract class AbstractOracleQuery<T, C extends AbstractOracleQuery<T, C>
      * @param path path
      * @return the current object
      */
-    @WithBridgeMethods(value = OracleQuery.class, castRequired = true)
     public C orderSiblingsBy(Expression<?> path) {
         return addFlag(Position.BEFORE_ORDER, ORDER_SIBLINGS_BY, path);
     }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/AbstractPostgreSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/postgresql/AbstractPostgreSQLQuery.java
@@ -17,7 +17,6 @@ import java.sql.Connection;
 
 import javax.inject.Provider;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.querydsl.core.QueryFlag;
 import com.querydsl.core.QueryFlag.Position;
 import com.querydsl.core.QueryMetadata;
@@ -52,7 +51,6 @@ public abstract class AbstractPostgreSQLQuery<T, C extends AbstractPostgreSQLQue
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = PostgreSQLQuery.class, castRequired = true)
     public C forShare() {
         // global forShare support was added later, delegating to super implementation
         return super.forShare();
@@ -64,7 +62,6 @@ public abstract class AbstractPostgreSQLQuery<T, C extends AbstractPostgreSQLQue
      *
      * @return the current object
      */
-    @WithBridgeMethods(value = PostgreSQLQuery.class, castRequired = true)
     public C noWait() {
         QueryFlag noWaitFlag = configuration.getTemplates().getNoWaitFlag();
         return addFlag(noWaitFlag);
@@ -76,7 +73,6 @@ public abstract class AbstractPostgreSQLQuery<T, C extends AbstractPostgreSQLQue
      * @param paths tables
      * @return the current object
      */
-    @WithBridgeMethods(value = PostgreSQLQuery.class, castRequired = true)
     public C of(RelationalPath<?>... paths) {
         StringBuilder builder = new StringBuilder(" of ");
         for (RelationalPath<?> path : paths) {
@@ -94,7 +90,6 @@ public abstract class AbstractPostgreSQLQuery<T, C extends AbstractPostgreSQLQue
      * @param exprs
      * @return
      */
-    @WithBridgeMethods(value = PostgreSQLQuery.class, castRequired = true)
     public C distinctOn(Expression<?>... exprs) {
         return addFlag(Position.AFTER_SELECT,
             Expressions.template(Object.class, "distinct on({0}) ",

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/AbstractJSR310DateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/AbstractJSR310DateTimeType.java
@@ -5,14 +5,11 @@ import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.TimeZone;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 /**
  * Common abstract superclass for Type implementations for Java Time API (JSR310)
  *
  * @param <T>
  */
-@IgnoreJRERequirement //conditionally included
 public abstract class AbstractJSR310DateTimeType<T extends Temporal> extends AbstractType<T> {
 
     private static final Calendar UTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"));

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310InstantType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310InstantType.java
@@ -7,14 +7,11 @@ import java.time.ZoneId;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 /**
  * JSR310InstantType maps {@linkplain java.time.Instant} to
  * {@linkplain java.sql.Timestamp} on the JDBC level
  *
  */
-@IgnoreJRERequirement //conditionally included
 public class JSR310InstantType extends AbstractJSR310DateTimeType<Instant>  {
 
     public JSR310InstantType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
@@ -1,7 +1,5 @@
 package com.querydsl.sql.types;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -16,7 +14,6 @@ import java.time.ZoneOffset;
  * to {@linkplain java.sql.Timestamp} on the JDBC level
  *
  */
-@IgnoreJRERequirement //conditionally included
 public class JSR310LocalDateTimeType extends AbstractJSR310DateTimeType<LocalDateTime> {
 
     public JSR310LocalDateTimeType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
@@ -8,14 +8,11 @@ import java.time.ZoneOffset;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 /**
  * JSR310LocalDateType maps {@linkplain java.time.LocalDate}
  * to {@linkplain java.sql.Date} on the JDBC level
  *
  */
-@IgnoreJRERequirement //conditionally included
 public class JSR310LocalDateType extends AbstractJSR310DateTimeType<LocalDate> {
 
     public JSR310LocalDateType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalTimeType.java
@@ -6,14 +6,11 @@ import java.time.temporal.ChronoField;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 /**
  * JSR310LocalTimeType maps {@linkplain java.time.LocalTime}
  * to {@linkplain java.sql.Time} on the JDBC level
  *
  */
-@IgnoreJRERequirement //conditionally included
 public class JSR310LocalTimeType extends AbstractJSR310DateTimeType<LocalTime> {
 
     public JSR310LocalTimeType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
@@ -1,7 +1,5 @@
 package com.querydsl.sql.types;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -16,7 +14,6 @@ import java.time.ZoneOffset;
  * to {@linkplain java.sql.Timestamp} on the JDBC level
  *
  */
-@IgnoreJRERequirement //conditionally included
 public class JSR310OffsetDateTimeType extends AbstractJSR310DateTimeType<OffsetDateTime> {
 
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetTimeType.java
@@ -8,14 +8,11 @@ import java.time.temporal.ChronoField;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 /**
  * JSR310OffsetTimeType maps {@linkplain java.time.OffsetTime}
  * to {@linkplain java.sql.Time} on the JDBC level
  *
  */
-@IgnoreJRERequirement //conditionally included
 public class JSR310OffsetTimeType extends AbstractJSR310DateTimeType<OffsetTime> {
 
     public JSR310OffsetTimeType() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
@@ -1,7 +1,5 @@
 package com.querydsl.sql.types;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -16,7 +14,6 @@ import java.time.ZonedDateTime;
  * to {@linkplain java.sql.Timestamp} on the JDBC level
  *
  */
-@IgnoreJRERequirement //conditionally included
 public class JSR310ZonedDateTimeType extends AbstractJSR310DateTimeType<ZonedDateTime> {
 
     public JSR310ZonedDateTimeType() {

--- a/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
@@ -261,15 +261,12 @@ public final class Connections {
         // test
         stmt.execute("drop table if exists \"TEST\"");
         stmt.execute("create table \"TEST\"(NAME varchar(255))");
-        PreparedStatement pstmt = c.prepareStatement("insert into \"TEST\" values(?)");
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement("insert into \"TEST\" values(?)")) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -329,15 +326,12 @@ public final class Connections {
         dropTable(templates, "TEST");
         stmt.execute(CREATE_TABLE_TEST);
         stmt.execute("create index test_name on test(name)");
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -394,15 +388,12 @@ public final class Connections {
         dropTable(templates, "TEST");
         stmt.execute(CREATE_TABLE_TEST);
         stmt.execute("create index test_name on test(name)");
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -487,15 +478,12 @@ public final class Connections {
         // test
         dropTable(templates, "TEST");
         stmt.execute(CREATE_TABLE_TEST);
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -589,15 +577,12 @@ public final class Connections {
         // test
         stmt.execute("drop table TEST if exists");
         stmt.execute(CREATE_TABLE_TEST);
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -659,15 +644,12 @@ public final class Connections {
         // test
         stmt.execute("drop table TEST if exists");
         stmt.execute(CREATE_TABLE_TEST);
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -723,15 +705,12 @@ public final class Connections {
         // test
         stmt.execute("drop table if exists TEST");
         stmt.execute(CREATE_TABLE_TEST);
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -909,15 +888,12 @@ public final class Connections {
         dropTable(templates, "TEST");
         stmt.execute(quote(CREATE_TABLE_TEST,"TEST","NAME"));
         String sql = quote(INSERT_INTO_TEST_VALUES,"TEST");
-        PreparedStatement pstmt = c.prepareStatement(sql);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(sql)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -972,15 +948,12 @@ public final class Connections {
         // test
         stmt.execute("drop table if exists TEST");
         stmt.execute(CREATE_TABLE_TEST);
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -1043,15 +1016,12 @@ public final class Connections {
         // test
         dropTable(templates, "TEST");
         stmt.execute(CREATE_TABLE_TEST);
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee
@@ -1110,15 +1080,12 @@ public final class Connections {
         // test
         dropTable(templates, "TEST");
         stmt.execute(CREATE_TABLE_TEST);
-        PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES);
-        try {
+        try (PreparedStatement pstmt = c.prepareStatement(INSERT_INTO_TEST_VALUES)) {
             for (int i = 0; i < TEST_ROW_COUNT; i++) {
                 pstmt.setString(1, "name" + i);
                 pstmt.addBatch();
             }
             pstmt.executeBatch();
-        } finally {
-            pstmt.close();
         }
 
         // employee

--- a/querydsl-sql/src/test/java/com/querydsl/sql/QueryPerformanceTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/QueryPerformanceTest.java
@@ -67,20 +67,14 @@ public class QueryPerformanceTest {
             @Override
             public void run(int times) throws Exception {
                 for (int i = 0; i < times; i++) {
-                    PreparedStatement stmt = conn.prepareStatement(QUERY);
-                    try {
+                    try (PreparedStatement stmt = conn.prepareStatement(QUERY)) {
                         stmt.setLong(1, i);
-                        ResultSet rs = stmt.executeQuery();
-                        try {
+                        try (ResultSet rs = stmt.executeQuery()) {
                             while (rs.next()) {
                                 rs.getString(1);
                             }
-                        } finally {
-                            rs.close();
                         }
 
-                    } finally {
-                        stmt.close();
                     }
                 }
             }
@@ -93,20 +87,14 @@ public class QueryPerformanceTest {
             @Override
             public void run(int times) throws Exception {
                 for (int i = 0; i < times; i++) {
-                    PreparedStatement stmt = conn.prepareStatement(QUERY);
-                    try {
+                    try (PreparedStatement stmt = conn.prepareStatement(QUERY)) {
                         stmt.setString(1, String.valueOf(i));
-                        ResultSet rs = stmt.executeQuery();
-                        try {
+                        try (ResultSet rs = stmt.executeQuery()) {
                             while (rs.next()) {
                                 rs.getString(1);
                             }
-                        } finally {
-                            rs.close();
                         }
 
-                    } finally {
-                        stmt.close();
                     }
                 }
             }
@@ -136,14 +124,11 @@ public class QueryPerformanceTest {
                 for (int i = 0; i < times; i++) {
                     QCompanies companies = QCompanies.companies;
                     SQLQuery<?> query = new SQLQuery<Void>(conn, conf);
-                    CloseableIterator<String> it = query.from(companies)
-                            .where(companies.id.eq((long) i)).select(companies.name).iterate();
-                    try {
+                    try (CloseableIterator<String> it = query.from(companies)
+                            .where(companies.id.eq((long) i)).select(companies.name).iterate()) {
                         while (it.hasNext()) {
                             it.next();
                         }
-                    } finally {
-                        it.close();
                     }
                 }
             }
@@ -158,14 +143,11 @@ public class QueryPerformanceTest {
                 for (int i = 0; i < times; i++) {
                     QCompanies companies = QCompanies.companies;
                     SQLQuery<?> query = new SQLQuery<Void>(conn, conf);
-                    ResultSet rs = query.select(companies.name).from(companies)
-                            .where(companies.id.eq((long) i)).getResults();
-                    try {
+                    try (ResultSet rs = query.select(companies.name).from(companies)
+                            .where(companies.id.eq((long) i)).getResults()) {
                         while (rs.next()) {
                             rs.getString(1);
                         }
-                    } finally {
-                        rs.close();
                     }
                 }
             }
@@ -225,15 +207,12 @@ public class QueryPerformanceTest {
                 for (int i = 0; i < times; i++) {
                     QCompanies companies = QCompanies.companies;
                     SQLQuery<?> query = new SQLQuery<Void>(conn, conf);
-                    CloseableIterator<String> it = query.from(companies)
+                    try (CloseableIterator<String> it = query.from(companies)
                             .where(companies.name.eq(String.valueOf(i)))
-                            .select(companies.name).iterate();
-                    try {
+                            .select(companies.name).iterate()) {
                         while (it.hasNext()) {
                             it.next();
                         }
-                    } finally {
-                        it.close();
                     }
                 }
             }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLBindingsTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLBindingsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class SQLBindingsTest {
         query.from(survey).where(survey.name.eq("Bob")).select(survey.id);
         SQLBindings bindings = query.getSQL();
         assertEquals("select SURVEY.ID\nfrom SURVEY SURVEY\nwhere SURVEY.NAME = ?", bindings.getSQL());
-        assertEquals(Arrays.asList("Bob"), bindings.getBindings());
+        assertEquals(Collections.singletonList("Bob"), bindings.getBindings());
     }
 
     @Test

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLCloseListenerTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLCloseListenerTest.java
@@ -55,13 +55,10 @@ public class SQLCloseListenerTest {
 
     @Test
     public void iterate() {
-        CloseableIterator<Employee> it = query.iterate();
-        try {
+        try (CloseableIterator<Employee> it = query.iterate()) {
             while (it.hasNext()) {
                 it.next();
             }
-        } finally {
-            it.close();
         }
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLSerializerTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLSerializerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -206,7 +207,7 @@ public class SQLSerializerTest {
         QSurvey s1 = new QSurvey("s1");
         serializer.handle(s1.name.startsWith("X"));
         assertEquals("s1.NAME like ? escape '\\'", serializer.toString());
-        assertEquals(Arrays.asList("X%"), serializer.getConstants());
+        assertEquals(Collections.singletonList("X%"), serializer.getConstants());
     }
 
     @Test

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -281,7 +281,7 @@ public class SelectBase extends AbstractBaseTest {
     @Test
     public void coalesce() {
         Coalesce<String> c = new Coalesce<String>(employee.firstname, employee.lastname).add("xxx");
-        assertEquals(Arrays.asList(),
+        assertEquals(Collections.emptyList(),
                 query().from(employee).where(c.getValue().eq("xxx")).select(employee.id).fetch());
     }
 
@@ -806,7 +806,7 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void groupBy_yearMonth() {
-        assertEquals(Arrays.asList(10L), query().from(employee)
+        assertEquals(Collections.singletonList(10L), query().from(employee)
                .groupBy(employee.datefield.yearMonth())
                .orderBy(employee.datefield.yearMonth().asc())
                .select(employee.id.count()).fetch());
@@ -1316,21 +1316,21 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void operation_in_constant_list() {
-        assertEquals(0, query().from(survey).where(survey.name.charAt(0).in(Arrays.asList('a'))).fetchCount());
+        assertEquals(0, query().from(survey).where(survey.name.charAt(0).in(Collections.singletonList('a'))).fetchCount());
         assertEquals(0, query().from(survey).where(survey.name.charAt(0).in(Arrays.asList('a','b'))).fetchCount());
         assertEquals(0, query().from(survey).where(survey.name.charAt(0).in(Arrays.asList('a','b','c'))).fetchCount());
     }
 
     @Test
     public void order_nullsFirst() {
-        assertEquals(Arrays.asList("Hello World"), query().from(survey)
+        assertEquals(Collections.singletonList("Hello World"), query().from(survey)
             .orderBy(survey.name.asc().nullsFirst())
             .select(survey.name).fetch());
     }
 
     @Test
     public void order_nullsLast() {
-        assertEquals(Arrays.asList("Hello World"), query().from(survey)
+        assertEquals(Collections.singletonList("Hello World"), query().from(survey)
             .orderBy(survey.name.asc().nullsLast())
             .select(survey.name).fetch());
     }
@@ -1378,7 +1378,7 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void path_in_constant_list() {
-        assertEquals(0, query().from(survey).where(survey.name.in(Arrays.asList("a"))).fetchCount());
+        assertEquals(0, query().from(survey).where(survey.name.in(Collections.singletonList("a"))).fetchCount());
         assertEquals(0, query().from(survey).where(survey.name.in(Arrays.asList("a","b"))).fetchCount());
         assertEquals(0, query().from(survey).where(survey.name.in(Arrays.asList("a","b","c"))).fetchCount());
     }
@@ -1815,7 +1815,7 @@ public class SelectBase extends AbstractBaseTest {
     @Test
     public void templateExpression() {
         NumberExpression<Integer> one = Expressions.numberTemplate(Integer.class, "1");
-        assertEquals(Arrays.asList(1), query().from(survey).select(one.as("col1")).fetch());
+        assertEquals(Collections.singletonList(1), query().from(survey).select(one.as("col1")).fetch());
     }
 
     @Test

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectWindowFunctionsBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectWindowFunctionsBase.java
@@ -5,6 +5,7 @@ import static com.querydsl.sql.Constants.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -92,7 +93,7 @@ public class SelectWindowFunctionsBase extends AbstractBaseTest {
         System.out.println("#4");
         SQLQuery<Tuple> sub3 = query().from(employee).select(employee.firstname, employee.lastname, rowNumber);
         for (Tuple row : query().from(sub3.as(employee2)).select(employee2.firstname, employee2.lastname).fetch()) {
-            System.out.println(Arrays.asList(row));
+            System.out.println(Collections.singletonList(row));
         }
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/StoredProcedures.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/StoredProcedures.java
@@ -22,12 +22,10 @@ public final class StoredProcedures {
     public static void main(String[] args) throws ClassNotFoundException, SQLException {
         Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
         String url = "jdbc:derby:target/procedure_test;create=true";
-        Connection connection = DriverManager.getConnection(url, "", "");
 
-        try {
+        try (Connection connection = DriverManager.getConnection(url, "", "")) {
             DatabaseMetaData md = connection.getMetaData();
-            ResultSet procedures = md.getProcedures(null, null, null);
-            try {
+            try (ResultSet procedures = md.getProcedures(null, null, null)) {
                 while (procedures.next()) {
                     String cat = procedures.getString(1);
                     String schema = procedures.getString(2);
@@ -37,8 +35,7 @@ public final class StoredProcedures {
                     String specificName = procedures.getString(9);
                     System.out.println(name + "\n" + remarks + "\n" + type + "\n" + specificName);
 
-                    ResultSet procedureColumns = md.getProcedureColumns(cat, schema, name, null);
-                    try {
+                    try (ResultSet procedureColumns = md.getProcedureColumns(cat, schema, name, null)) {
                         while (procedureColumns.next()) {
                             String columnName = procedureColumns.getString(4);
                             int columnType = procedureColumns.getInt(5);
@@ -48,15 +45,9 @@ public final class StoredProcedures {
                             System.out.println(" " + columnName + " " + columnType + " " + dataType + " " + typeName + " " + nullable);
                         }
                         System.out.println();
-                    } finally {
-                        procedureColumns.close();
                     }
                 }
-            } finally {
-                procedures.close();
             }
-        } finally {
-            connection.close();
         }
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/TypesBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/TypesBase.java
@@ -60,8 +60,7 @@ public class TypesBase extends AbstractBaseTest {
         DatabaseMetaData md = conn.getMetaData();
 
         // types
-        ResultSet rs = md.getUDTs(null, null, null, null);
-        try {
+        try (ResultSet rs = md.getUDTs(null, null, null, null)) {
             while (rs.next()) {
                 // cat, schema, name, classname, datatype, remarks, base_type
                 String cat = rs.getString(1);
@@ -72,11 +71,10 @@ public class TypesBase extends AbstractBaseTest {
                 String remarks = rs.getString(6);
                 String baseType = rs.getString(7);
                 System.out.println(name + " " + classname + " " + datatype + " " +
-                                   remarks + " " + baseType);
+                        remarks + " " + baseType);
 
                 // attributes
-                ResultSet rs2 = md.getAttributes(cat, schema, name, null);
-                try {
+                try (ResultSet rs2 = md.getAttributes(cat, schema, name, null)) {
                     while (rs2.next()) {
                         // cat, schema, name, attr_name, data_type, attr_type_name, attr_size
                         // decimal_digits, num_prec_radix, nullable, remarks, attr_def, sql_data_type, ordinal_position
@@ -91,12 +89,8 @@ public class TypesBase extends AbstractBaseTest {
 
                         System.out.println(" " + attrName2 + " " + dataType2 + " " + attrTypeName2 + " " + attrSize2);
                     }
-                } finally {
-                    rs2.close();
                 }
             }
-        } finally {
-            rs.close();
         }
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/TypesDump.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/TypesDump.java
@@ -25,8 +25,7 @@ public final class TypesDump {
             Connection c = Connections.getConnection();
             DatabaseMetaData m = c.getMetaData();
             System.out.println(m.getDatabaseProductName());
-            ResultSet rs = m.getTypeInfo();
-            try {
+            try (ResultSet rs = m.getTypeInfo()) {
                 while (rs.next()) {
                     String name = rs.getString("TYPE_NAME");
                     int jdbcType = rs.getInt("DATA_TYPE");
@@ -39,8 +38,6 @@ public final class TypesDump {
                         //System.out.println(rs.getInt("PRECISION"));
                     }
                 }
-            } finally {
-                rs.close();
             }
         } finally {
             Connections.close();

--- a/querydsl-sql/src/test/java/com/querydsl/sql/UnionBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/UnionBase.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Ignore;
@@ -169,7 +169,7 @@ public class UnionBase extends AbstractBaseTest {
                 .select(employee.id, employee.firstname, null, null);
         List<Tuple> results = query().union(sq1, sq2).orderBy(employee.id.asc()).fetch();
         for (Tuple result : results) {
-            System.err.println(Arrays.asList(result));
+            System.err.println(Collections.singletonList(result));
         }
     }
 
@@ -203,14 +203,11 @@ public class UnionBase extends AbstractBaseTest {
         SubQueryExpression<Tuple> sq1 = query().from(employee).select(employee.id.max(), employee.id.max().subtract(1));
         SubQueryExpression<Tuple> sq2 = query().from(employee).select(employee.id.min(), employee.id.min().subtract(1));
 
-        CloseableIterator<Tuple> iterator = query().union(sq1,sq2).iterate();
-        try {
+        try (CloseableIterator<Tuple> iterator = query().union(sq1, sq2).iterate()) {
             assertTrue(iterator.hasNext());
             assertTrue(iterator.next() != null);
             assertTrue(iterator.next() != null);
             assertFalse(iterator.hasNext());
-        } finally {
-            iterator.close();
         }
     }
 
@@ -232,14 +229,11 @@ public class UnionBase extends AbstractBaseTest {
         SubQueryExpression<Integer> sq1 = query().from(employee).select(employee.id.max());
         SubQueryExpression<Integer> sq2 = query().from(employee).select(employee.id.min());
 
-        CloseableIterator<Integer> iterator = query().union(sq1,sq2).iterate();
-        try {
+        try (CloseableIterator<Integer> iterator = query().union(sq1, sq2).iterate()) {
             assertTrue(iterator.hasNext());
             assertTrue(iterator.next() != null);
             assertTrue(iterator.next() != null);
             assertFalse(iterator.hasNext());
-        } finally {
-            iterator.close();
         }
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/ddl/CreateTableClause.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/ddl/CreateTableClause.java
@@ -194,9 +194,7 @@ public class CreateTableClause {
         builder.append("\n)\n");
         logger.info(builder.toString());
 
-        Statement stmt = null;
-        try {
-            stmt = connection.createStatement();
+        try (Statement stmt = connection.createStatement()) {
             stmt.execute(builder.toString());
 
             // indexes
@@ -213,14 +211,6 @@ public class CreateTableClause {
         } catch (SQLException e) {
             System.err.println(builder.toString());
             throw new QueryException(e.getMessage(), e);
-        } finally {
-            if (stmt != null) {
-                try {
-                    stmt.close();
-                } catch (SQLException e) {
-                    throw new QueryException(e);
-                }
-            }
         }
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/ddl/CreateTableClause.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/ddl/CreateTableClause.java
@@ -156,14 +156,14 @@ public class CreateTableClause {
     @SuppressWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
     public void execute() {
         StringBuilder builder = new StringBuilder();
-        builder.append(templates.getCreateTable() + table + " (\n");
+        builder.append(templates.getCreateTable()).append(table).append(" (\n");
         List<String> lines = new ArrayList<String>(columns.size() + foreignKeys.size() + 1);
         // columns
         for (ColumnData column : columns) {
             StringBuilder line = new StringBuilder();
-            line.append(column.getName() + " " + column.getType().toUpperCase());
+            line.append(column.getName()).append(" ").append(column.getType().toUpperCase());
             if (column.getSize() != null) {
-                line.append("(" + column.getSize() + ")");
+                line.append("(").append(column.getSize()).append(")");
             }
             if (!column.isNullAllowed()) {
                 line.append(templates.getNotNull().toUpperCase());
@@ -177,20 +177,20 @@ public class CreateTableClause {
         // primary key
         if (primaryKey != null) {
             StringBuilder line = new StringBuilder();
-            line.append("CONSTRAINT " + primaryKey.getName() + " ");
-            line.append("PRIMARY KEY(" + COMMA_JOINER.join(primaryKey.getColumns()) + ")");
+            line.append("CONSTRAINT ").append(primaryKey.getName()).append(" ");
+            line.append("PRIMARY KEY(").append(COMMA_JOINER.join(primaryKey.getColumns())).append(")");
             lines.add(line.toString());
         }
 
         // foreign keys
         for (ForeignKeyData foreignKey : foreignKeys) {
             StringBuilder line = new StringBuilder();
-            line.append("CONSTRAINT " + foreignKey.getName() + " ");
-            line.append("FOREIGN KEY(" + COMMA_JOINER.join(foreignKey.getForeignColumns()) + ") ");
-            line.append("REFERENCES " + foreignKey.getTable() + "(" + COMMA_JOINER.join(foreignKey.getParentColumns()) + ")");
+            line.append("CONSTRAINT ").append(foreignKey.getName()).append(" ");
+            line.append("FOREIGN KEY(").append(COMMA_JOINER.join(foreignKey.getForeignColumns())).append(") ");
+            line.append("REFERENCES ").append(foreignKey.getTable()).append("(").append(COMMA_JOINER.join(foreignKey.getParentColumns())).append(")");
             lines.add(line.toString());
         }
-        builder.append("  " + Joiner.on(",\n  ").join(lines));
+        builder.append("  ").append(Joiner.on(",\n  ").join(lines));
         builder.append("\n)\n");
         logger.info(builder.toString());
 


### PR DESCRIPTION
_This pull request is a work in progress. I am also awaiting the very first CI results. I expect a couple of issues still._

# Changelog

## 5.0.0

### Breaking changes

* Java 8 minimal requirement. If you still rely on Java <7, please use the latest 4.x.x version.
* Removed bridge method that were in place for backwards compatibility of legacy API's. This may lead to some breaking API changes.

### New features

* Added `Fetchable#stream()` which returns a `Stream<T>`. _Make sure that the returned stream is always closed to free up resources, for example using try-with-resources. It does **not** suffice to rely on a terminating operation on the stream for this (i.e. `forEach`, `collect`)._

### Dependency updates

* `cglib` to 3.3.0 for Java 8+ support
* `asm` to 9.0 for Java 8+ support
* DataNucleus 5.2.x for Java 8+ support
  * JDO now uses `org.datanucleus:javax.jdo` instead of `javax.jdo:jdo-api`. Seems more widely used and also got more recently updated.

### Plans

- [x] Require Java 8
- [x] Optimize code for Java 8 (use new API's)
- [x] Switch out Guava's Optional with Java 8's `Optional`.
- [x] Add `Fetchable#stream`
- [x] Add tests for `Fetchable#stream` (in particular Hibernate and plain JPA)


