### PR TITLE
[#2479] Migrate off of JSR305

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ A huge thanks goes out to all contributors that made this release possible in th
   The `joda-time` types will still be registered automatically if they are on the classpath.
 * [#2215](https://github.com/querydsl/querydsl/issues/2215) - MongoDB 4 support through the Document API 
 * [#2697](https://github.com/querydsl/querydsl/issues/2697) - Allow `com.querydsl.core.alias.Alias.*` to be used on a JRE by relying on ECJ as compiler
+* [#2479](https://github.com/querydsl/querydsl/issues/2479) - Swap out JSR305 for Jetbrains Annotations.
 
 #### Bugfixes
 
@@ -56,6 +57,7 @@ A huge thanks goes out to all contributors that made this release possible in th
 * This release targets Hibernate 5 in the Hibernate integration. If you need Hibernate 4 dialect specific workarounds, use the `HQLTemplates` instead of the `Hibernate5Templates`.
 * Removal of various deprecated methods.
 * `joda-time` is now an optional dependency. If your application relies on `joda-time` make sure to specify it as a direct dependency rather than relying on QueryDSL to include it transitively.
+* `com.google.code.findbugs:jsr305` is no longer a dependency. If your application currently relies on QueryDSL shipping JSR305 transitivily, you should add JSR305 as a direct dependency to your project.
 
 #### Dependency updates
 

--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -35,6 +35,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
       <version>2.2.3</version>

--- a/querydsl-apt/src/main/java/com/querydsl/apt/Configuration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/Configuration.java
@@ -20,7 +20,7 @@ import com.querydsl.codegen.SerializerConfig;
 import com.querydsl.codegen.TypeMappings;
 import com.querydsl.core.util.Annotations;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;

--- a/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
@@ -33,8 +33,8 @@ import com.querydsl.core.types.Expression;
 import com.querydsl.core.util.Annotations;
 import com.querydsl.core.util.StringUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
@@ -89,10 +89,10 @@ public class DefaultConfiguration implements Configuration {
 
     protected final Class<? extends Annotation> entityAnn;
 
-    @Nonnull
+    @NotNull
     private final Set<String> excludedPackages, excludedClasses;
 
-    @Nonnull
+    @NotNull
     private final Set<String> includedPackages, includedClasses;
 
     @Nullable
@@ -524,7 +524,7 @@ public class DefaultConfiguration implements Configuration {
     }
 
     @Override
-    public boolean isExcludedPackage(@Nonnull String packageName) {
+    public boolean isExcludedPackage(@NotNull String packageName) {
         if (!includedPackages.isEmpty()) {
             boolean included = false;
             for (String includedPackage : includedPackages) {
@@ -548,7 +548,7 @@ public class DefaultConfiguration implements Configuration {
     }
 
     @Override
-    public boolean isExcludedClass(@Nonnull String className) {
+    public boolean isExcludedClass(@NotNull String className) {
         if (!includedClasses.isEmpty() && !includedClasses.contains(className)) {
             return true;
         } else {

--- a/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
@@ -26,7 +26,7 @@ import com.querydsl.codegen.Supertype;
 import com.querydsl.codegen.TypeMappings;
 import com.querydsl.core.annotations.QueryExclude;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;

--- a/querydsl-codegen/pom.xml
+++ b/querydsl-codegen/pom.xml
@@ -29,6 +29,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>codegen-utils</artifactId>
       <version>${project.version}</version>

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
@@ -19,7 +19,6 @@ import com.querydsl.codegen.utils.model.Type;
 import com.querydsl.codegen.utils.model.TypeAdapter;
 import com.querydsl.codegen.utils.model.TypeCategory;
 
-import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
-
+import org.jetbrains.annotations.Nullable;
 /**
  * {@code EntityType} represents a model of a query domain type with properties
  *

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
@@ -20,6 +20,13 @@ import com.querydsl.codegen.utils.model.Parameter;
 import com.querydsl.codegen.utils.model.Type;
 import com.querydsl.codegen.utils.model.TypeCategory;
 import com.querydsl.codegen.utils.support.ClassUtils;
+import java.io.*;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.nio.charset.Charset;
+import java.util.*;
+
+import org.jetbrains.annotations.Nullable;
 import com.querydsl.core.QueryException;
 import com.querydsl.core.annotations.Config;
 import com.querydsl.core.annotations.PropertyType;
@@ -36,7 +43,6 @@ import com.querydsl.core.util.Annotations;
 import com.querydsl.core.util.BeanUtils;
 import com.querydsl.core.util.ReflectionUtils;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/Supertype.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/Supertype.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.codegen;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.codegen.utils.model.Type;
 

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/TypeMappings.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/TypeMappings.java
@@ -17,7 +17,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.codegen.utils.model.*;
 import com.querydsl.core.types.Expression;

--- a/querydsl-collections/pom.xml
+++ b/querydsl-collections/pom.xml
@@ -29,6 +29,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
       <version>${project.version}</version>

--- a/querydsl-collections/src/main/java/com/querydsl/collections/CollQueryFunctions.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/CollQueryFunctions.java
@@ -18,7 +18,7 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Operator;

--- a/querydsl-collections/src/main/java/com/querydsl/collections/DefaultEvaluatorFactory.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/DefaultEvaluatorFactory.java
@@ -35,8 +35,8 @@ import com.querydsl.core.types.ParamExpression;
 import com.querydsl.core.types.ParamNotSetException;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.util.PrimitiveUtils;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import java.net.URLClassLoader;

--- a/querydsl-core/pom.xml
+++ b/querydsl-core/pom.xml
@@ -24,10 +24,11 @@
   
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
-    </dependency>          
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.mysema.commons</groupId>
       <artifactId>mysema-commons-lang</artifactId>

--- a/querydsl-core/src/main/java/com/querydsl/core/BooleanBuilder.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/BooleanBuilder.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/DefaultQueryMetadata.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/DefaultQueryMetadata.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.util.CollectionUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/JoinExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/JoinExpression.java
@@ -18,8 +18,8 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Predicate;

--- a/querydsl-core/src/main/java/com/querydsl/core/JoinFlag.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/JoinFlag.java
@@ -15,7 +15,7 @@ package com.querydsl.core;
 
 import java.io.Serializable;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/QueryMetadata.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/QueryMetadata.java
@@ -18,12 +18,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.ParamExpression;
 import com.querydsl.core.types.Predicate;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * {@code QueryMetadata} defines query metadata such as query sources, filtering
@@ -105,6 +106,7 @@ public interface QueryMetadata extends Serializable {
      *
      * @return group by
      */
+    @Unmodifiable
     List<Expression<?>> getGroupBy();
 
     /**
@@ -120,6 +122,7 @@ public interface QueryMetadata extends Serializable {
      *
      * @return joins
      */
+    @Unmodifiable
     List<JoinExpression> getJoins();
 
     /**
@@ -134,6 +137,7 @@ public interface QueryMetadata extends Serializable {
      *
      * @return order by
      */
+    @Unmodifiable
     List<OrderSpecifier<?>> getOrderBy();
 
     /**
@@ -149,6 +153,7 @@ public interface QueryMetadata extends Serializable {
      *
      * @return parameter bindings
      */
+    @Unmodifiable
     Map<ParamExpression<?>,Object> getParams();
 
     /**
@@ -257,6 +262,7 @@ public interface QueryMetadata extends Serializable {
      *
      * @return all used query flags
      */
+    @Unmodifiable
     Set<QueryFlag> getFlags();
 
     /**

--- a/querydsl-core/src/main/java/com/querydsl/core/QueryModifiers.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/QueryModifiers.java
@@ -17,8 +17,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
-import javax.annotation.Nonnegative;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Range;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code QueryModifiers} combines limit and offset info into a single immutable value type.
@@ -42,11 +42,11 @@ public final class QueryModifiers implements Serializable {
         }
     }
 
-    public static QueryModifiers limit(@Nonnegative long limit) {
+    public static QueryModifiers limit(@Range(from = 0, to = Integer.MAX_VALUE) long limit) {
         return new QueryModifiers(limit, null);
     }
 
-    public static QueryModifiers offset(@Nonnegative long offset) {
+    public static QueryModifiers offset(@Range(from = 0, to = Integer.MAX_VALUE) long offset) {
         return new QueryModifiers(null, offset);
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/QueryResults.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/QueryResults.java
@@ -17,7 +17,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code QueryResults} bundles data for paged query results

--- a/querydsl-core/src/main/java/com/querydsl/core/SimpleQuery.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/SimpleQuery.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core;
 
-import javax.annotation.Nonnegative;
+import org.jetbrains.annotations.Range;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.ParamExpression;
@@ -34,7 +34,7 @@ public interface SimpleQuery<Q extends SimpleQuery<Q>> extends FilteredClause<Q>
      * @param limit max rows
      * @return the current object
      */
-    Q limit(@Nonnegative long limit);
+    Q limit(@Range(from = 0, to = Integer.MAX_VALUE) long limit);
 
     /**
      * Set the offset for the query results
@@ -42,7 +42,7 @@ public interface SimpleQuery<Q extends SimpleQuery<Q>> extends FilteredClause<Q>
      * @param offset row offset
      * @return the current object
      */
-    Q offset(@Nonnegative long offset);
+    Q offset(@Range(from = 0, to = Integer.MAX_VALUE) long offset);
 
     /**
      * Set both limit and offset of the query results

--- a/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Tuple.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/alias/Alias.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/alias/Alias.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;

--- a/querydsl-core/src/main/java/com/querydsl/core/alias/AliasFactory.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/alias/AliasFactory.java
@@ -19,8 +19,8 @@ import com.querydsl.core.types.Path;
 import com.querydsl.core.types.PathMetadataFactory;
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.MethodInterceptor;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;

--- a/querydsl-core/src/main/java/com/querydsl/core/alias/MethodType.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/alias/MethodType.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Path;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/alias/PropertyAccessInvocationHandler.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/alias/PropertyAccessInvocationHandler.java
@@ -25,7 +25,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.util.BeanUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/annotations/Immutable.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/annotations/Immutable.java
@@ -1,0 +1,18 @@
+package com.querydsl.core.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code Immutable} marks a class as immutable
+ *
+ * @author Jan-Willem Gmelig Meyling
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+public @interface Immutable {
+}

--- a/querydsl-core/src/main/java/com/querydsl/core/dml/StoreClause.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/dml/StoreClause.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.dml;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;

--- a/querydsl-core/src/main/java/com/querydsl/core/support/ConstantHidingExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/ConstantHidingExpression.java
@@ -16,7 +16,7 @@ package com.querydsl.core.support;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.Expressions;

--- a/querydsl-core/src/main/java/com/querydsl/core/support/FetchableQueryBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/FetchableQueryBase.java
@@ -15,7 +15,7 @@ package com.querydsl.core.support;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;

--- a/querydsl-core/src/main/java/com/querydsl/core/support/QueryBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/QueryBase.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.support;
 
-import javax.annotation.Nonnegative;
+import org.jetbrains.annotations.Range;
 
 import com.querydsl.core.QueryModifiers;
 import com.querydsl.core.types.Expression;
@@ -139,7 +139,7 @@ public abstract class QueryBase<Q extends QueryBase<Q>> {
      * @param limit max rows
      * @return the current object
      */
-    public Q limit(@Nonnegative long limit) {
+    public Q limit(@Range(from = 0, to = Integer.MAX_VALUE) long limit) {
         return queryMixin.limit(limit);
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/support/QueryMixin.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/QueryMixin.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.support;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.*;
 import com.querydsl.core.types.*;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/AppendingFactoryExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/AppendingFactoryExpression.java
@@ -17,7 +17,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 class AppendingFactoryExpression<T> extends FactoryExpressionBase<T> {
 
@@ -25,6 +26,7 @@ class AppendingFactoryExpression<T> extends FactoryExpressionBase<T> {
 
     private final Expression<T> base;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     protected AppendingFactoryExpression(Expression<T> base, Expression<?>... rest) {
@@ -37,6 +39,7 @@ class AppendingFactoryExpression<T> extends FactoryExpressionBase<T> {
     }
 
     @Override
+    @Unmodifiable
     public List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ArrayConstructorExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ArrayConstructorExpression.java
@@ -19,7 +19,8 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * {@code ArrayConstructorExpression} extends {@link FactoryExpressionBase} to represent array initializers
@@ -35,6 +36,7 @@ public class ArrayConstructorExpression<T> extends FactoryExpressionBase<T[]> {
 
     private final Class<T> elementType;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     @SuppressWarnings("unchecked")
@@ -71,6 +73,7 @@ public class ArrayConstructorExpression<T> extends FactoryExpressionBase<T[]> {
     }
 
     @Override
+    @Unmodifiable
     public List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ConstantImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ConstantImpl.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 /**
  * {@code ConstantImpl} is the default implementation of the {@link Constant} interface

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ConstructorExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ConstructorExpression.java
@@ -13,7 +13,6 @@
  */
 package com.querydsl.core.types;
 
-import javax.annotation.concurrent.Immutable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.reflect.Constructor;
@@ -27,6 +26,8 @@ import java.util.function.Function;
 import static com.querydsl.core.util.ConstructorUtils.getConstructor;
 import static com.querydsl.core.util.ConstructorUtils.getConstructorParameters;
 import static com.querydsl.core.util.ConstructorUtils.getTransformers;
+import com.querydsl.core.annotations.Immutable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * {@code ConstructorExpression} represents a constructor invocation
@@ -60,6 +61,7 @@ public class ConstructorExpression<T> extends FactoryExpressionBase<T> {
         return paramTypes;
     }
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     private final Class<?>[] parameterTypes;
@@ -127,6 +129,7 @@ public class ConstructorExpression<T> extends FactoryExpressionBase<T> {
     }
 
     @Override
+    @Unmodifiable
     public final List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/Expression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/Expression.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types;
 
 import java.io.Serializable;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code Expression} defines a general typed expression in a Query instance. The generic type parameter

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionBase.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code ExpressionBase} is the base class for immutable {@link Expression} implementations

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionUtils.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types;
 
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.QueryException;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpression.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code FactoryExpression} represents factory expressions such as JavaBean or

--- a/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/FactoryExpressionBase.java
@@ -13,9 +13,9 @@
  */
 package com.querydsl.core.types;
 
-import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Common superclass for {@link FactoryExpression} implementations

--- a/querydsl-core/src/main/java/com/querydsl/core/types/MappingProjection.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/MappingProjection.java
@@ -15,8 +15,8 @@ package com.querydsl.core.types;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.Tuple;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/Operation.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/Operation.java
@@ -13,6 +13,8 @@
  */
 package com.querydsl.core.types;
 
+import org.jetbrains.annotations.Unmodifiable;
+
 import java.util.List;
 
 /**
@@ -36,6 +38,7 @@ public interface Operation<T> extends Expression<T> {
      *
      * @return arguments
      */
+    @Unmodifiable
     List<Expression<?>> getArgs();
 
     /**

--- a/querydsl-core/src/main/java/com/querydsl/core/types/OperationImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/OperationImpl.java
@@ -16,10 +16,11 @@ package com.querydsl.core.types;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.util.CollectionUtils;
 import com.querydsl.core.util.PrimitiveUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * {@code OperationImpl} is the default implementation of the {@link Operation} interface
@@ -33,6 +34,7 @@ public class OperationImpl<T> extends ExpressionBase<T> implements Operation<T> 
 
     private static final long serialVersionUID = 4796432056083507588L;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     private final Operator operator;
@@ -57,6 +59,7 @@ public class OperationImpl<T> extends ExpressionBase<T> implements Operation<T> 
     }
 
     @Override
+    @Unmodifiable
     public final List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/OrderSpecifier.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/OrderSpecifier.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types;
 
 import java.io.Serializable;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 /**
  * {@code OrderSpecifier} represents an order-by-element in a Query instance

--- a/querydsl-core/src/main/java/com/querydsl/core/types/ParamExpressionImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/ParamExpressionImpl.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types;
 
 import java.util.UUID;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 /**
  * {@code ParamExpressionImpl} defines a parameter in a query with an optional name

--- a/querydsl-core/src/main/java/com/querydsl/core/types/PathImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/PathImpl.java
@@ -15,8 +15,8 @@ package com.querydsl.core.types;
 
 import java.lang.reflect.AnnotatedElement;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.util.ReflectionUtils;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/PathMetadata.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/PathMetadata.java
@@ -16,8 +16,8 @@ package com.querydsl.core.types;
 import java.io.Serializable;
 import java.util.Objects;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 /**
  * {@code PathMetadata} provides metadata for {@link Path} expressions.

--- a/querydsl-core/src/main/java/com/querydsl/core/types/PathMetadataFactory.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/PathMetadataFactory.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types;
 
-import javax.annotation.Nonnegative;
+import org.jetbrains.annotations.Range;
 
 /**
  * {@code PathMetadataFactory} is a factory class for {@link Path} construction
@@ -41,7 +41,7 @@ public final class PathMetadataFactory {
      * @param index index of element
      * @return array access path
      */
-    public static PathMetadata forArrayAccess(Path<?> parent, @Nonnegative int index) {
+    public static PathMetadata forArrayAccess(Path<?> parent, @Range(from = 0, to = Integer.MAX_VALUE) int index) {
         return new PathMetadata(parent, index, PathType.ARRAYVALUE_CONSTANT);
     }
 
@@ -83,7 +83,7 @@ public final class PathMetadataFactory {
      * @param index index of element
      * @return list access path
      */
-    public static PathMetadata forListAccess(Path<?> parent, @Nonnegative int index) {
+    public static PathMetadata forListAccess(Path<?> parent, @Range(from = 0, to = Integer.MAX_VALUE) int index) {
         return new PathMetadata(parent, index, PathType.LISTVALUE_CONSTANT);
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/PredicateOperation.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/PredicateOperation.java
@@ -13,8 +13,8 @@
  */
 package com.querydsl.core.types;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 import java.util.List;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/PredicateTemplate.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/PredicateTemplate.java
@@ -13,8 +13,8 @@
  */
 package com.querydsl.core.types;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 import java.util.List;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/QList.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/QList.java
@@ -18,9 +18,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.util.CollectionUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * {@code QList} represents a projection of type List
@@ -32,6 +33,7 @@ public class QList extends FactoryExpressionBase<List<?>> {
 
     private static final long serialVersionUID = -7545994090073480810L;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     /**
@@ -78,6 +80,7 @@ public class QList extends FactoryExpressionBase<List<?>> {
     }
 
     @Override
+    @Unmodifiable
     public List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/QMap.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/QMap.java
@@ -22,7 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * {@code QMap} represents a projection of type Map
@@ -45,6 +46,7 @@ public class QMap extends FactoryExpressionBase<Map<Expression<?>,?>> {
 
     private static final long serialVersionUID = -7545994090073480810L;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     /**
@@ -91,6 +93,7 @@ public class QMap extends FactoryExpressionBase<Map<Expression<?>,?>> {
     }
 
     @Override
+    @Unmodifiable
     public List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/QTuple.java
@@ -21,10 +21,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.util.CollectionUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * {@code QTuple} represents a projection of type {@link Tuple}
@@ -129,6 +130,7 @@ public class QTuple extends FactoryExpressionBase<Tuple> {
 
     private static final long serialVersionUID = -2640616030595420465L;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     private final Map<Expression<?>, Integer> bindings;
@@ -191,6 +193,7 @@ public class QTuple extends FactoryExpressionBase<Tuple> {
     }
 
     @Override
+    @Unmodifiable
     public List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/SubQueryExpressionImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/SubQueryExpressionImpl.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.QueryMetadata;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/Template.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/Template.java
@@ -17,7 +17,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.util.CollectionUtils;
 import com.querydsl.core.util.MathUtils;
 
-import javax.annotation.concurrent.Immutable;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Collections;
@@ -25,6 +24,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+
+import com.querydsl.core.annotations.Immutable;
 
 /**
  * {@code Template} provides serialization templates for {@link Operation},

--- a/querydsl-core/src/main/java/com/querydsl/core/types/TemplateExpressionImpl.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/TemplateExpressionImpl.java
@@ -16,9 +16,10 @@ package com.querydsl.core.types;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.util.CollectionUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * Default implementation of the {@link TemplateExpression} interface
@@ -32,6 +33,7 @@ public class TemplateExpressionImpl<T> extends ExpressionBase<T> implements Temp
 
     private static final long serialVersionUID = 6951623726800809083L;
 
+    @Unmodifiable
     private final List<?> args;
 
     private final Template template;
@@ -52,6 +54,7 @@ public class TemplateExpressionImpl<T> extends ExpressionBase<T> implements Temp
     }
 
     @Override
+    @Unmodifiable
     public final List<?> getArgs() {
         return args;
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/Templates.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/Templates.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code Templates} provides operator patterns for query expression serialization

--- a/querydsl-core/src/main/java/com/querydsl/core/types/Visitor.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/Visitor.java
@@ -13,6 +13,8 @@
  */
 package com.querydsl.core.types;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * {@code Visitor} defines a visitor signature for {@link Expression} instances.
  *
@@ -30,7 +32,7 @@ public interface Visitor<R, C> {
      * @param context context of the visit or null, if not used
      * @return visit result
      */
-    R visit(Constant<?> expr, C context);
+    R visit(Constant<?> expr, @Nullable C context);
 
     /**
      * Visit a FactoryExpression instance with the given context
@@ -39,7 +41,7 @@ public interface Visitor<R, C> {
      * @param context context of the visit or null, if not used
      * @return visit result
      */
-    R visit(FactoryExpression<?> expr, C context);
+    R visit(FactoryExpression<?> expr, @Nullable C context);
 
     /**
      * Visit an Operation instance with the given context
@@ -48,7 +50,7 @@ public interface Visitor<R, C> {
      * @param context context of the visit or null, if not used
      * @return visit result
      */
-    R visit(Operation<?> expr, C context);
+    R visit(Operation<?> expr, @Nullable C context);
 
     /**
      * Visit a ParamExpression instance with the given context
@@ -57,7 +59,7 @@ public interface Visitor<R, C> {
      * @param context context of the visit or null, if not used
      * @return visit result
      */
-    R visit(ParamExpression<?> expr, C context);
+    R visit(ParamExpression<?> expr, @Nullable C context);
 
     /**
      * Visit a Path instance with the given context
@@ -66,7 +68,7 @@ public interface Visitor<R, C> {
      * @param context context of the visit or null, if not used
      * @return visit result
      */
-    R visit(Path<?> expr, C context);
+    R visit(Path<?> expr, @Nullable C context);
 
     /**
      * Visit a SubQueryExpression instance with the given context
@@ -75,7 +77,7 @@ public interface Visitor<R, C> {
      * @param context context of the visit or null, if not used
      * @return visit result
      */
-    R visit(SubQueryExpression<?> expr, C context);
+    R visit(SubQueryExpression<?> expr, @Nullable C context);
 
     /**
      * Visit a TemplateExpression instance with the given context
@@ -84,6 +86,6 @@ public interface Visitor<R, C> {
      * @param context context of the visit or null, if not used
      * @return visit result
      */
-    R visit(TemplateExpression<?> expr, C context);
+    R visit(TemplateExpression<?> expr, @Nullable C context);
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ArrayExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ArrayExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types.dsl;
 
-import javax.annotation.Nonnegative;
+import org.jetbrains.annotations.Range;
 
 import com.querydsl.core.types.Expression;
 
@@ -54,6 +54,6 @@ public interface ArrayExpression<A, T> extends Expression<A> {
      * @param index zero based index
      * @return element at index
      */
-    SimpleExpression<T> get(@Nonnegative int index);
+    SimpleExpression<T> get(@Range(from = 0, to = Integer.MAX_VALUE) int index);
 
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ArrayPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ArrayPath.java
@@ -23,9 +23,10 @@ import com.querydsl.core.types.PathMetadataFactory;
 import com.querydsl.core.types.Visitor;
 import com.querydsl.core.util.PrimitiveUtils;
 
-import javax.annotation.Nonnegative;
-import javax.annotation.Nullable;
 import java.lang.reflect.AnnotatedElement;
+
+import org.jetbrains.annotations.Range;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code ArrayPath} represents an array typed path
@@ -73,7 +74,7 @@ public class ArrayPath<A, E> extends SimpleExpression<A> implements Path<A>, Arr
     }
 
     @Override
-    public SimplePath<E> get(@Nonnegative int index) {
+    public SimplePath<E> get(@Range(from = 0, to = Integer.MAX_VALUE) int index) {
         PathMetadata md = PathMetadataFactory.forArrayAccess(pathMixin, index);
         return Expressions.path(componentType, md);
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BeanPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BeanPath.java
@@ -18,7 +18,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types.dsl;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CaseBuilder.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CaseBuilder.java
@@ -18,7 +18,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CaseForEqBuilder.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CaseForEqBuilder.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionExpressionBase.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types.dsl;
 
 import java.util.Collection;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionOperation.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionOperation.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionPath.java
@@ -16,7 +16,7 @@ package com.querydsl.core.types.dsl;
 import java.lang.reflect.AnnotatedElement;
 import java.util.Collection;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionPathBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/CollectionPathBase.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.ExpressionException;
 import com.querydsl.core.types.Path;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types.dsl;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types.dsl;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateExpression.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types.dsl;
 
 import java.util.Date;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateTimeExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateTimeExpression.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types.dsl;
 
 import java.util.Date;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EntityPathBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EntityPathBase.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types.dsl;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Path;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ListExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ListExpression.java
@@ -15,10 +15,9 @@ package com.querydsl.core.types.dsl;
 
 import java.util.List;
 
-import javax.annotation.Nonnegative;
-
 import com.querydsl.core.types.CollectionExpression;
 import com.querydsl.core.types.Expression;
+import org.jetbrains.annotations.Range;
 
 /**
  * {@code ListExpression} represents {@link java.util.List} typed expressions
@@ -47,5 +46,5 @@ public interface ListExpression<E, Q extends SimpleExpression<? super E>> extend
      * @return this.get(index)
      * @see java.util.List#get(int)
      */
-    Q get(@Nonnegative int index);
+    Q get(@Range(from = 0, to = Integer.MAX_VALUE) int index);
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ListPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ListPath.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/LiteralExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/LiteralExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types.dsl;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/MapExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/MapExpressionBase.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types.dsl;
 
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/MapPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/MapPath.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -16,7 +16,7 @@ package com.querydsl.core.types.dsl;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.Ops.MathOps;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SetPath.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SetPath.java
@@ -16,7 +16,7 @@ package com.querydsl.core.types.dsl;
 import java.lang.reflect.AnnotatedElement;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
@@ -16,7 +16,7 @@ package com.querydsl.core.types.dsl;
 import java.util.Arrays;
 import java.util.Collection;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.util.CollectionUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core.types.dsl;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TimeExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TimeExpression.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types.dsl;
 
 import java.sql.Time;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;

--- a/querydsl-core/src/main/java/com/querydsl/core/util/Annotations.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/Annotations.java
@@ -18,7 +18,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Annotations is a merging adapter for the {@link AnnotatedElement} interface

--- a/querydsl-core/src/main/java/com/querydsl/core/util/ConstructorUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/ConstructorUtils.java
@@ -15,7 +15,6 @@ package com.querydsl.core.util;
 
 import com.querydsl.core.types.ExpressionException;
 
-import javax.annotation.Nullable;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -29,6 +28,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jetbrains.annotations.Nullable;
 import static com.querydsl.core.util.ArrayUtils.isEmpty;
 
 /**

--- a/querydsl-core/src/main/java/com/querydsl/core/util/MultiIterator.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/MultiIterator.java
@@ -18,7 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * MultiIterator provides a cartesian view on the given iterators

--- a/querydsl-core/src/main/java/com/querydsl/core/util/ReflectionUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/ReflectionUtils.java
@@ -16,7 +16,7 @@ package com.querydsl.core.util;
 import java.lang.reflect.*;
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 
 /**

--- a/querydsl-core/src/test/java/com/querydsl/core/StringConstant.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/StringConstant.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.core;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Constant;
 import com.querydsl.core.types.ConstantImpl;

--- a/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchable.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchable.java
@@ -2,7 +2,7 @@ package com.querydsl.core.support;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;

--- a/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchableQuery.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchableQuery.java
@@ -2,7 +2,7 @@ package com.querydsl.core.support;
 
 import java.util.List;
 
-import javax.annotation.Nonnegative;
+import org.jetbrains.annotations.Range;
 
 import com.querydsl.core.FetchableQuery;
 import com.querydsl.core.QueryModifiers;
@@ -37,12 +37,12 @@ public class DummyFetchableQuery<T> extends DummyFetchable<T> implements Fetchab
     }
 
     @Override
-    public DummyFetchableQuery<T> limit(@Nonnegative long limit) {
+    public DummyFetchableQuery<T> limit(@Range(from = 0, to = Integer.MAX_VALUE) long limit) {
         return this;
     }
 
     @Override
-    public DummyFetchableQuery<T> offset(@Nonnegative long offset) {
+    public DummyFetchableQuery<T> offset(@Range(from = 0, to = Integer.MAX_VALUE) long offset) {
         return this;
     }
 

--- a/querydsl-core/src/test/java/com/querydsl/core/support/ReplaceVisitorTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/ReplaceVisitorTest.java
@@ -2,7 +2,7 @@ package com.querydsl.core.support;
 
 import static org.junit.Assert.assertEquals;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.junit.Test;
 

--- a/querydsl-core/src/test/java/com/querydsl/core/types/Concatenation.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/Concatenation.java
@@ -13,6 +13,8 @@
  */
 package com.querydsl.core.types;
 
+import org.jetbrains.annotations.Unmodifiable;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,6 +26,7 @@ public class Concatenation extends FactoryExpressionBase<String> {
 
     private static final long serialVersionUID = -355693583588722395L;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     public Concatenation(Expression<?>... args) {
@@ -32,6 +35,7 @@ public class Concatenation extends FactoryExpressionBase<String> {
     }
 
     @Override
+    @Unmodifiable
     public List<Expression<?>> getArgs() {
         return args;
     }

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/BeanPathTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/BeanPathTest.java
@@ -15,7 +15,7 @@ package com.querydsl.core.types.dsl;
 
 import static org.junit.Assert.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/PathTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/PathTest.java
@@ -18,14 +18,13 @@ import static com.querydsl.core.alias.Alias.$;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import org.junit.Test;
 
@@ -62,12 +61,12 @@ public class PathTest {
             return property1;
         }
 
-        @Nonnull
+        @NotNull
         public String getProperty2() {
             return property2;
         }
 
-        @Nonnull
+        @NotNull
         public String getProperty3() {
             return property3;
         }
@@ -92,32 +91,18 @@ public class PathTest {
         AnnotatedElement property4 = $(entity.getProperty4()).getAnnotatedElement();
 
         // property (field)
-        assertEquals(Field.class, property1.getClass());
-        assertTrue(property1.isAnnotationPresent(Nullable.class));
-        assertNotNull(property1.getAnnotation(Nullable.class));
-        assertFalse(property1.isAnnotationPresent(Nonnull.class));
-        assertNull(property1.getAnnotation(Nonnull.class));
+        assertEquals(Annotations.class, property1.getClass());
 
         // property2 (method)
-        assertEquals(Method.class, property2.getClass());
-        assertTrue(property2.isAnnotationPresent(Nonnull.class));
-        assertNotNull(property2.getAnnotation(Nonnull.class));
-        assertFalse(property2.isAnnotationPresent(Nullable.class));
-        assertNull(property2.getAnnotation(Nullable.class));
+        assertEquals(Annotations.class, property2.getClass());
 
         // property3 (both)
-        assertEquals(Annotations.class, property3.getClass());
+        assertEquals(Field.class, property3.getClass());
         assertTrue(property3.isAnnotationPresent(QueryTransient.class));
         assertNotNull(property3.getAnnotation(QueryTransient.class));
-        assertTrue(property3.isAnnotationPresent(Nonnull.class));
-        assertNotNull(property3.getAnnotation(Nonnull.class));
-        assertFalse(property3.isAnnotationPresent(Nullable.class));
-        assertNull(property3.getAnnotation(Nullable.class));
 
         // property 4 (superclass)
-        assertEquals(Method.class, property4.getClass());
-        assertTrue(property4.isAnnotationPresent(Nullable.class));
-        assertNotNull(property4.getAnnotation(Nullable.class));
+        assertEquals(Annotations.class, property4.getClass());
 
     }
 

--- a/querydsl-core/src/test/java/com/querydsl/core/util/ReflectionUtilsTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/util/ReflectionUtilsTest.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import org.junit.Test;
 
 import com.querydsl.core.types.Expression;
@@ -31,13 +29,12 @@ import com.querydsl.core.types.dsl.SimpleExpression;
 
 public class ReflectionUtilsTest {
 
-    @Nullable
     String property;
 
     @Test
     public void getAnnotatedElement() {
         AnnotatedElement annotatedElement = ReflectionUtils.getAnnotatedElement(ReflectionUtilsTest.class, "property", String.class);
-        assertNotNull(annotatedElement.getAnnotation(Nullable.class));
+        assertNotNull(annotatedElement);
     }
 
     @Test

--- a/querydsl-jdo/pom.xml
+++ b/querydsl-jdo/pom.xml
@@ -40,6 +40,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-codegen</artifactId>
       <version>${project.version}</version>

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.jdo.JDOUserException;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQLSerializer.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/JDOQLSerializer.java
@@ -16,7 +16,7 @@ package com.querydsl.jdo;
 import java.util.*;
 import java.util.Map.Entry;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.JoinExpression;
 import com.querydsl.core.QueryMetadata;

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/JDOSQLQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/JDOSQLQuery.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.jdo.sql;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.jdo.PersistenceManager;
 
 import com.querydsl.core.DefaultQueryMetadata;

--- a/querydsl-jpa-codegen/pom.xml
+++ b/querydsl-jpa-codegen/pom.xml
@@ -27,7 +27,13 @@
     <hibernate4.validator.version>4.3.0.Final</hibernate4.validator.version>
   </properties>
 
-  <dependencies>   
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>

--- a/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/AbstractDomainExporter.java
+++ b/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/AbstractDomainExporter.java
@@ -13,10 +13,6 @@
  */
 package com.querydsl.jpa.codegen;
 
-import com.querydsl.codegen.utils.CodeWriter;
-import com.querydsl.codegen.utils.JavaWriter;
-import com.querydsl.codegen.utils.model.Type;
-import com.querydsl.codegen.utils.model.TypeCategory;
 import com.querydsl.codegen.CodegenModule;
 import com.querydsl.codegen.EmbeddableSerializer;
 import com.querydsl.codegen.EntitySerializer;
@@ -30,6 +26,10 @@ import com.querydsl.codegen.Supertype;
 import com.querydsl.codegen.SupertypeSerializer;
 import com.querydsl.codegen.TypeFactory;
 import com.querydsl.codegen.TypeMappings;
+import com.querydsl.codegen.utils.CodeWriter;
+import com.querydsl.codegen.utils.JavaWriter;
+import com.querydsl.codegen.utils.model.Type;
+import com.querydsl.codegen.utils.model.TypeCategory;
 import com.querydsl.core.QueryException;
 import com.querydsl.core.annotations.Config;
 import com.querydsl.core.annotations.PropertyType;
@@ -37,10 +37,10 @@ import com.querydsl.core.annotations.QueryInit;
 import com.querydsl.core.annotations.QueryType;
 import com.querydsl.core.util.Annotations;
 import com.querydsl.core.util.ReflectionUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import java.io.File;

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -26,7 +26,13 @@
     <osgi.import.package>javax.persistence.*;version="[1.1,3)",${osgi.import.package.root}</osgi.import.package>
   </properties>
   
-  <dependencies>   
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/DefaultQueryHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/DefaultQueryHandler.java
@@ -16,7 +16,7 @@ package com.querydsl.jpa;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.Query;
 
 import com.mysema.commons.lang.CloseableIterator;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/EclipseLinkHandler.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
 import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
@@ -30,6 +29,7 @@ import org.eclipse.persistence.queries.Cursor;
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
 import com.querydsl.core.types.FactoryExpression;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code EclipseLinkHandler} is the {@link QueryHandler} implementation for EclipseLink

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/HibernateHandler.java
@@ -16,7 +16,6 @@ package com.querydsl.jpa;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
 import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
@@ -28,6 +27,7 @@ import org.hibernate.transform.ResultTransformer;
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
 import com.querydsl.core.types.FactoryExpression;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code HibernateHandler} is the {@link QueryHandler} implementation for Hibernate

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAListAccessVisitor.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAListAccessVisitor.java
@@ -16,7 +16,7 @@ package com.querydsl.jpa;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.JoinType;
 import com.querydsl.core.QueryMetadata;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAMapAccessVisitor.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAMapAccessVisitor.java
@@ -16,7 +16,7 @@ package com.querydsl.jpa;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.JoinType;
 import com.querydsl.core.QueryMetadata;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryMixin.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryMixin.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.Entity;
 
 import com.querydsl.core.DefaultQueryMetadata;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
@@ -15,7 +15,7 @@ package com.querydsl.jpa;
 
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.*;
 import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.Metamodel;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLTemplates.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLTemplates.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Operator;
 import com.querydsl.core.types.Ops;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/QueryHandler.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/QueryHandler.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.jpa;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.Query;
 
 import com.mysema.commons.lang.CloseableIterator;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/ScrollableResultsIterator.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/ScrollableResultsIterator.java
@@ -15,7 +15,7 @@ package com.querydsl.jpa;
 
 import java.util.NoSuchElementException;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.hibernate.ScrollableResults;
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.hibernate.*;
 import org.hibernate.Query;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.hibernate.Query;
 import org.hibernate.*;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPADeleteClause.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPADeleteClause.java
@@ -15,7 +15,7 @@ package com.querydsl.jpa.impl;
 
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.Query;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
@@ -19,7 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.Query;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAQueryFactory.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAQueryFactory.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.jpa.impl;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAUpdateClause.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAUpdateClause.java
@@ -17,7 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.Query;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.hibernate.hql.internal.ast.HqlParser;
 import org.slf4j.Logger;

--- a/querydsl-lucene3/pom.xml
+++ b/querydsl-lucene3/pom.xml
@@ -30,7 +30,13 @@
     </osgi.import.package>
   </properties>
   
-  <dependencies>   
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>

--- a/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
+++ b/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
@@ -42,8 +42,8 @@ import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TotalHitCountCollector;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/querydsl-lucene3/src/main/java/com/querydsl/lucene3/LuceneSerializer.java
+++ b/querydsl-lucene3/src/main/java/com/querydsl/lucene3/LuceneSerializer.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryParser.QueryParser;

--- a/querydsl-lucene3/src/main/java/com/querydsl/lucene3/ResultIterator.java
+++ b/querydsl-lucene3/src/main/java/com/querydsl/lucene3/ResultIterator.java
@@ -19,8 +19,8 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldSelector;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.function.Function;
 

--- a/querydsl-lucene4/pom.xml
+++ b/querydsl-lucene4/pom.xml
@@ -30,7 +30,13 @@
     </osgi.import.package>
   </properties>
   
-  <dependencies>   
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
@@ -40,8 +40,8 @@ import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TotalHitCountCollector;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/LuceneSerializer.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/LuceneSerializer.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.QueryParser;

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/ResultIterator.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/ResultIterator.java
@@ -18,8 +18,8 @@ import com.querydsl.core.QueryException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Set;
 import java.util.function.Function;

--- a/querydsl-lucene5/pom.xml
+++ b/querydsl-lucene5/pom.xml
@@ -32,6 +32,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
       <version>${lucene.version}</version>

--- a/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
+++ b/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
@@ -41,8 +41,8 @@ import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TotalHitCountCollector;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/querydsl-lucene5/src/main/java/com/querydsl/lucene5/LuceneSerializer.java
+++ b/querydsl-lucene5/src/main/java/com/querydsl/lucene5/LuceneSerializer.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.QueryParser;

--- a/querydsl-lucene5/src/main/java/com/querydsl/lucene5/ResultIterator.java
+++ b/querydsl-lucene5/src/main/java/com/querydsl/lucene5/ResultIterator.java
@@ -18,8 +18,8 @@ import com.querydsl.core.QueryException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Set;
 import java.util.function.Function;

--- a/querydsl-maven-plugin/pom.xml
+++ b/querydsl-maven-plugin/pom.xml
@@ -34,7 +34,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.6.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/querydsl-mongodb/pom.xml
+++ b/querydsl-mongodb/pom.xml
@@ -27,6 +27,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
       <version>${mongodb.version}</version>

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/AbstractMongodbQuery.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/AbstractMongodbQuery.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.function.Function;

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractFetchableMongodbQuery.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractFetchableMongodbQuery.java
@@ -26,8 +26,8 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import org.bson.Document;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractMongodbQuery.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractMongodbQuery.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
 import org.bson.Document;
 
 import com.mongodb.ReadPreference;
@@ -40,6 +38,7 @@ import com.querydsl.core.types.ParamExpression;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.CollectionPathBase;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code AbstractMongodbQuery} provides a base class for general Querydsl query implementation.

--- a/querydsl-scala/pom.xml
+++ b/querydsl-scala/pom.xml
@@ -25,7 +25,13 @@
     <hibernate.validator.version>4.0.2.GA</hibernate.validator.version>
   </properties>
   
-  <dependencies>   
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>

--- a/querydsl-spatial/pom.xml
+++ b/querydsl-spatial/pom.xml
@@ -17,6 +17,13 @@
   
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
       <version>${project.version}</version>

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/CurveExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/CurveExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.Point;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/GeometryCollectionExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/GeometryCollectionExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.GeometryCollection;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/GeometryExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/GeometryExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/LineStringExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/LineStringExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.LineString;
 import org.geolatte.geom.Point;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/MultiCurveExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/MultiCurveExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.GeometryCollection;
 

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/MultiSurfaceExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/MultiSurfaceExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.GeometryCollection;
 import org.geolatte.geom.Point;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/PointExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/PointExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Point;
 

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/PolygonExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/PolygonExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.LineString;
 import org.geolatte.geom.Polygon;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/PolyhedralSurfaceExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/PolyhedralSurfaceExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.PolyHedralSurface;
 

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/SurfaceExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/SurfaceExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.Point;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSCurveExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSCurveExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSGeometryCollectionExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSGeometryCollectionExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSGeometryExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSGeometryExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSLineStringExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSLineStringExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSMultiCurveExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSMultiCurveExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSMultiSurfaceExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSMultiSurfaceExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.Expressions;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSPointExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSPointExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.Expressions;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSPolygonExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSPolygonExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Expression;

--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSSurfaceExpression.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/jts/JTSSurfaceExpression.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.spatial.jts;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.Expressions;

--- a/querydsl-sql-codegen/pom.xml
+++ b/querydsl-sql-codegen/pom.xml
@@ -21,6 +21,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-codegen</artifactId>
       <version>${project.version}</version>

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/KeyDataFactory.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/KeyDataFactory.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.TreeMap;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.codegen.utils.model.SimpleType;
 import com.querydsl.codegen.utils.model.Type;

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
@@ -13,13 +13,6 @@
  */
 package com.querydsl.sql.codegen;
 
-import com.querydsl.codegen.utils.CodeWriter;
-import com.querydsl.codegen.utils.JavaWriter;
-import com.querydsl.codegen.utils.ScalaWriter;
-import com.querydsl.codegen.utils.model.ClassType;
-import com.querydsl.codegen.utils.model.SimpleType;
-import com.querydsl.codegen.utils.model.Type;
-import com.querydsl.codegen.utils.model.TypeCategory;
 import com.querydsl.codegen.CodegenModule;
 import com.querydsl.codegen.EntityType;
 import com.querydsl.codegen.Property;
@@ -27,6 +20,13 @@ import com.querydsl.codegen.QueryTypeFactory;
 import com.querydsl.codegen.Serializer;
 import com.querydsl.codegen.SimpleSerializerConfig;
 import com.querydsl.codegen.TypeMappings;
+import com.querydsl.codegen.utils.CodeWriter;
+import com.querydsl.codegen.utils.JavaWriter;
+import com.querydsl.codegen.utils.ScalaWriter;
+import com.querydsl.codegen.utils.model.ClassType;
+import com.querydsl.codegen.utils.model.SimpleType;
+import com.querydsl.codegen.utils.model.Type;
+import com.querydsl.codegen.utils.model.TypeCategory;
 import com.querydsl.sql.ColumnImpl;
 import com.querydsl.sql.ColumnMetadata;
 import com.querydsl.sql.Configuration;
@@ -38,10 +38,10 @@ import com.querydsl.sql.codegen.support.InverseForeignKeyData;
 import com.querydsl.sql.codegen.support.NotNullImpl;
 import com.querydsl.sql.codegen.support.PrimaryKeyData;
 import com.querydsl.sql.codegen.support.SizeImpl;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/ForeignKeyData.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/ForeignKeyData.java
@@ -16,7 +16,7 @@ package com.querydsl.sql.codegen.support;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.codegen.utils.model.Type;
 

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/InverseForeignKeyData.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/support/InverseForeignKeyData.java
@@ -16,7 +16,7 @@ package com.querydsl.sql.codegen.support;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.codegen.utils.model.Type;
 

--- a/querydsl-sql-spatial/pom.xml
+++ b/querydsl-sql-spatial/pom.xml
@@ -25,6 +25,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-sql</artifactId>
       <version>${project.version}</version>

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeoDBWkbType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeoDBWkbType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.ByteBuffer;
 import org.geolatte.geom.ByteOrder;

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeometryWkbType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeometryWkbType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.ByteBuffer;
 import org.geolatte.geom.ByteOrder;

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeometryWktClobType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeometryWktClobType.java
@@ -15,7 +15,7 @@ package com.querydsl.sql.spatial;
 
 import java.sql.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.codec.Wkt;

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeometryWktType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/GeometryWktType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.codec.Wkt;

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/JGeometryType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/JGeometryType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/MySQLWkbType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/MySQLWkbType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.ByteBuffer;
 import org.geolatte.geom.ByteOrder;

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/PGgeometryType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/PGgeometryType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.codec.Wkt;

--- a/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SQLServerGeometryType.java
+++ b/querydsl-sql-spatial/src/main/java/com/querydsl/sql/spatial/SQLServerGeometryType.java
@@ -19,7 +19,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.codec.Wkt;

--- a/querydsl-sql-spring/pom.xml
+++ b/querydsl-sql-spring/pom.xml
@@ -21,6 +21,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-sql</artifactId>
       <version>${project.version}</version>

--- a/querydsl-sql/pom.xml
+++ b/querydsl-sql/pom.xml
@@ -25,6 +25,13 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
       <version>${project.version}</version>

--- a/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
 import org.slf4j.Logger;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.util.PrimitiveUtils;
 import org.slf4j.Logger;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ForeignKey.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ForeignKey.java
@@ -17,8 +17,8 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/JDBCTypeMapping.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/JDBCTypeMapping.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.mysema.commons.lang.Pair;
 import com.querydsl.sql.types.Null;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/JavaTypeMapping.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/JavaTypeMapping.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.util.PrimitiveUtils;
 import com.querydsl.core.util.ReflectionUtils;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/PrimaryKey.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/PrimaryKey.java
@@ -17,8 +17,8 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.Nullable;
+import com.querydsl.core.annotations.Immutable;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.*;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.FetchableQuery;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPath.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPath.java
@@ -16,7 +16,7 @@ package com.querydsl.sql;
 import java.util.Collection;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Path;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathBase.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/RelationalPathBase.java
@@ -19,7 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.BeanPath;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLListeners.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLListeners.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.types.Expression;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLResultIterator.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLResultIterator.java
@@ -18,7 +18,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.NoSuchElementException;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.QueryException;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
@@ -16,7 +16,7 @@ package com.querydsl.sql;
 import java.sql.Types;
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.JoinExpression;
 import com.querydsl.core.JoinFlag;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/StatementOptions.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/StatementOptions.java
@@ -16,7 +16,7 @@ package com.querydsl.sql;
 
 import java.sql.Statement;
 
-import javax.annotation.concurrent.Immutable;
+import com.querydsl.core.annotations.Immutable;
 
 /**
  * {@code StatementOptions} holds parameters that should be applied to {@link Statement}s.

--- a/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
@@ -16,7 +16,7 @@ package com.querydsl.sql;
 import java.util.List;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.NonUniqueResultException;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/WindowFirstLast.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/WindowFirstLast.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/WindowFunction.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/WindowFunction.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/WithinGroup.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/WithinGroup.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
 import org.slf4j.Logger;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLDeleteClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLDeleteClause.java
@@ -18,7 +18,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.*;
 
-import javax.annotation.Nonnegative;
+import org.jetbrains.annotations.Range;
 import javax.inject.Provider;
 
 import org.slf4j.Logger;
@@ -257,7 +257,7 @@ public abstract class AbstractSQLDeleteClause<C extends AbstractSQLDeleteClause<
         return (C) this;
     }
 
-    public C limit(@Nonnegative long limit) {
+    public C limit(@Range(from = 0, to = Integer.MAX_VALUE) long limit) {
         metadata.setModifiers(QueryModifiers.limit(limit));
         return (C) this;
     }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
@@ -16,7 +16,7 @@ package com.querydsl.sql.dml;
 import java.sql.*;
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
 import com.querydsl.core.util.CollectionUtils;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLUpdateClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLUpdateClause.java
@@ -18,7 +18,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.*;
 
-import javax.annotation.Nonnegative;
+import org.jetbrains.annotations.Range;
 import javax.inject.Provider;
 
 import org.slf4j.Logger;
@@ -297,7 +297,7 @@ public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<
         return (C) this;
     }
 
-    public C limit(@Nonnegative long limit) {
+    public C limit(@Range(from = 0, to = Integer.MAX_VALUE) long limit) {
         metadata.setModifiers(QueryModifiers.limit(limit));
         return (C) this;
     }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLInsertBatch.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLInsertBatch.java
@@ -16,7 +16,7 @@ package com.querydsl.sql.dml;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeBatch.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeBatch.java
@@ -16,7 +16,7 @@ package com.querydsl.sql.dml;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
@@ -16,7 +16,7 @@ package com.querydsl.sql.dml;
 import java.sql.*;
 import java.util.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
 import com.querydsl.core.util.CollectionUtils;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/ArrayType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/ArrayType.java
@@ -15,7 +15,7 @@ package com.querydsl.sql.types;
 
 import java.sql.*;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.util.PrimitiveUtils;
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/CurrencyType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/CurrencyType.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Currency;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code CurrencyType} maps Currency to String on the JDBC level

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310InstantType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310InstantType.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * JSR310InstantType maps {@linkplain java.time.Instant} to

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateTimeType.java
@@ -1,6 +1,6 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * JSR310LocalDateType maps {@linkplain java.time.LocalDate}

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalTimeType.java
@@ -4,7 +4,7 @@ import java.sql.*;
 import java.time.LocalTime;
 import java.time.temporal.ChronoField;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * JSR310LocalTimeType maps {@linkplain java.time.LocalTime}

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetDateTimeType.java
@@ -1,6 +1,6 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310OffsetTimeType.java
@@ -6,7 +6,7 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * JSR310OffsetTimeType maps {@linkplain java.time.OffsetTime}

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310ZonedDateTimeType.java
@@ -1,6 +1,6 @@
 package com.querydsl.sql.types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/LocaleType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/LocaleType.java
@@ -20,7 +20,7 @@ import java.sql.Types;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code LocaleType} maps Locale to String on the JDBC level

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/NumericBooleanType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/NumericBooleanType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code NumericBooleanType} maps Boolean to 1/0 (Integer) on the JDBC level

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/TrueFalseType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/TrueFalseType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code TrueFalseType} maps Boolean to 'T'/'F' on the JDBC level

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/Type.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/Type.java
@@ -17,7 +17,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Defines the de/serialization of a typed Java object from a ResultSet or to a PreparedStatement

--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/YesNoType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/YesNoType.java
@@ -18,7 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code YesNoType} maps Boolean to 'Y'/'N' on the JDBC level

--- a/querydsl-sql/src/test/java/com/querydsl/sql/AbstractBaseTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/AbstractBaseTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 import java.sql.Connection;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.junit.ClassRule;
 import org.junit.Rule;

--- a/querydsl-sql/src/test/java/com/querydsl/sql/Projection.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/Projection.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.sql;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.types.Expression;
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/QProjection.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/QProjection.java
@@ -21,11 +21,13 @@ import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionBase;
 import com.querydsl.core.types.FactoryExpression;
 import com.querydsl.core.types.Visitor;
+import org.jetbrains.annotations.Unmodifiable;
 
 public class QProjection extends ExpressionBase<Projection> implements FactoryExpression<Projection> {
 
     private static final long serialVersionUID = -7330905848558102164L;
 
+    @Unmodifiable
     private final List<Expression<?>> args;
 
     public QProjection(Expression<?>... args) {
@@ -70,6 +72,7 @@ public class QProjection extends ExpressionBase<Projection> implements FactoryEx
     }
 
     @Override
+    @Unmodifiable
     public List<Expression<?>> getArgs() {
         return args;
     }


### PR DESCRIPTION
There are issues with JSR305 considering that it was never accepted and that now the `javax` package cannot be used anymore legally. Another issue is that JSR305 is shipped as dependency transitively. Some users raised complaints about this and mentioned that they rather have annotations with class retention for static analysis instead.

This PR replaces JSR305 with jetbrains annotations module, which has the majority of the annotations used.

The only annotation I found missing was `@Immutable`. I have suggested it in an issue to their repository. For the time being, I added an `@Immutable` annotation to QueryDSL itself.

Fixes #2479 