### PR TITLE
 Return Optional from Fetchable#fetchOne and fetchFirst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,20 @@
 # Changelog
 
-### 5.0.0
+## 5.0.0
 
-#### Breaking changes
+### Breaking changes
 
 * Java 8 minimal requirement. If you still rely on Java <7, please use the latest 4.x.x version.
 * Removed bridge method that were in place for backwards compatibility of legacy API's. This may lead to some breaking API changes.
+* `Fetchable#fetchFirst()` and `Fetchable#fetchOne()` now return an `Optional<T>`. As an `Optional` cannot hold a `null` value, the `NULL` result set returns `Optional.empty()`.
 
-#### Dependency updates
+### New features
+
+* Added `Fetchable#stream()` which returns a `Stream<T>`. _Make sure that the returned stream is always closed to free up resources, for example using try-with-resources. It does **not** suffice to rely on a terminating operation on the stream for this (i.e. `forEach`, `collect`)._
+
+### Dependency updates
 
 * `cglib` to 3.3.0 for Java 8+ support
+* `asm` to 9.0 for Java 8+ support
 * DataNucleus 5.2.x for Java 8+ support
-  * JDO now uses `org.datanucleus:javax.jdo` instead of `javax.jdo:jdo-api`
-
-#### Plans
-
-- [x] Require Java 8
-- [ ] Optimize code for Java 8 (use new API's)
-- [ ] Support Java 8 date/time for `querydsl-sql`
-- [ ] Drop Guava dependency #2324 
-   - [ ] Support Java 8 Optional in favour of Guava's Optional
-- [ ] Assume Hibernate 5.3+ by default in Hibernate integration
-- [ ] Switch from`com.vividsolutions` to `org.locationtech` for JTS #2404. `hibernate-spatial` doesn't support the old artifact for a while now. If you still rely on `com.vividsolutions`, please use the lastest 4.x.x version.
-- [ ] Migrate off from jsr305 to https://github.com/JetBrains/java-annotations #2479
-- [ ] Consider breaking out some integrations (Hibernate, Datanucleus, OpenJPA) and extensions (Alias.*) to separate modules (if it helps with cleaning up dependencies, and in particular, not providing a false sense of support).
+  * JDO now uses `org.datanucleus:javax.jdo` instead of `javax.jdo:jdo-api`. Seems more widely used and also got more recently updated.

--- a/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/AbstractCollQuery.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.mysema.commons.lang.CloseableIterator;
@@ -202,7 +203,7 @@ public abstract class AbstractCollQuery<T, Q extends AbstractCollQuery<T, Q>> ex
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         queryMixin.setUnique(true);
         if (queryMixin.getMetadata().getModifiers().getLimit() == null) {
             limit(2L);

--- a/querydsl-collections/src/test/java/com/querydsl/collections/AggregationTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/AggregationTest.java
@@ -29,38 +29,38 @@ public class AggregationTest extends AbstractQueryTest {
 
     @Test
     public void avg() {
-        assertEquals(3.5, query.select(cat.weight.avg()).fetchOne(), 0.0);
+        assertEquals(3.5, query.select(cat.weight.avg()).fetchOne().get(), 0.0);
     }
 
     @Test
     public void count() {
-        assertEquals(Long.valueOf(4L), query.select(cat.count()).fetchOne());
+        assertEquals(Long.valueOf(4L), query.select(cat.count()).fetchOne().get());
     }
 
     @Test
     public void countDistinct() {
-        assertEquals(Long.valueOf(4L), query.select(cat.countDistinct()).fetchOne());
+        assertEquals(Long.valueOf(4L), query.select(cat.countDistinct()).fetchOne().get());
     }
 
     @Test
     public void max() {
-        assertEquals(Integer.valueOf(5), query.select(cat.weight.max()).fetchOne());
+        assertEquals(Integer.valueOf(5), query.select(cat.weight.max()).fetchOne().get());
     }
 
     @Test
     public void min() {
-        assertEquals(Integer.valueOf(2), query.select(cat.weight.min()).fetchOne());
+        assertEquals(Integer.valueOf(2), query.select(cat.weight.min()).fetchOne().get());
     }
 
     @SuppressWarnings("unchecked")
     @Test(expected = UnsupportedOperationException.class)
     public void min_and_max() {
-        query.select(cat.weight.min(), cat.weight.max()).fetchOne();
+        query.select(cat.weight.min(), cat.weight.max()).fetchOne().get();
     }
 
     @Test
     public void sum() {
-        assertEquals(Integer.valueOf(14), query.select(cat.weight.sum()).fetchOne());
+        assertEquals(Integer.valueOf(14), query.select(cat.weight.sum()).fetchOne().get());
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/CastTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/CastTest.java
@@ -29,7 +29,7 @@ public class CastTest extends AbstractQueryTest {
          assertEquals(Color.TABBY,
              CollQueryFactory.from(QAnimal.animal, cat)
                  .where(QAnimal.animal.instanceOf(Cat.class))
-                 .select(QAnimal.animal.as(QCat.class).eyecolor).fetchFirst());
+                 .select(QAnimal.animal.as(QCat.class).eyecolor).fetchFirst().get());
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/CollQueryStandardTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/CollQueryStandardTest.java
@@ -125,19 +125,19 @@ public class CollQueryStandardTest {
     @Test
     public void params() {
         Param<String> name = new Param<String>(String.class,"name");
-        assertEquals("Bob", CollQueryFactory.from(cat, data).where(cat.name.eq(name)).set(name,"Bob").select(cat.name).fetchOne());
+        assertEquals("Bob", CollQueryFactory.from(cat, data).where(cat.name.eq(name)).set(name,"Bob").select(cat.name).fetchOne().get());
     }
 
     @Test
     public void params_anon() {
         Param<String> name = new Param<String>(String.class);
-        assertEquals("Bob", CollQueryFactory.from(cat, data).where(cat.name.eq(name)).set(name,"Bob").select(cat.name).fetchOne());
+        assertEquals("Bob", CollQueryFactory.from(cat, data).where(cat.name.eq(name)).set(name,"Bob").select(cat.name).fetchOne().get());
     }
 
     @Test(expected = ParamNotSetException.class)
     public void params_not_set() {
         Param<String> name = new Param<String>(String.class,"name");
-        assertEquals("Bob", CollQueryFactory.from(cat, data).where(cat.name.eq(name)).select(cat.name).fetchOne());
+        assertEquals("Bob", CollQueryFactory.from(cat, data).where(cat.name.eq(name)).select(cat.name).fetchOne().get());
     }
 
     @Test

--- a/querydsl-collections/src/test/java/com/querydsl/collections/CollectionTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/CollectionTest.java
@@ -48,7 +48,7 @@ public class CollectionTest {
     public void join() {
         assertEquals("4", CollQueryFactory.from(cat, cats)
                 .innerJoin(cat.kittens, other)
-                .where(other.name.eq("4")).select(cat.name).fetchFirst());
+                .where(other.name.eq("4")).select(cat.name).fetchFirst().get());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CollectionTest {
     @Test
     public void any_uniqueResult() {
         assertEquals("4", CollQueryFactory.from(cat, cats)
-                .where(cat.kittens.any().name.eq("4")).select(cat.name).fetchOne());
+                .where(cat.kittens.any().name.eq("4")).select(cat.name).fetchOne().get());
     }
 
     @Test

--- a/querydsl-collections/src/test/java/com/querydsl/collections/EntityWithLongIdTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/EntityWithLongIdTest.java
@@ -23,7 +23,7 @@ public class EntityWithLongIdTest {
         CollQuery<?> query = new CollQuery<Void>().from(root, entities);
         query.where(root.id.eq(1000L));
 
-        Long found = query.select(root.id).fetchFirst();
+        Long found = query.select(root.id).fetchFirst().get();
         assertNotNull(found);
         assertEquals(found.longValue(), 1000);
     }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/FirstResultContractTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/FirstResultContractTest.java
@@ -21,7 +21,7 @@ public class FirstResultContractTest extends AbstractQueryTest {
 
     @Test
     public void singleResult() {
-        assertNotNull(CollQueryFactory.from(cat, cats).where(cat.name.isNotNull()).fetchFirst());
+        assertNotNull(CollQueryFactory.from(cat, cats).where(cat.name.isNotNull()).fetchFirst().orElse(null));
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/MathTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/MathTest.java
@@ -63,7 +63,7 @@ public class MathTest {
 
     private <T> T unique(Expression<T> expr) {
         //return query().fetchOne(expr);
-        return CollQueryFactory.<Double> from(num, Collections.singletonList(0.5)).select(expr).fetchOne();
+        return CollQueryFactory.<Double> from(num, Collections.singletonList(0.5)).select(expr).fetchOne().get();
     }
 
 }

--- a/querydsl-collections/src/test/java/com/querydsl/collections/NumberTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/NumberTest.java
@@ -17,6 +17,6 @@ public class NumberTest {
         NumberPath<BigDecimal> num = Expressions.numberPath(BigDecimal.class, "num");
         CollQuery<BigDecimal> query = CollQueryFactory.<BigDecimal> from(num, Arrays.<BigDecimal> asList(new BigDecimal("1.6"), new BigDecimal("1.3")));
 
-        assertEquals(new BigDecimal("2.9"), query.<BigDecimal> select(num.sum()).fetchOne());
+        assertEquals(new BigDecimal("2.9"), query.<BigDecimal> select(num.sum()).fetchOne().get());
     }
 }

--- a/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/Fetchable.java
@@ -14,6 +14,7 @@
 package com.querydsl.core;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
@@ -42,7 +43,7 @@ public interface Fetchable<T> {
      *
      * @return first result or null
      */
-    T fetchFirst();
+    Optional<T> fetchFirst();
 
     /**
      * Get the projection as a unique result or null if no result is found
@@ -50,7 +51,7 @@ public interface Fetchable<T> {
      * @throws NonUniqueResultException if there is more than one matching result
      * @return first result or null
      */
-    T fetchOne() throws NonUniqueResultException;
+    Optional<T> fetchOne() throws NonUniqueResultException;
 
     /**
      * Get the projection as a typed closeable Iterator

--- a/querydsl-core/src/main/java/com/querydsl/core/support/FetchableQueryBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/support/FetchableQueryBase.java
@@ -14,8 +14,7 @@
 package com.querydsl.core.support;
 
 import java.util.List;
-
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
@@ -47,7 +46,7 @@ public abstract class FetchableQueryBase<T, Q extends FetchableQueryBase<T, Q>>
     }
 
     @Override
-    public final T fetchFirst() {
+    public final Optional<T> fetchFirst() {
         return limit(1).fetchOne();
     }
 
@@ -55,17 +54,16 @@ public abstract class FetchableQueryBase<T, Q extends FetchableQueryBase<T, Q>>
         return transformer.transform((FetchableQuery<?,?>) this);
     }
 
-    @Nullable
-    protected <T> T uniqueResult(CloseableIterator<T> it) {
+    protected <T> Optional<T> uniqueResult(CloseableIterator<T> it) {
         try {
             if (it.hasNext()) {
                 T rv = it.next();
                 if (it.hasNext()) {
                     throw new NonUniqueResultException();
                 }
-                return rv;
+                return Optional.ofNullable(rv);
             } else {
-                return null;
+                return Optional.empty();
             }
         } finally {
             it.close();

--- a/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchable.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/support/DummyFetchable.java
@@ -1,8 +1,7 @@
 package com.querydsl.core.support;
 
 import java.util.List;
-
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
@@ -29,21 +28,19 @@ public class DummyFetchable<T> implements Fetchable<T> {
         return results;
     }
 
-    @Nullable
     @Override
-    public T fetchFirst() {
-        return results.isEmpty() ? null : results.get(0);
+    public Optional<T> fetchFirst() {
+        return results.isEmpty() ? Optional.empty() : Optional.ofNullable(results.get(0));
     }
 
-    @Nullable
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         if (results.size() > 1) {
             throw new NonUniqueResultException();
         } else if (results.isEmpty()) {
-            return null;
+            return Optional.empty();
         } else {
-            return results.get(0);
+            return Optional.ofNullable(results.get(0));
         }
     }
 

--- a/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/TweetRepository.java
+++ b/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/TweetRepository.java
@@ -40,7 +40,7 @@ public class TweetRepository extends AbstractRepository {
 
     @Transactional
     public Tweet findById(Long id) {
-        return selectFrom(tweet).where(tweet.id.eq(id)).fetchOne();
+        return selectFrom(tweet).where(tweet.id.eq(id)).fetchOne().orElse(null);
     }
 
     @Transactional

--- a/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/UserRepository.java
+++ b/querydsl-examples/querydsl-example-sql-guice/src/main/java/com/querydsl/example/sql/repository/UserRepository.java
@@ -13,7 +13,7 @@ import static com.querydsl.example.sql.model.QUser.user;
 public class UserRepository extends AbstractRepository {
     @Transactional
     public User findById(Long id) {
-        return selectFrom(user).where(user.id.eq(id)).fetchOne();
+        return selectFrom(user).where(user.id.eq(id)).fetchOne().orElse(null);
     }
 
     @Transactional

--- a/querydsl-examples/querydsl-example-sql-spring/src/main/java/com/querydsl/example/dao/PersonDaoImpl.java
+++ b/querydsl-examples/querydsl-example-sql-spring/src/main/java/com/querydsl/example/dao/PersonDaoImpl.java
@@ -25,7 +25,7 @@ public class PersonDaoImpl implements PersonDao {
         return queryFactory.select(personBean)
                 .from(person)
                 .where(person.id.eq(id))
-                .fetchOne();
+                .fetchOne().orElse(null);
     }
 
     @Override

--- a/querydsl-hibernate-search/src/main/java/com/querydsl/hibernate/search/AbstractSearchQuery.java
+++ b/querydsl-hibernate-search/src/main/java/com/querydsl/hibernate/search/AbstractSearchQuery.java
@@ -14,6 +14,7 @@
 package com.querydsl.hibernate.search;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.hibernate.Session;
@@ -146,15 +147,15 @@ public abstract class AbstractSearchQuery<T, Q extends AbstractSearchQuery<T,Q>>
     }
 
     @Override
-    public T fetchFirst() {
+    public Optional<T> fetchFirst() {
         return limit(1).fetchOne();
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         try {
-            return (T) createQuery(false).uniqueResult();
+            return Optional.ofNullable((T) createQuery(false).uniqueResult());
         } catch (org.hibernate.NonUniqueResultException e) {
             throw new NonUniqueResultException(e);
         }

--- a/querydsl-hibernate-search/src/test/java/com/querydsl/hibernate/search/SearchQueryTest.java
+++ b/querydsl-hibernate-search/src/test/java/com/querydsl/hibernate/search/SearchQueryTest.java
@@ -69,7 +69,7 @@ public class SearchQueryTest extends AbstractQueryTest {
     @Test
     public void uniqueResult() {
         BooleanExpression filter = user.emailAddress.eq("bob@example.com");
-        User u = query().where(filter).fetchOne();
+        User u = query().where(filter).fetchOne().get();
         assertNotNull(u);
         assertEquals("bob@example.com", u.getEmailAddress());
     }
@@ -79,7 +79,7 @@ public class SearchQueryTest extends AbstractQueryTest {
         BooleanExpression filter = user.emailAddress.eq("bob@example.com");
         List<User> list = query().where(filter).fetch();
         assertEquals(1, list.size());
-        User u = query().where(filter).fetchOne();
+        User u = query().where(filter).fetchOne().get();
         assertEquals(u, list.get(0));
     }
 
@@ -90,7 +90,7 @@ public class SearchQueryTest extends AbstractQueryTest {
 
     @Test
     public void singleResult() {
-        assertNotNull(query().where(user.middleName.eq("X")).fetchFirst());
+        assertNotNull(query().where(user.middleName.eq("X")).fetchFirst().orElse(null));
     }
 
     @Test

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -311,9 +311,8 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
         }
     }
 
-    @Nullable
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         if (getMetadata().getModifiers().getLimit() == null) {
             limit(2);
         }
@@ -327,15 +326,15 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
                     if (list.size() > 1) {
                         throw new NonUniqueResultException();
                     }
-                    return list.get(0);
+                    return Optional.ofNullable(list.get(0));
                 } else {
-                    return null;
+                    return Optional.empty();
                 }
             } else {
                 // it is not a List typed expression
                 @SuppressWarnings("unchecked") // Compile time checking of user code mandates this
                 T result = (T) rv;
-                return result;
+                return Optional.ofNullable(result);
             }
         } finally {
             reset();

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.jdo.PersistenceManager;
@@ -221,8 +222,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
 
     @SuppressWarnings("unchecked")
     @Override
-    @Nullable
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         if (getMetadata().getModifiers().getLimit() == null) {
             limit(2);
         }
@@ -234,12 +234,13 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
                 if (list.size() > 1) {
                     throw new NonUniqueResultException();
                 }
-                return (T) list.get(0);
+                return Optional.ofNullable((T) list.get(0));
             } else {
-                return null;
+                return Optional.empty();
             }
         } else {
-            return (T) rv;
+            return Optional.ofNullable((T) rv);
         }
     }
+
 }

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/AggregateTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/AggregateTest.java
@@ -31,9 +31,9 @@ public class AggregateTest extends AbstractJDOTest {
     @Test
     public void unique() {
         double min = 200.00, avg = 400.00, max = 600.00;
-        assertEquals(Double.valueOf(min), query().from(product).select(product.price.min()).fetchOne());
-        assertEquals(Double.valueOf(avg), query().from(product).select(product.price.avg()).fetchOne());
-        assertEquals(Double.valueOf(max), query().from(product).select(product.price.max()).fetchOne());
+        assertEquals(Double.valueOf(min), query().from(product).select(product.price.min()).fetchOne().get());
+        assertEquals(Double.valueOf(avg), query().from(product).select(product.price.avg()).fetchOne().get());
+        assertEquals(Double.valueOf(max), query().from(product).select(product.price.max()).fetchOne().get());
     }
 
     @Test

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/BasicsTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/BasicsTest.java
@@ -129,14 +129,14 @@ public class BasicsTest extends AbstractJDOTest {
     public void simpleTest() throws IOException {
         JDOQuery<?> query = new JDOQuery<Void>(pm, templates, false);
         assertEquals("Sony Discman", query.from(product).where(product.name.eq("Sony Discman"))
-                .select(product.name).fetchOne());
+                .select(product.name).fetchOne().get());
         query.close();
     }
 
     @Test
     public void projectionTests() {
         assertEquals("Sony Discman", query().from(product).where(product.name.eq("Sony Discman"))
-                .select(product.name).fetchOne());
+                .select(product.name).fetchOne().get());
     }
 
     @Test

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOQLMethodsTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOQLMethodsTest.java
@@ -33,7 +33,7 @@ public class JDOQLMethodsTest extends AbstractJDOTest {
 
     @Test
     public void test() {
-        Product p = query().from(product).limit(1).select(product).fetchOne();
+        Product p = query().from(product).limit(1).select(product).fetchOne().get();
         for (BooleanExpression f : getFilters(
                 product.name, product.description, "A0",
                 store.products, p,

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOQueryStandardTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOQueryStandardTest.java
@@ -108,8 +108,8 @@ public class JDOQueryStandardTest extends AbstractJDOTest {
 
     @Test
     public void standardTest() {
-        Product p = query().from(product).where(product.name.eq(productName)).limit(1).select(product).fetchOne();
-        Product p2 = query().from(product).where(product.name.startsWith(otherName)).limit(1).select(product).fetchOne();
+        Product p = query().from(product).where(product.name.eq(productName)).limit(1).select(product).fetchOne().get();
+        Product p2 = query().from(product).where(product.name.startsWith(otherName)).limit(1).select(product).fetchOne().get();
         standardTest.noProjections();
         standardTest.noCounts();
 
@@ -170,21 +170,21 @@ public class JDOQueryStandardTest extends AbstractJDOTest {
     public void params() {
         Param<String> name = new Param<String>(String.class,"name");
         assertEquals("ABC0",query().from(product).where(product.name.eq(name)).set(name, "ABC0")
-                .select(product.name).fetchFirst());
+                .select(product.name).fetchFirst().orElse(null));
     }
 
     @Test
     public void params_anon() {
         Param<String> name = new Param<String>(String.class);
         assertEquals("ABC0",query().from(product).where(product.name.eq(name)).set(name, "ABC0")
-                .select(product.name).fetchFirst());
+                .select(product.name).fetchFirst().orElse(null));
     }
 
     @Test(expected = ParamNotSetException.class)
     public void params_not_set() {
         Param<String> name = new Param<String>(String.class,"name");
         assertEquals("ABC0",query().from(product).where(product.name.eq(name))
-                .select(product.name).fetchFirst());
+                .select(product.name).fetchFirst().orElse(null));
     }
 
     @Test

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOSQLQueryTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/JDOSQLQueryTest.java
@@ -59,13 +59,13 @@ public class JDOSQLQueryTest extends AbstractJDOTest {
     @Test
     public void singleResult() {
         assertEquals("A0", sql().from(product).orderBy(product.name.asc())
-                .select(product.name).fetchFirst());
+                .select(product.name).fetchFirst().orElse(null));
     }
 
     @Test
     public void singleResult_with_array() {
         assertEquals("A0", sql().from(product).orderBy(product.name.asc())
-                .select(new Expression<?>[]{product.name}).fetchFirst().get(product.name));
+                .select(new Expression<?>[]{product.name}).fetchFirst().orElse(null).get(product.name));
     }
 
     @Test

--- a/querydsl-jdo/src/test/java/com/querydsl/jdo/SubqueriesTest.java
+++ b/querydsl-jdo/src/test/java/com/querydsl/jdo/SubqueriesTest.java
@@ -48,7 +48,7 @@ public class SubqueriesTest extends AbstractJDOTest {
 
     @Test
     public void gt_subquery() {
-        double avg = query().from(product).select(product.price.avg()).fetchFirst();
+        double avg = query().from(product).select(product.price.avg()).fetchFirst().get();
         for (double price : query().from(product)
                 .where(product.price.gt(query().from(other).select(other.price.avg())))
                 .select(product.price).fetch()) {
@@ -67,7 +67,7 @@ public class SubqueriesTest extends AbstractJDOTest {
 
     @Test
     public void eq_subquery() {
-        double avg = query().from(product).select(product.price.avg()).fetchFirst();
+        double avg = query().from(product).select(product.price.avg()).fetchFirst().get();
         for (double price : query().from(product)
                 .where(product.price.eq(query().from(other).select(other.price.avg())))
                 .select(product.price).fetch()) {

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/JPASubQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/JPASubQuery.java
@@ -21,6 +21,8 @@ import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
 
+import java.util.Optional;
+
 class JPASubQuery<T> extends JPAQueryBase<T, JPASubQuery<T>> {
 
     JPASubQuery() {
@@ -63,7 +65,7 @@ class JPASubQuery<T> extends JPAQueryBase<T, JPASubQuery<T>> {
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         throw new UnsupportedOperationException();
     }
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.jpa.hibernate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -334,12 +335,12 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
 
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         try {
             QueryModifiers modifiers = getMetadata().getModifiers();
             Query query = createQuery(modifiers, false);
             try {
-                return (T) query.uniqueResult();
+                return Optional.ofNullable((T) query.uniqueResult());
             } catch (org.hibernate.NonUniqueResultException e) {
                 throw new NonUniqueResultException(e);
             }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
@@ -15,6 +15,7 @@ package com.querydsl.jpa.hibernate.sql;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -223,10 +224,10 @@ public abstract class AbstractHibernateSQLQuery<T, Q extends AbstractHibernateSQ
 
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         try {
             Query query = createQuery();
-            return (T) uniqueResult(query);
+            return Optional.ofNullable((T) uniqueResult(query));
         } finally {
             reset();
         }

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.jpa.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -168,20 +169,19 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
      * @param query query
      * @return single result
      */
-    @Nullable
-    private Object getSingleResult(Query query) {
+    private Optional<Object> getSingleResult(Query query) {
         if (projection != null) {
             Object result = query.getSingleResult();
             if (result != null) {
                 if (!result.getClass().isArray()) {
                     result = new Object[]{result};
                 }
-                return projection.newInstance((Object[]) result);
+                return Optional.ofNullable(projection.newInstance((Object[]) result));
             } else {
-                return null;
+                return Optional.empty();
             }
         } else {
-            return query.getSingleResult();
+            return Optional.ofNullable(query.getSingleResult());
         }
     }
 
@@ -258,10 +258,10 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
     @Nullable
     @SuppressWarnings("unchecked")
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         try {
             Query query = createQuery(getMetadata().getModifiers(), false);
-            return (T) getSingleResult(query);
+            return (Optional<T>) getSingleResult(query);
         } catch (javax.persistence.NoResultException e) {
             logger.trace(e.getMessage(),e);
             return null;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.jpa.sql;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -304,18 +305,17 @@ public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>
 
     @Override
     @SuppressWarnings("unchecked")
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         Query query = createQuery();
-        return (T) uniqueResult(query);
+        return (Optional<T>) uniqueResult(query);
     }
 
-    @Nullable
-    private Object uniqueResult(Query query) {
+    private Optional<Object> uniqueResult(Query query) {
         try {
-            return getSingleResult(query);
+            return Optional.ofNullable(getSingleResult(query));
         } catch (javax.persistence.NoResultException e) {
             logger.trace(e.getMessage(),e);
-            return null;
+            return Optional.empty();
         } catch (javax.persistence.NonUniqueResultException e) {
             throw new NonUniqueResultException(e);
         } finally {

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractJPATest.java
@@ -193,22 +193,22 @@ public abstract class AbstractJPATest {
 
     @Test
     public void aggregates_list_max() {
-        assertEquals(Integer.valueOf(6), query().from(cat).select(cat.id.max()).fetchFirst());
+        assertEquals(Integer.valueOf(6), query().from(cat).select(cat.id.max()).fetchFirst().orElse(null));
     }
 
     @Test
     public void aggregates_list_min() {
-        assertEquals(Integer.valueOf(1), query().from(cat).select(cat.id.min()).fetchFirst());
+        assertEquals(Integer.valueOf(1), query().from(cat).select(cat.id.min()).fetchFirst().orElse(null));
     }
 
     @Test
     public void aggregates_uniqueResult_max() {
-        assertEquals(Integer.valueOf(6), query().from(cat).select(cat.id.max()).fetchFirst());
+        assertEquals(Integer.valueOf(6), query().from(cat).select(cat.id.max()).fetchFirst().orElse(null));
     }
 
     @Test
     public void aggregates_uniqueResult_min() {
-        assertEquals(Integer.valueOf(1), query().from(cat).select(cat.id.min()).fetchFirst());
+        assertEquals(Integer.valueOf(1), query().from(cat).select(cat.id.min()).fetchFirst().orElse(null));
     }
 
     @Test
@@ -644,7 +644,7 @@ public abstract class AbstractJPATest {
     @NoEclipseLink(HSQLDB)
     public void count_distinct3() {
         QCat kitten = new QCat("kitten");
-        assertEquals(4, query().from(cat).leftJoin(cat.kittens, kitten).select(kitten.countDistinct()).fetchOne().intValue());
+        assertEquals(4, query().from(cat).leftJoin(cat.kittens, kitten).select(kitten.countDistinct()).fetchOne().orElse(null).intValue());
         assertEquals(6, query().from(cat).leftJoin(cat.kittens, kitten).select(kitten.countDistinct()).fetchCount());
     }
 
@@ -668,20 +668,20 @@ public abstract class AbstractJPATest {
 
     @Test
     public void date() {
-        assertEquals(2000, query().from(cat).select(cat.birthdate.year()).fetchFirst().intValue());
-        assertEquals(200002, query().from(cat).select(cat.birthdate.yearMonth()).fetchFirst().intValue());
-        assertEquals(2, query().from(cat).select(cat.birthdate.month()).fetchFirst().intValue());
-        assertEquals(2, query().from(cat).select(cat.birthdate.dayOfMonth()).fetchFirst().intValue());
-        assertEquals(3, query().from(cat).select(cat.birthdate.hour()).fetchFirst().intValue());
-        assertEquals(4, query().from(cat).select(cat.birthdate.minute()).fetchFirst().intValue());
-        assertEquals(0, query().from(cat).select(cat.birthdate.second()).fetchFirst().intValue());
+        assertEquals(2000, query().from(cat).select(cat.birthdate.year()).fetchFirst().orElse(null).intValue());
+        assertEquals(200002, query().from(cat).select(cat.birthdate.yearMonth()).fetchFirst().orElse(null).intValue());
+        assertEquals(2, query().from(cat).select(cat.birthdate.month()).fetchFirst().orElse(null).intValue());
+        assertEquals(2, query().from(cat).select(cat.birthdate.dayOfMonth()).fetchFirst().orElse(null).intValue());
+        assertEquals(3, query().from(cat).select(cat.birthdate.hour()).fetchFirst().orElse(null).intValue());
+        assertEquals(4, query().from(cat).select(cat.birthdate.minute()).fetchFirst().orElse(null).intValue());
+        assertEquals(0, query().from(cat).select(cat.birthdate.second()).fetchFirst().orElse(null).intValue());
     }
 
     @Test
     @NoEclipseLink({DERBY, HSQLDB})
     @NoHibernate({DERBY, POSTGRESQL, SQLSERVER})
     public void date_yearWeek() {
-        int value = query().from(cat).select(cat.birthdate.yearWeek()).fetchFirst();
+        int value = query().from(cat).select(cat.birthdate.yearWeek()).fetchFirst().orElse(null);
         assertTrue(value == 200006 || value == 200005);
     }
 
@@ -689,7 +689,7 @@ public abstract class AbstractJPATest {
     @NoEclipseLink({DERBY, HSQLDB})
     @NoHibernate({DERBY, POSTGRESQL, SQLSERVER})
     public void date_week() {
-        int value = query().from(cat).select(cat.birthdate.week()).fetchFirst();
+        int value = query().from(cat).select(cat.birthdate.week()).fetchFirst().orElse(null);
         assertTrue(value == 6 || value == 5);
     }
 
@@ -806,7 +806,7 @@ public abstract class AbstractJPATest {
                 .leftJoin(cat2.kittens, kitten)
                 .select(Projections.tuple(cat.id, new QFamily(cat, cat2, kitten).skipNulls()));
         assertEquals(6, query.fetch().size());
-        assertNotNull(query.limit(1).fetchOne());
+        assertNotNull(query.limit(1).fetchOne().orElse(null));
     }
 
     @Test
@@ -986,14 +986,14 @@ public abstract class AbstractJPATest {
     @NoOpenJPA
     public void indexOf() {
         assertEquals(Integer.valueOf(0), query().from(cat).where(cat.name.eq("Bob123"))
-                .select(cat.name.indexOf("B")).fetchFirst());
+                .select(cat.name.indexOf("B")).fetchFirst().orElse(null));
     }
 
     @Test
     @NoOpenJPA
     public void indexOf2() {
         assertEquals(Integer.valueOf(1), query().from(cat).where(cat.name.eq("Bob123"))
-                .select(cat.name.indexOf("o")).fetchFirst());
+                .select(cat.name.indexOf("o")).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1206,12 +1206,12 @@ public abstract class AbstractJPATest {
 
     @Test
     public void max() {
-        assertEquals(6.0, query().from(cat).select(cat.bodyWeight.max()).fetchFirst(), 0.0001);
+        assertEquals(6.0, query().from(cat).select(cat.bodyWeight.max()).fetchFirst().orElse(null), 0.0001);
     }
 
     @Test
     public void min() {
-        assertEquals(1.0, query().from(cat).select(cat.bodyWeight.min()).fetchFirst(), 0.0001);
+        assertEquals(1.0, query().from(cat).select(cat.bodyWeight.min()).fetchFirst().orElse(null), 0.0001);
     }
 
     @Test
@@ -1269,16 +1269,10 @@ public abstract class AbstractJPATest {
     }
 
     @Test
-    public void null_as_uniqueResult() {
-        assertNull(query().from(cat).where(cat.name.eq(UUID.randomUUID().toString()))
-                .select(cat).fetchFirst());
-    }
-
-    @Test
     @NoEclipseLink
     public void numeric() {
         QNumeric numeric = QNumeric.numeric;
-        BigDecimal singleResult = query().from(numeric).select(numeric.value).fetchFirst();
+        BigDecimal singleResult = query().from(numeric).select(numeric.value).fetchFirst().orElse(null);
         assertEquals(26.9, singleResult.doubleValue(), 0.001);
     }
 
@@ -1358,7 +1352,7 @@ public abstract class AbstractJPATest {
     public void order_nullsFirst() {
         assertNull(query().from(cat)
                 .orderBy(cat.dateField.asc().nullsFirst())
-                .select(cat.dateField).fetchFirst());
+                .select(cat.dateField).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1367,27 +1361,27 @@ public abstract class AbstractJPATest {
     public void order_nullsLast() {
         assertNotNull(query().from(cat)
                 .orderBy(cat.dateField.asc().nullsLast())
-                .select(cat.dateField).fetchFirst());
+                .select(cat.dateField).fetchFirst().orElse(null));
     }
 
     @Test
     public void params() {
         Param<String> name = new Param<String>(String.class,"name");
         assertEquals("Bob123", query().from(cat).where(cat.name.eq(name)).set(name, "Bob123")
-                .select(cat.name).fetchFirst());
+                .select(cat.name).fetchFirst().orElse(null));
     }
 
     @Test
     public void params_anon() {
         Param<String> name = new Param<String>(String.class);
         assertEquals("Bob123",query().from(cat).where(cat.name.eq(name)).set(name, "Bob123")
-                .select(cat.name).fetchFirst());
+                .select(cat.name).fetchFirst().orElse(null));
     }
 
     @Test(expected = ParamNotSetException.class)
     public void params_not_set() {
         Param<String> name = new Param<String>(String.class,"name");
-        assertEquals("Bob123", query().from(cat).where(cat.name.eq(name)).select(cat.name).fetchFirst());
+        assertEquals("Bob123", query().from(cat).where(cat.name.eq(name)).select(cat.name).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1454,7 +1448,7 @@ public abstract class AbstractJPATest {
         assertEquals(0, query().from(cat).where(cat.name.startsWith("r")).fetchCount());
         assertEquals(0, query().from(cat).where(cat.name.endsWith("H123")).fetchCount());
         assertEquals(Integer.valueOf(2), query().from(cat).where(cat.name.eq("Bob123"))
-                .select(cat.name.indexOf("b")).fetchFirst());
+                .select(cat.name.indexOf("b")).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1517,24 +1511,24 @@ public abstract class AbstractJPATest {
     public void substring2() {
         QCompany company = QCompany.company;
         StringExpression name = company.name;
-        Integer companyId = query().from(company).select(company.id).fetchFirst();
+        Integer companyId = query().from(company).select(company.id).fetchFirst().orElse(null);
         JPQLQuery<?> query = query().from(company).where(company.id.eq(companyId));
-        String str = query.select(company.name).fetchFirst();
+        String str = query.select(company.name).fetchFirst().orElse(null);
 
         assertEquals(Integer.valueOf(29),
-                query.select(name.length().subtract(11)).fetchFirst());
+                query.select(name.length().subtract(11)).fetchFirst().orElse(null));
 
         assertEquals(str.substring(0, 7),
-                query.select(name.substring(0, 7)).fetchFirst());
+                query.select(name.substring(0, 7)).fetchFirst().orElse(null));
 
         assertEquals(str.substring(15),
-                query.select(name.substring(15)).fetchFirst());
+                query.select(name.substring(15)).fetchFirst().orElse(null));
 
         assertEquals(str.substring(str.length()),
-                query.select(name.substring(name.length())).fetchFirst());
+                query.select(name.substring(name.length())).fetchFirst().orElse(null));
 
         assertEquals(str.substring(str.length() - 11),
-                query.select(name.substring(name.length().subtract(11))).fetchFirst());
+                query.select(name.substring(name.length().subtract(11))).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1584,27 +1578,27 @@ public abstract class AbstractJPATest {
 
     @Test
     public void sum_3() {
-        assertEquals(21.0, query().from(cat).select(cat.bodyWeight.sum()).fetchFirst(), 0.0001);
+        assertEquals(21.0, query().from(cat).select(cat.bodyWeight.sum()).fetchFirst().orElse(null), 0.0001);
     }
 
     @Test
     public void sum_3_projected() {
-        double val = query().from(cat).select(cat.bodyWeight.sum()).fetchFirst();
+        double val = query().from(cat).select(cat.bodyWeight.sum()).fetchFirst().orElse(null);
         DoubleProjection projection = query().from(cat)
-                .select(new QDoubleProjection(cat.bodyWeight.sum())).fetchFirst();
+                .select(new QDoubleProjection(cat.bodyWeight.sum())).fetchFirst().orElse(null);
         assertEquals(val, projection.val, 0.001);
     }
 
     @Test
     public void sum_4() {
-        Double dbl = query().from(cat).select(cat.bodyWeight.sum().negate()).fetchFirst();
+        Double dbl = query().from(cat).select(cat.bodyWeight.sum().negate()).fetchFirst().orElse(null);
         assertNotNull(dbl);
     }
 
     @Test
     public void sum_5() {
         QShow show = QShow.show;
-        Long lng = query().from(show).select(show.id.sum()).fetchFirst();
+        Long lng = query().from(show).select(show.id.sum()).fetchFirst().orElse(null);
         assertNotNull(lng);
     }
 
@@ -1637,27 +1631,27 @@ public abstract class AbstractJPATest {
 
     @Test
     public void sum_as_float() {
-        float val = query().from(cat).select(cat.floatProperty.sum()).fetchFirst();
+        float val = query().from(cat).select(cat.floatProperty.sum()).fetchFirst().orElse(null);
         assertTrue(val > 0);
     }
 
     @Test
     public void sum_as_float_projected() {
-        float val = query().from(cat).select(cat.floatProperty.sum()).fetchFirst();
+        float val = query().from(cat).select(cat.floatProperty.sum()).fetchFirst().orElse(null);
         FloatProjection projection = query().from(cat)
-                .select(new QFloatProjection(cat.floatProperty.sum())).fetchFirst();
+                .select(new QFloatProjection(cat.floatProperty.sum())).fetchFirst().orElse(null);
         assertEquals(val, projection.val, 0.001);
     }
 
     @Test
     public void sum_as_float2() {
-        float val = query().from(cat).select(cat.floatProperty.sum().negate()).fetchFirst();
+        float val = query().from(cat).select(cat.floatProperty.sum().negate()).fetchFirst().orElse(null);
         assertTrue(val < 0);
     }
 
     @Test
     public void sum_coalesce() {
-        int val = query().from(cat).select(cat.weight.sum().coalesce(0)).fetchFirst();
+        int val = query().from(cat).select(cat.weight.sum().coalesce(0)).fetchFirst().orElse(null);
         assertEquals(0, val);
     }
 
@@ -1665,14 +1659,14 @@ public abstract class AbstractJPATest {
     public void sum_noRows_double() {
         assertNull(query().from(cat)
                 .where(cat.name.eq(UUID.randomUUID().toString()))
-                .select(cat.bodyWeight.sum()).fetchFirst());
+                .select(cat.bodyWeight.sum()).fetchFirst().orElse(null));
     }
 
     @Test
     public void sum_noRows_float() {
         assertNull(query().from(cat)
                 .where(cat.name.eq(UUID.randomUUID().toString()))
-                .select(cat.floatProperty.sum()).fetchFirst());
+                .select(cat.floatProperty.sum()).fetchFirst().orElse(null));
     }
 
     @Test

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractSQLTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/AbstractSQLTest.java
@@ -7,7 +7,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -51,7 +50,7 @@ public abstract class AbstractSQLTest {
     @Test
     public void count_via_unique() {
         assertEquals(Long.valueOf(6), query().from(cat).where(cat.dtype.eq("C"))
-                .select(cat.id.count()).fetchFirst());
+                .select(cat.id.count()).fetchFirst().orElse(null));
     }
 
     @Test
@@ -108,7 +107,7 @@ public abstract class AbstractSQLTest {
     @Test
     public void entityQueries3() {
         QCat catEntity = new QCat("animal_");
-        assertEquals(0, query().from(catEntity).select(catEntity.toes.max()).fetchFirst().intValue());
+        assertEquals(0, query().from(catEntity).select(catEntity.toes.max()).fetchFirst().orElse(null).intValue());
     }
 
     @Test
@@ -243,13 +242,7 @@ public abstract class AbstractSQLTest {
     @Test
     @ExcludeIn(Target.HSQLDB)
     public void no_from() {
-        assertNotNull(query().select(DateExpression.currentDate()).fetchFirst());
-    }
-
-    @Test
-    public void null_as_uniqueResult() {
-        assertNull(query().from(cat).where(cat.name.eq(UUID.randomUUID().toString()))
-                .select(cat.name).fetchOne());
+        assertNotNull(query().select(DateExpression.currentDate()).fetchFirst().orElse(null));
     }
 
     private void print(Iterable<Tuple> rows) {
@@ -266,12 +259,12 @@ public abstract class AbstractSQLTest {
 
     @Test
     public void single_result() {
-        query().from(cat).select(cat.id).fetchFirst();
+        query().from(cat).select(cat.id).fetchFirst().orElse(null);
     }
 
     @Test
     public void single_result_multiple() {
-        assertEquals(1, query().from(cat).orderBy(cat.id.asc()).select(new Expression<?>[]{cat.id}).fetchFirst().get(cat.id).intValue());
+        assertEquals(1, query().from(cat).orderBy(cat.id.asc()).select(new Expression<?>[]{cat.id}).fetchFirst().orElse(null).get(cat.id).intValue());
     }
 
     @Test
@@ -362,13 +355,13 @@ public abstract class AbstractSQLTest {
     @Test
     public void unique_result() {
         assertEquals(1,
-                query().from(cat).orderBy(cat.id.asc()).limit(1).select(cat.id).fetchOne().intValue());
+                query().from(cat).orderBy(cat.id.asc()).limit(1).select(cat.id).fetchOne().orElse(null).intValue());
     }
 
     @Test
     public void unique_result_multiple() {
         assertEquals(1,
-                query().from(cat).orderBy(cat.id.asc()).limit(1).select(new Expression<?>[]{cat.id}).fetchOne().get(cat.id).intValue());
+                query().from(cat).orderBy(cat.id.asc()).limit(1).select(new Expression<?>[]{cat.id}).fetchOne().orElse(null).get(cat.id).intValue());
     }
 
     @Test

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
@@ -211,7 +211,7 @@ public class JPABase extends AbstractJPATest implements JPATest {
 
     @Test
     public void limit1_uniqueResult() {
-        assertNotNull(query().from(cat).limit(1).select(cat).fetchOne());
+        assertNotNull(query().from(cat).limit(1).select(cat).fetchOne().get());
     }
 
     @Test
@@ -245,7 +245,7 @@ public class JPABase extends AbstractJPATest implements JPATest {
         BooleanExpression exists = selectOne().from(cat2).where(cat2.eyecolor.isNotNull()).exists();
         assertNotNull(query().from(cat)
                 .where(cat.breed.eq(0).not())
-                .select(new QCatSummary(cat.breed.count(), exists)).fetchOne());
+                .select(new QCatSummary(cat.breed.count(), exists)).fetchOne().get());
     }
 
     @SuppressWarnings("unchecked")

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -87,7 +88,7 @@ class QueryHelper<T> extends JPAQueryBase<T, QueryHelper<T>> {
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         throw new UnsupportedOperationException();
     }
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryPerformanceTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryPerformanceTest.java
@@ -67,7 +67,7 @@ public class QueryPerformanceTest implements JPATest {
         long start = System.currentTimeMillis();
         for (int i = 0; i < iterations; i++) {
             QCat cat = QCat.cat;
-            Cat c = query().from(cat).where(cat.id.eq(i + 100)).select(cat).fetchOne();
+            Cat c = query().from(cat).where(cat.id.eq(i + 100)).select(cat).fetchOne().get();
             assertNotNull(c);
         }
         System.err.println("by id - dsl" + (System.currentTimeMillis() - start));
@@ -90,7 +90,7 @@ public class QueryPerformanceTest implements JPATest {
         long start = System.currentTimeMillis();
         for (int i = 0; i < iterations; i++) {
             QCat cat = QCat.cat;
-            Tuple row = query().from(cat).where(cat.id.eq(i + 100)).select(cat.id, cat.name).fetchOne();
+            Tuple row = query().from(cat).where(cat.id.eq(i + 100)).select(cat.id, cat.name).fetchOne().get();
             assertNotNull(row);
         }
         System.err.println("by id - 2 cols - dsl" + (System.currentTimeMillis() - start));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/UniqueResultsTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/UniqueResultsTest.java
@@ -37,11 +37,11 @@ public class UniqueResultsTest implements HibernateTest {
         session.save(new Cat("Bob2", 2));
         session.save(new Cat("Bob3", 3));
 
-        assertEquals(Integer.valueOf(1), query().from(cat).orderBy(cat.name.asc()).offset(0).limit(1).select(cat.id).fetchOne());
-        assertEquals(Integer.valueOf(2), query().from(cat).orderBy(cat.name.asc()).offset(1).limit(1).select(cat.id).fetchOne());
-        assertEquals(Integer.valueOf(3), query().from(cat).orderBy(cat.name.asc()).offset(2).limit(1).select(cat.id).fetchOne());
+        assertEquals(Integer.valueOf(1), query().from(cat).orderBy(cat.name.asc()).offset(0).limit(1).select(cat.id).fetchOne().get());
+        assertEquals(Integer.valueOf(2), query().from(cat).orderBy(cat.name.asc()).offset(1).limit(1).select(cat.id).fetchOne().get());
+        assertEquals(Integer.valueOf(3), query().from(cat).orderBy(cat.name.asc()).offset(2).limit(1).select(cat.id).fetchOne().get());
 
-        assertEquals(Long.valueOf(3), query().from(cat).select(cat.count()).fetchOne());
+        assertEquals(Long.valueOf(3), query().from(cat).select(cat.count()).fetchOne().get());
     }
 
     private HibernateQuery<?> query() {

--- a/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
+++ b/querydsl-lucene3/src/main/java/com/querydsl/lucene3/AbstractLuceneQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.lucene3;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -284,12 +285,11 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
         return (Q) this;
     }
 
-    @Nullable
-    private T oneResult(boolean unique) {
+    private Optional<T> oneResult(boolean unique) {
         try {
             int maxDoc = maxDoc();
             if (maxDoc == 0) {
-                return null;
+                return Optional.empty();
             }
             final ScoreDoc[] scoreDocs = searcher.search(createQuery(), getFilter(), maxDoc).scoreDocs;
             int index = 0;
@@ -309,9 +309,9 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
                 } else {
                     document = searcher.doc(scoreDocs[index].doc);
                 }
-                return transformer.apply(document);
+                return Optional.ofNullable(transformer.apply(document));
             } else {
-                return null;
+                return Optional.empty();
             }
         } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
@@ -319,12 +319,12 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
     }
 
     @Override
-    public T fetchFirst() {
+    public Optional<T> fetchFirst() {
         return oneResult(false);
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         return oneResult(true);
     }
 

--- a/querydsl-lucene3/src/test/java/com/querydsl/lucene3/LuceneQueryTest.java
+++ b/querydsl-lucene3/src/test/java/com/querydsl/lucene3/LuceneQueryTest.java
@@ -452,21 +452,21 @@ public class LuceneQueryTest {
 
     @Test
     public void load_singleResult() {
-        Document document = query.where(title.ne("")).load(title).fetchFirst();
+        Document document = query.where(title.ne("")).load(title).fetchFirst().get();
         assertNotNull(document.get("title"));
         assertNull(document.get("year"));
     }
 
     @Test
     public void load_singleResult_fieldSelector() {
-        Document document = query.where(title.ne("")).load(new MapFieldSelector("title")).fetchFirst();
+        Document document = query.where(title.ne("")).load(new MapFieldSelector("title")).fetchFirst().get();
         assertNotNull(document.get("title"));
         assertNull(document.get("year"));
     }
 
     @Test
     public void singleResult() {
-        assertNotNull(query.where(title.ne("")).fetchFirst());
+        assertNotNull(query.where(title.ne("")).fetchFirst().orElse(null));
     }
 
     @Test
@@ -474,35 +474,35 @@ public class LuceneQueryTest {
         assertEquals("Jurassic Park", query
                                         .where(title.ne(""))
                                         .limit(1)
-                                        .fetchFirst().get("title"));
+                                        .fetchFirst().get().get("title"));
     }
 
     @Test
     public void single_result_considers_limit_and_actual_result_size() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.limit(3).fetchFirst();
+        final Document document = query.limit(3).fetchFirst().get();
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
     @Test
     public void single_result_returns_null_if_nothing_is_in_range() {
         query.where(title.startsWith("Nummi"));
-        assertNull(query.offset(10).fetchFirst());
+        assertNull(query.offset(10).fetchFirst().orElse(null));
     }
 
     @Test
     public void single_result_considers_offset() {
-        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchFirst().get("title"));
+        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchFirst().get().get("title"));
     }
 
     @Test
     public void single_result_considers_limit_and_offset() {
-        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchFirst().get("title"));
+        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchFirst().get().get("title"));
     }
 
     @Test(expected = NonUniqueResultException.class)
     public void uniqueResult_contract() {
-        query.where(title.ne("")).fetchOne();
+        query.where(title.ne("")).fetchOne().orElse(null);
     }
 
     @Test
@@ -510,36 +510,36 @@ public class LuceneQueryTest {
         assertEquals("Jurassic Park", query
                                         .where(title.ne(""))
                                         .limit(1)
-                                        .fetchOne().get("title"));
+                                        .fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void unique_result_considers_limit_and_actual_result_size() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.limit(3).fetchOne();
+        final Document document = query.limit(3).fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
     @Test
     public void unique_result_returns_null_if_nothing_is_in_range() {
         query.where(title.startsWith("Nummi"));
-        assertNull(query.offset(10).fetchOne());
+        assertNull(query.offset(10).fetchOne().orElse(null));
     }
 
     @Test
     public void unique_result_considers_offset() {
-        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchOne().get("title"));
+        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void unique_result_considers_limit_and_offset() {
-        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchOne().get("title"));
+        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void uniqueResult() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.fetchOne();
+        final Document document = query.fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
@@ -548,7 +548,7 @@ public class LuceneQueryTest {
         final Param<String> param = new Param<String>(String.class, "title");
         query.set(param, "Nummi");
         query.where(title.startsWith(param));
-        final Document document = query.fetchOne();
+        final Document document = query.fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
@@ -556,19 +556,19 @@ public class LuceneQueryTest {
     public void uniqueResult_param_not_set() {
         final Param<String> param = new Param<String>(String.class, "title");
         query.where(title.startsWith(param));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
     }
 
     @Test(expected = QueryException.class)
     public void uniqueResult_finds_more_than_one_result() {
         query.where(year.eq(1990));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
     }
 
     @Test
     public void uniqueResult_finds_no_results() {
         query.where(year.eq(2200));
-        assertNull(query.fetchOne());
+        assertNull(query.fetchOne().orElse(null));
     }
 
     @Test
@@ -579,7 +579,7 @@ public class LuceneQueryTest {
         query = new LuceneQuery(new LuceneSerializer(true, true), searcher);
         expect(searcher.maxDoc()).andReturn(0);
         replay(searcher);
-        assertNull(query.where(year.eq(3000)).fetchOne());
+        assertNull(query.where(year.eq(3000)).fetchOne().orElse(null));
         verify(searcher);
     }
 
@@ -592,7 +592,7 @@ public class LuceneQueryTest {
         expect(searcher.maxDoc()).andThrow(new IllegalArgumentException());
         replay(searcher);
         query.where(title.eq("Jurassic Park"));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
         verify(searcher);
     }
 

--- a/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
+++ b/querydsl-lucene4/src/main/java/com/querydsl/lucene4/AbstractLuceneQuery.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -286,12 +287,11 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
         return (Q) this;
     }
 
-    @Nullable
-    private T oneResult(boolean unique) {
+    private Optional<T> oneResult(boolean unique) {
         try {
             int maxDoc = maxDoc();
             if (maxDoc == 0) {
-                return null;
+                return Optional.empty();
             }
             final ScoreDoc[] scoreDocs = searcher.search(createQuery(), getFilter(), maxDoc, Sort.INDEXORDER, false, false).scoreDocs;
             int index = 0;
@@ -311,9 +311,9 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
                 } else {
                     document = searcher.doc(scoreDocs[index].doc);
                 }
-                return transformer.apply(document);
+                return Optional.ofNullable(transformer.apply(document));
             } else {
-                return null;
+                return Optional.empty();
             }
         } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
@@ -321,12 +321,12 @@ public abstract class AbstractLuceneQuery<T,Q extends AbstractLuceneQuery<T,Q>> 
     }
 
     @Override
-    public T fetchFirst() {
+    public Optional<T> fetchFirst() {
         return oneResult(false);
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         return oneResult(true);
     }
 

--- a/querydsl-lucene4/src/test/java/com/querydsl/lucene4/LuceneQueryTest.java
+++ b/querydsl-lucene4/src/test/java/com/querydsl/lucene4/LuceneQueryTest.java
@@ -449,21 +449,21 @@ public class LuceneQueryTest {
 
     @Test
     public void load_singleResult() {
-        Document document = query.where(title.ne("")).load(title).fetchFirst();
+        Document document = query.where(title.ne("")).load(title).fetchFirst().orElse(null);
         assertNotNull(document.get("title"));
         assertNull(document.get("year"));
     }
 
     @Test
     public void load_singleResult_fieldSelector() {
-        Document document = query.where(title.ne("")).load(Sets.newHashSet("title")).fetchFirst();
+        Document document = query.where(title.ne("")).load(Sets.newHashSet("title")).fetchFirst().orElse(null);
         assertNotNull(document.get("title"));
         assertNull(document.get("year"));
     }
 
     @Test
     public void singleResult() {
-        assertNotNull(query.where(title.ne("")).fetchFirst());
+        assertNotNull(query.where(title.ne("")).fetchFirst().orElse(null));
     }
 
     @Test
@@ -471,35 +471,35 @@ public class LuceneQueryTest {
         assertEquals("Jurassic Park", query
                                         .where(title.ne(""))
                                         .limit(1)
-                                        .fetchFirst().get("title"));
+                                        .fetchFirst().orElse(null).get("title"));
     }
 
     @Test
     public void single_result_considers_limit_and_actual_result_size() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.limit(3).fetchFirst();
+        final Document document = query.limit(3).fetchFirst().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
     @Test
     public void single_result_returns_null_if_nothing_is_in_range() {
         query.where(title.startsWith("Nummi"));
-        assertNull(query.offset(10).fetchFirst());
+        assertNull(query.offset(10).fetchFirst().orElse(null));
     }
 
     @Test
     public void single_result_considers_offset() {
-        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchFirst().get("title"));
+        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchFirst().orElse(null).get("title"));
     }
 
     @Test
     public void single_result_considers_limit_and_offset() {
-        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchFirst().get("title"));
+        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchFirst().orElse(null).get("title"));
     }
 
     @Test(expected = NonUniqueResultException.class)
     public void uniqueResult_contract() {
-        query.where(title.ne("")).fetchOne();
+        query.where(title.ne("")).fetchOne().orElse(null);
     }
 
     @Test
@@ -507,36 +507,36 @@ public class LuceneQueryTest {
         assertEquals("Jurassic Park", query
                                         .where(title.ne(""))
                                         .limit(1)
-                                        .fetchOne().get("title"));
+                                        .fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void unique_result_considers_limit_and_actual_result_size() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.limit(3).fetchOne();
+        final Document document = query.limit(3).fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
     @Test
     public void unique_result_returns_null_if_nothing_is_in_range() {
         query.where(title.startsWith("Nummi"));
-        assertNull(query.offset(10).fetchOne());
+        assertNull(query.offset(10).fetchOne().orElse(null));
     }
 
     @Test
     public void unique_result_considers_offset() {
-        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchOne().get("title"));
+        assertEquals("Introduction to Algorithms", query.where(title.ne("")).offset(3).fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void unique_result_considers_limit_and_offset() {
-        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchOne().get("title"));
+        assertEquals("The Lord of the Rings", query.where(title.ne("")).limit(1).offset(2).fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void uniqueResult() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.fetchOne();
+        final Document document = query.fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
@@ -545,7 +545,7 @@ public class LuceneQueryTest {
         final Param<String> param = new Param<String>(String.class, "title");
         query.set(param, "Nummi");
         query.where(title.startsWith(param));
-        final Document document = query.fetchOne();
+        final Document document = query.fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
@@ -553,19 +553,19 @@ public class LuceneQueryTest {
     public void uniqueResult_param_not_set() {
         final Param<String> param = new Param<String>(String.class, "title");
         query.where(title.startsWith(param));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
     }
 
     @Test(expected = QueryException.class)
     public void uniqueResult_finds_more_than_one_result() {
         query.where(year.eq(1990));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
     }
 
     @Test
     public void uniqueResult_finds_no_results() {
         query.where(year.eq(2200));
-        assertNull(query.fetchOne());
+        assertNull(query.fetchOne().orElse(null));
     }
 
     @Test
@@ -577,7 +577,7 @@ public class LuceneQueryTest {
         query = new LuceneQuery(new LuceneSerializer(true, true), searcher);
         expect(searcher.getIndexReader().maxDoc()).andReturn(0);
         replay(searcher);
-        assertNull(query.where(year.eq(3000)).fetchOne());
+        assertNull(query.where(year.eq(3000)).fetchOne().orElse(null));
         verify(searcher);
     }
 
@@ -591,7 +591,7 @@ public class LuceneQueryTest {
         expect(searcher.getIndexReader().maxDoc()).andThrow(new IllegalArgumentException());
         replay(searcher);
         query.where(title.eq("Jurassic Park"));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
         verify(searcher);
     }
 

--- a/querydsl-lucene5/pom.xml
+++ b/querydsl-lucene5/pom.xml
@@ -96,13 +96,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>

--- a/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
+++ b/querydsl-lucene5/src/main/java/com/querydsl/lucene5/AbstractLuceneQuery.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -322,12 +323,11 @@ public abstract class AbstractLuceneQuery<T, Q extends AbstractLuceneQuery<T, Q>
         return (Q) this;
     }
 
-    @Nullable
-    private T oneResult(boolean unique) {
+    private Optional<T> oneResult(boolean unique) {
         try {
             int maxDoc = maxDoc();
             if (maxDoc == 0) {
-                return null;
+                return Optional.empty();
             }
             final ScoreDoc[] scoreDocs = searcher.search(createQuery(),
                     maxDoc, Sort.INDEXORDER, false, false).scoreDocs;
@@ -351,9 +351,9 @@ public abstract class AbstractLuceneQuery<T, Q extends AbstractLuceneQuery<T, Q>
                 } else {
                     document = searcher.doc(scoreDocs[index].doc);
                 }
-                return transformer.apply(document);
+                return Optional.ofNullable(transformer.apply(document));
             } else {
-                return null;
+                return Optional.empty();
             }
         } catch (IOException | IllegalArgumentException e) {
             throw new QueryException(e);
@@ -361,12 +361,12 @@ public abstract class AbstractLuceneQuery<T, Q extends AbstractLuceneQuery<T, Q>
     }
 
     @Override
-    public T fetchFirst() {
+    public Optional<T> fetchFirst() {
         return oneResult(false);
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         return oneResult(true);
     }
 

--- a/querydsl-lucene5/src/test/java/com/querydsl/lucene5/LuceneQueryTest.java
+++ b/querydsl-lucene5/src/test/java/com/querydsl/lucene5/LuceneQueryTest.java
@@ -529,7 +529,7 @@ public class LuceneQueryTest {
 
     @Test
     public void load_singleResult() {
-        Document document = query.where(title.ne("")).load(title).fetchFirst();
+        Document document = query.where(title.ne("")).load(title).fetchFirst().orElse(null);
         assertNotNull(document.get("title"));
         assertNull(document.get("year"));
     }
@@ -537,87 +537,87 @@ public class LuceneQueryTest {
     @Test
     public void load_singleResult_fieldSelector() {
         Document document = query.where(title.ne(""))
-                .load(Sets.newHashSet("title")).fetchFirst();
+                .load(Sets.newHashSet("title")).fetchFirst().orElse(null);
         assertNotNull(document.get("title"));
         assertNull(document.get("year"));
     }
 
     @Test
     public void singleResult() {
-        assertNotNull(query.where(title.ne("")).fetchFirst());
+        assertNotNull(query.where(title.ne("")).fetchFirst().orElse(null));
     }
 
     @Test
     public void single_result_takes_limit() {
         assertEquals("Jurassic Park", query.where(title.ne("")).limit(1)
-                .fetchFirst().get("title"));
+                .fetchFirst().orElse(null).get("title"));
     }
 
     @Test
     public void single_result_considers_limit_and_actual_result_size() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.limit(3).fetchFirst();
+        final Document document = query.limit(3).fetchFirst().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
     @Test
     public void single_result_returns_null_if_nothing_is_in_range() {
         query.where(title.startsWith("Nummi"));
-        assertNull(query.offset(10).fetchFirst());
+        assertNull(query.offset(10).fetchFirst().orElse(null));
     }
 
     @Test
     public void single_result_considers_offset() {
         assertEquals("Introduction to Algorithms", query.where(title.ne(""))
-                .offset(3).fetchFirst().get("title"));
+                .offset(3).fetchFirst().orElse(null).get("title"));
     }
 
     @Test
     public void single_result_considers_limit_and_offset() {
         assertEquals("The Lord of the Rings", query.where(title.ne(""))
-                .limit(1).offset(2).fetchFirst().get("title"));
+                .limit(1).offset(2).fetchFirst().orElse(null).get("title"));
     }
 
     @Test(expected = NonUniqueResultException.class)
     public void uniqueResult_contract() {
-        query.where(title.ne("")).fetchOne();
+        query.where(title.ne("")).fetchOne().orElse(null);
     }
 
     @Test
     public void unique_result_takes_limit() {
         assertEquals("Jurassic Park", query.where(title.ne("")).limit(1)
-                .fetchOne().get("title"));
+                .fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void unique_result_considers_limit_and_actual_result_size() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.limit(3).fetchOne();
+        final Document document = query.limit(3).fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
     @Test
     public void unique_result_returns_null_if_nothing_is_in_range() {
         query.where(title.startsWith("Nummi"));
-        assertNull(query.offset(10).fetchOne());
+        assertNull(query.offset(10).fetchOne().orElse(null));
     }
 
     @Test
     public void unique_result_considers_offset() {
         assertEquals("Introduction to Algorithms", query.where(title.ne(""))
-                .offset(3).fetchOne().get("title"));
+                .offset(3).fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void unique_result_considers_limit_and_offset() {
         assertEquals("The Lord of the Rings", query.where(title.ne(""))
-                .limit(1).offset(2).fetchOne().get("title"));
+                .limit(1).offset(2).fetchOne().orElse(null).get("title"));
     }
 
     @Test
     public void uniqueResult() {
         query.where(title.startsWith("Nummi"));
-        final Document document = query.fetchOne();
+        final Document document = query.fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
@@ -626,7 +626,7 @@ public class LuceneQueryTest {
         final Param<String> param = new Param<String>(String.class, "title");
         query.set(param, "Nummi");
         query.where(title.startsWith(param));
-        final Document document = query.fetchOne();
+        final Document document = query.fetchOne().orElse(null);
         assertEquals("Nummisuutarit", document.get("title"));
     }
 
@@ -634,19 +634,19 @@ public class LuceneQueryTest {
     public void uniqueResult_param_not_set() {
         final Param<String> param = new Param<String>(String.class, "title");
         query.where(title.startsWith(param));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
     }
 
     @Test(expected = QueryException.class)
     public void uniqueResult_finds_more_than_one_result() {
         query.where(year.eq(1990));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
     }
 
     @Test
     public void uniqueResult_finds_no_results() {
         query.where(year.eq(2200));
-        assertNull(query.fetchOne());
+        assertNull(query.fetchOne().orElse(null));
     }
 
     @Test
@@ -658,7 +658,7 @@ public class LuceneQueryTest {
         query = new LuceneQuery(new LuceneSerializer(true, true), searcher);
         expect(searcher.getIndexReader().maxDoc()).andReturn(0);
         replay(searcher);
-        assertNull(query.where(year.eq(3000)).fetchOne());
+        assertNull(query.where(year.eq(3000)).fetchOne().orElse(null));
         verify(searcher);
     }
 
@@ -673,7 +673,7 @@ public class LuceneQueryTest {
                 new IllegalArgumentException());
         replay(searcher);
         query.where(title.eq("Jurassic Park"));
-        query.fetchOne();
+        query.fetchOne().orElse(null);
         verify(searcher);
     }
 

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/AbstractMongodbQuery.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/AbstractMongodbQuery.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -307,22 +308,22 @@ public abstract class AbstractMongodbQuery<K, Q extends AbstractMongodbQuery<K, 
      * @param paths fields to return
      * @return first result
      */
-    public K fetchFirst(Path<?>...paths) {
+    public Optional<K> fetchFirst(Path<?>...paths) {
         queryMixin.setProjection(paths);
         return fetchFirst();
     }
 
     @Override
-    public K fetchFirst() {
+    public Optional<K> fetchFirst() {
         try {
             DBCursor c = createCursor().limit(1);
             if (c.hasNext()) {
-                return transformer.apply(c.next());
+                return Optional.ofNullable(transformer.apply(c.next()));
             } else {
-                return null;
+                return Optional.empty();
             }
         } catch (NoResults ex) {
-            return null;
+            return Optional.empty();
         }
     }
 
@@ -332,13 +333,13 @@ public abstract class AbstractMongodbQuery<K, Q extends AbstractMongodbQuery<K, 
      * @param paths fields to return
      * @return first result
      */
-    public K fetchOne(Path<?>... paths) {
+    public Optional<K> fetchOne(Path<?>... paths) {
         queryMixin.setProjection(paths);
         return fetchOne();
     }
 
     @Override
-    public K fetchOne() throws NonUniqueResultException {
+    public Optional<K> fetchOne() throws NonUniqueResultException {
         try {
             Long limit = queryMixin.getMetadata().getModifiers().getLimit();
             if (limit == null) {
@@ -350,12 +351,12 @@ public abstract class AbstractMongodbQuery<K, Q extends AbstractMongodbQuery<K, 
                 if (c.hasNext()) {
                     throw new NonUniqueResultException();
                 }
-                return rv;
+                return Optional.ofNullable(rv);
             } else {
-                return null;
+                return Optional.empty();
             }
         } catch (NoResults ex) {
-            return null;
+            return Optional.empty();
         }
     }
 

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/JoinTest.java
@@ -109,15 +109,15 @@ public class JoinTest {
 
     @Test
     public void single() {
-        assertEquals("Jane", where().join(user.friend(), friend).on(friend.firstName.eq("Max")).fetchFirst().getFirstName());
-        assertEquals("Jane", where(user.firstName.eq("Jane")).join(user.friend(), friend).on(friend.firstName.eq("Max")).fetchFirst().getFirstName());
-        assertNull(where(user.firstName.eq("Mary")).join(user.friend(), friend).on(friend.firstName.eq("Max")).fetchFirst());
-        assertNull(where(user.firstName.eq("Jane")).join(user.friend(), friend).on(friend.firstName.eq("Jack")).fetchFirst());
+        assertEquals("Jane", where().join(user.friend(), friend).on(friend.firstName.eq("Max")).fetchFirst().get().getFirstName());
+        assertEquals("Jane", where(user.firstName.eq("Jane")).join(user.friend(), friend).on(friend.firstName.eq("Max")).fetchFirst().get().getFirstName());
+        assertNull(where(user.firstName.eq("Mary")).join(user.friend(), friend).on(friend.firstName.eq("Max")).fetchFirst().orElse(null));
+        assertNull(where(user.firstName.eq("Jane")).join(user.friend(), friend).on(friend.firstName.eq("Jack")).fetchFirst().orElse(null));
     }
 
     @Test
     public void single_collection() {
-        assertEquals("Bart", where().join(user.friends, friend).on(friend.firstName.eq("Mary")).fetchFirst().getFirstName());
+        assertEquals("Bart", where().join(user.friends, friend).on(friend.firstName.eq("Mary")).fetchFirst().get().getFirstName());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class JoinTest {
         assertEquals("Mike", where()
                 .join(user.friend(), friend).on(friend.firstName.isNotNull())
                 .join(user.enemy(), enemy).on(enemy.firstName.isNotNull())
-                .fetchFirst().getFirstName());
+                .fetchFirst().get().getFirstName());
     }
 
     @Test
@@ -133,7 +133,7 @@ public class JoinTest {
         assertEquals("Mike", where()
                 .join(user.friend(), friend).on(friend.firstName.eq("Mary"))
                 .join(user.enemy(), enemy).on(enemy.firstName.eq("Ann"))
-                .fetchFirst().getFirstName());
+                .fetchFirst().get().getFirstName());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class JoinTest {
         assertEquals("Mike", where()
                 .join(user.friend(), friend).on(friend.firstName.isNotNull())
                 .join(friend.friend(), friend2).on(friend2.firstName.eq("Jane"))
-                .fetchFirst().getFirstName());
+                .fetchFirst().get().getFirstName());
     }
 
     private MorphiaQuery<User> query() {

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongodbQueryTest.java
@@ -106,21 +106,21 @@ public class MongodbQueryTest {
 
     @Test
     public void singleResult_keys() {
-        User u = where(user.firstName.eq("Jaakko")).fetchFirst(user.firstName);
+        User u = where(user.firstName.eq("Jaakko")).fetchFirst(user.firstName).get();
         assertEquals("Jaakko", u.getFirstName());
         assertNull(u.getLastName());
     }
 
     @Test
     public void uniqueResult_keys() {
-        User u = where(user.firstName.eq("Jaakko")).fetchOne(user.firstName);
+        User u = where(user.firstName.eq("Jaakko")).fetchOne(user.firstName).get();
         assertEquals("Jaakko", u.getFirstName());
         assertNull(u.getLastName());
     }
 
     @Test
     public void list_deep_keys() {
-        User u = where(user.firstName.eq("Jaakko")).fetchFirst(user.addresses.any().street);
+        User u = where(user.firstName.eq("Jaakko")).fetchFirst(user.addresses.any().street).get();
         for (Address a : u.getAddresses()) {
             assertNotNull(a.street);
             assertNull(a.city);
@@ -213,7 +213,7 @@ public class MongodbQueryTest {
 
     @Test
     public void find_by_id() {
-        assertNotNull(where(user.id.eq(u1.getId())).fetchFirst() != null);
+        assertNotNull(where(user.id.eq(u1.getId())).fetchFirst().orElse(null));
     }
 
     @Test
@@ -224,7 +224,7 @@ public class MongodbQueryTest {
 
     @Test
     public void uniqueResult() {
-        assertEquals("Jantunen", where(user.firstName.eq("Jaakko")).fetchOne().getLastName());
+        assertEquals("Jantunen", where(user.firstName.eq("Jaakko")).fetchOne().get().getLastName());
     }
 
     @Test(expected = NonUniqueResultException.class)
@@ -260,7 +260,7 @@ public class MongodbQueryTest {
         ds.save(d);
         Date end = new Date(current + 2 * dayInMillis);
 
-        assertEquals(d, query(dates).where(dates.date.between(start, end)).fetchFirst());
+        assertEquals(d, query(dates).where(dates.date.between(start, end)).fetchFirst().orElse(null));
         assertEquals(0, query(dates).where(dates.date.between(new Date(0), start)).fetchCount());
     }
 
@@ -598,7 +598,7 @@ public class MongodbQueryTest {
         Country germany = new Country("Germany", Locale.GERMANY);
         ds.save(germany);
 
-        Country fetchedCountry = query(Country.class).where(country.defaultLocale.eq(Locale.GERMANY)).fetchOne();
+        Country fetchedCountry = query(Country.class).where(country.defaultLocale.eq(Locale.GERMANY)).fetchOne().get();
         assertEquals(germany, fetchedCountry);
     }
 

--- a/querydsl-scala/src/test/scala/com/querydsl/scala/sql/JDBCIntegrationTest.scala
+++ b/querydsl-scala/src/test/scala/com/querydsl/scala/sql/JDBCIntegrationTest.scala
@@ -117,10 +117,10 @@ class JDBCIntegrationTest extends SQLHelpers {
 
   @Test
   def Unique_Result {
-    assertEquals("abc", query.from(survey).where(survey.id eq 1).select(survey.name).fetchOne())
-    assertEquals("def", query.from(survey).where(survey.id eq 2).select(survey.name).fetchOne())
-    assertEquals("Bob", query.from(employee).where(employee.lastname eq "Smith").select(employee.firstname).fetchOne())
-    assertEquals("John", query.from(employee).where(employee.lastname eq "Doe").select(employee.firstname).fetchOne())
+    assertEquals("abc", query.from(survey).where(survey.id eq 1).select(survey.name).fetchOne() orElse null)
+    assertEquals("def", query.from(survey).where(survey.id eq 2).select(survey.name).fetchOne() orElse null)
+    assertEquals("Bob", query.from(employee).where(employee.lastname eq "Smith").select(employee.firstname).fetchOne() orElse null)
+    assertEquals("John", query.from(employee).where(employee.lastname eq "Doe").select(employee.firstname).fetchOne() orElse null)
   }
 
   @Test
@@ -129,7 +129,7 @@ class JDBCIntegrationTest extends SQLHelpers {
     s.name = "XXX"
 
     val id = insert(survey) populate(s) executeWithKey(survey.id)
-    val sNew = query from survey where (survey.id === id) select (survey) fetchOne()
+    val sNew = query from survey where (survey.id === id) select (survey) fetchOne() orElse null
     assertEquals(s.name, sNew.name)
   }
 
@@ -145,7 +145,7 @@ class JDBCIntegrationTest extends SQLHelpers {
     val count = update(survey) populate(s) execute()
     assertTrue(count > 0)
 
-    val sNew = query from survey where (survey.id === id) select (survey) fetchOne()
+    val sNew = query from survey where (survey.id === id) select (survey) fetchOne() orElse null
     assertEquals(s.name, sNew.name)
   }
 

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/CustomTypesTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/CustomTypesTest.java
@@ -93,7 +93,7 @@ public class CustomTypesTest extends AbstractJDBCTest {
 
         // query
         SQLQuery<?> query = new SQLQuery<Void>(connection, configuration);
-        assertEquals(Gender.MALE, query.from(person).where(person.id.eq(10)).select(person.gender).fetchOne());
+        assertEquals(Gender.MALE, query.from(person).where(person.id.eq(10)).select(person.gender).fetchOne().orElse(null));
 
         // update
         SQLUpdateClause update = new SQLUpdateClause(connection, configuration, person);
@@ -104,7 +104,7 @@ public class CustomTypesTest extends AbstractJDBCTest {
 
         // query
         query = new SQLQuery<Void>(connection, configuration);
-        assertEquals(Gender.FEMALE, query.from(person).where(person.id.eq(10)).select(person.gender).fetchOne());
+        assertEquals(Gender.FEMALE, query.from(person).where(person.id.eq(10)).select(person.gender).fetchOne().orElse(null));
     }
 
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/ProjectableSQLQuery.java
@@ -16,6 +16,7 @@ package com.querydsl.sql;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -150,7 +151,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     @Override
     public long fetchCount() {
         queryMixin.setProjection(Wildcard.countAsInt);
-        return ((Number) fetchOne()).longValue();
+        return ((Number) fetchOne().get()).longValue();
     }
 
     public Q from(Expression<?> arg) {
@@ -392,7 +393,7 @@ public abstract class ProjectableSQLQuery<T, Q extends ProjectableSQLQuery<T, Q>
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         if (getMetadata().getModifiers().getLimit() == null
             && !queryMixin.getMetadata().getProjection().toString().contains("count(")) {
             limit(2);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/UnionImpl.java
@@ -14,6 +14,7 @@
 package com.querydsl.sql;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -52,12 +53,12 @@ public class UnionImpl<T, Q extends ProjectableSQLQuery<T, Q> & Query<Q>>  imple
     }
 
     @Override
-    public T fetchFirst() {
+    public Optional<T> fetchFirst() {
         return query.fetchFirst();
     }
 
     @Override
-    public T fetchOne() throws NonUniqueResultException {
+    public Optional<T> fetchOne() throws NonUniqueResultException {
         return query.fetchOne();
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
@@ -325,7 +325,7 @@ public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements
         }
         query.addListener(SQLNoCloseListener.DEFAULT);
         addKeyConditions(query);
-        return query.select(Expressions.ONE).fetchFirst() != null;
+        return query.select(Expressions.ONE).fetchFirst().isPresent();
     }
 
     @SuppressWarnings("unchecked")

--- a/querydsl-sql/src/test/java/com/querydsl/sql/BeanPopulationBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/BeanPopulationBase.java
@@ -50,21 +50,21 @@ public class BeanPopulationBase extends AbstractBaseTest {
         // Query
         Employee smith = extQuery().from(e).where(e.lastname.eq("S"))
             .limit(1)
-            .uniqueResult(Employee.class, e.lastname, e.firstname);
+            .uniqueResult(Employee.class, e.lastname, e.firstname).get();
         assertEquals("John", smith.getFirstname());
         assertEquals("S", smith.getLastname());
 
         // Query with alias
         smith = extQuery().from(e).where(e.lastname.eq("S"))
             .limit(1)
-            .uniqueResult(Employee.class, e.lastname.as("lastname"), e.firstname.as("firstname"));
+            .uniqueResult(Employee.class, e.lastname.as("lastname"), e.firstname.as("firstname")).get();
         assertEquals("John", smith.getFirstname());
         assertEquals("S", smith.getLastname());
 
         // Query into custom type
         OtherEmployee other = extQuery().from(e).where(e.lastname.eq("S"))
             .limit(1)
-            .uniqueResult(OtherEmployee.class, e.lastname, e.firstname);
+            .uniqueResult(OtherEmployee.class, e.lastname, e.firstname).get();
         assertEquals("John", other.getFirstname());
         assertEquals("S", other.getLastname());
 
@@ -86,7 +86,7 @@ public class BeanPopulationBase extends AbstractBaseTest {
         assertEquals(1L, update(e).populate(employee).where(e.id.eq(employee.getId())).execute());
 
         // Query
-        Employee smith = query().from(e).where(e.lastname.eq("S")).limit(1).select(e).fetchFirst();
+        Employee smith = query().from(e).where(e.lastname.eq("S")).limit(1).select(e).fetchFirst().get();
         assertEquals("John", smith.getFirstname());
 
         // Delete (no changes needed)

--- a/querydsl-sql/src/test/java/com/querydsl/sql/ExtendedSQLQuery.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/ExtendedSQLQuery.java
@@ -15,6 +15,7 @@ package com.querydsl.sql;
 
 import java.sql.Connection;
 import java.util.List;
+import java.util.Optional;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.DefaultQueryMetadata;
@@ -51,7 +52,7 @@ public class ExtendedSQLQuery<T> extends AbstractSQLQuery<T, ExtendedSQLQuery<T>
         return select(createProjection(type, exprs)).iterate();
     }
 
-    public <RT> RT uniqueResult(Class<RT> type, Expression<?>... exprs) {
+    public <RT> Optional<RT> uniqueResult(Class<RT> type, Expression<?>... exprs) {
         return select(createProjection(type, exprs)).fetchOne();
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/InsertBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/InsertBase.java
@@ -80,7 +80,7 @@ public class InsertBase extends AbstractBaseTest {
                 dateTest.dateTest.year(),
                 dateTest.dateTest.month(),
                 dateTest.dateTest.dayOfMonth(),
-                dateTimeProperty).fetchFirst();
+                dateTimeProperty).fetchFirst().get();
         assertEquals(Integer.valueOf(1978), result.get(0, Integer.class));
         assertEquals(Integer.valueOf(1), result.get(1, Integer.class));
         assertEquals(Integer.valueOf(2), result.get(2, Integer.class));
@@ -363,7 +363,7 @@ public class InsertBase extends AbstractBaseTest {
         assertEquals(1, insert(survey).set(survey.name,
             query().where(query().from(survey2)
                            .where(survey2.name.eq("MyModule")).notExists())
-                .select(Expressions.constant("MyModule")).fetchFirst())
+                .select(Expressions.constant("MyModule")).fetchFirst().get())
             .execute());
 
         assertEquals(1L , query().from(survey).where(survey.name.eq("MyModule")).fetchCount());
@@ -495,7 +495,7 @@ public class InsertBase extends AbstractBaseTest {
         QUuids uuids = QUuids.uuids;
         UUID uuid = UUID.randomUUID();
         insert(uuids).set(uuids.field, uuid).execute();
-        assertEquals(uuid, query().from(uuids).select(uuids.field).fetchFirst());
+        assertEquals(uuid, query().from(uuids).select(uuids.field).fetchFirst().orElse(null));
     }
 
     @Test
@@ -505,7 +505,7 @@ public class InsertBase extends AbstractBaseTest {
         QXmlTest xmlTest = QXmlTest.xmlTest;
         String contents = "<html><head>a</head><body>b</body></html>";
         insert(xmlTest).set(xmlTest.col, contents).execute();
-        assertEquals(contents, query().from(xmlTest).select(xmlTest.col).fetchFirst());
+        assertEquals(contents, query().from(xmlTest).select(xmlTest.col).fetchFirst().orElse(null));
     }
 
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/KeywordQuotingBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/KeywordQuotingBase.java
@@ -79,7 +79,7 @@ public class KeywordQuotingBase extends AbstractBaseTest {
         assertEquals("from", query().from(quoting.as(from))
                 .where(from.from.eq("from")
                         .and(from.all.isNotNull()))
-                .select(from.from).fetchFirst());
+                .select(from.from).fetchFirst().orElse(null));
     }
 
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLCloseListenerTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLCloseListenerTest.java
@@ -40,12 +40,12 @@ public class SQLCloseListenerTest {
 
     @Test
     public void fetchOne() {
-        assertNotNull(query.limit(1).fetchOne());
+        assertNotNull(query.limit(1).fetchOne().get());
     }
 
     @Test
     public void fetchFirst() {
-        assertNotNull(query.fetchFirst());
+        assertNotNull(query.fetchFirst().orElse(null));
     }
 
     @Test

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -63,11 +63,11 @@ public class SelectBase extends AbstractBaseTest {
     };
 
     private <T> T firstResult(Expression<T> expr) {
-        return query().select(expr).fetchFirst();
+        return query().select(expr).fetchFirst().get();
     }
 
     private Tuple firstResult(Expression<?>... exprs) {
-        return query().select(exprs).fetchFirst();
+        return query().select(exprs).fetchFirst().get();
     }
 
     @Test
@@ -83,9 +83,9 @@ public class SelectBase extends AbstractBaseTest {
     public void aggregate_uniqueResult() {
         int min = 30000, avg = 65000, max = 160000;
         // fetchOne
-        assertEquals(min, query().from(employee).select(employee.salary.min()).fetchOne().intValue());
-        assertEquals(avg, query().from(employee).select(employee.salary.avg()).fetchOne().intValue());
-        assertEquals(max, query().from(employee).select(employee.salary.max()).fetchOne().intValue());
+        assertEquals(min, query().from(employee).select(employee.salary.min()).fetchOne().get().intValue());
+        assertEquals(avg, query().from(employee).select(employee.salary.avg()).fetchOne().get().intValue());
+        assertEquals(max, query().from(employee).select(employee.salary.max()).fetchOne().get().intValue());
     }
 
     @Test
@@ -201,13 +201,6 @@ public class SelectBase extends AbstractBaseTest {
     }
 
     @Test
-    @ExcludeIn({DERBY, HSQLDB})
-    public void array_null() {
-        Expression<Integer[]> expr = Expressions.template(Integer[].class, "null");
-        assertNull(firstResult(expr));
-    }
-
-    @Test
     public void array_projection() {
         List<String[]> results = query().from(employee).select(
                 new ArrayConstructorExpression<String>(String[].class, employee.firstname)).fetch();
@@ -238,13 +231,13 @@ public class SelectBase extends AbstractBaseTest {
     @Test
     @ExcludeIn({ORACLE, CUBRID, FIREBIRD, DB2, DERBY, SQLSERVER, SQLITE, TERADATA})
     public void boolean_all() {
-        assertTrue(query().from(employee).select(SQLExpressions.all(employee.firstname.isNotNull())).fetchOne());
+        assertTrue(query().from(employee).select(SQLExpressions.all(employee.firstname.isNotNull())).fetchOne().get());
     }
 
     @Test
     @ExcludeIn({ORACLE, CUBRID, FIREBIRD, DB2, DERBY, SQLSERVER, SQLITE, TERADATA})
     public void boolean_any() {
-        assertTrue(query().from(employee).select(SQLExpressions.any(employee.firstname.isNotNull())).fetchOne());
+        assertTrue(query().from(employee).select(SQLExpressions.any(employee.firstname.isNotNull())).fetchOne().get());
     }
 
     @Test
@@ -366,7 +359,7 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void count2() {
-        assertEquals(10, query().from(employee).select(employee.count()).fetchFirst().intValue());
+        assertEquals(10, query().from(employee).select(employee.count()).fetchFirst().get().intValue());
     }
 
     @Test
@@ -375,7 +368,7 @@ public class SelectBase extends AbstractBaseTest {
     public void count_all() {
         expectedQuery = "select count(*) as rc from EMPLOYEE e";
         NumberPath<Long> rowCount = Expressions.numberPath(Long.class, "rc");
-        assertEquals(10, query().from(employee).select(Wildcard.count.as(rowCount)).fetchOne().intValue());
+        assertEquals(10, query().from(employee).select(Wildcard.count.as(rowCount)).fetchOne().get().intValue());
     }
 
     @Test
@@ -384,7 +377,7 @@ public class SelectBase extends AbstractBaseTest {
     public void count_all_Oracle() {
         expectedQuery = "select count(*) rc from EMPLOYEE e";
         NumberPath<Long> rowCount = Expressions.numberPath(Long.class, "rc");
-        assertEquals(10, query().from(employee).select(Wildcard.count.as(rowCount)).fetchOne().intValue());
+        assertEquals(10, query().from(employee).select(Wildcard.count.as(rowCount)).fetchOne().get().intValue());
     }
 
     @Test
@@ -517,10 +510,10 @@ public class SelectBase extends AbstractBaseTest {
     @ExcludeIn({SQLITE})
     public void date_add() {
         SQLQuery<?> query = query().from(employee);
-        Date date1 = query.select(employee.datefield).fetchFirst();
-        Date date2 = query.select(SQLExpressions.addYears(employee.datefield, 1)).fetchFirst();
-        Date date3 = query.select(SQLExpressions.addMonths(employee.datefield, 1)).fetchFirst();
-        Date date4 = query.select(SQLExpressions.addDays(employee.datefield, 1)).fetchFirst();
+        Date date1 = query.select(employee.datefield).fetchFirst().get();
+        Date date2 = query.select(SQLExpressions.addYears(employee.datefield, 1)).fetchFirst().get();
+        Date date3 = query.select(SQLExpressions.addMonths(employee.datefield, 1)).fetchFirst().get();
+        Date date4 = query.select(SQLExpressions.addDays(employee.datefield, 1)).fetchFirst().get();
 
         assertTrue(date2.getTime() > date1.getTime());
         assertTrue(date3.getTime() > date1.getTime());
@@ -566,9 +559,9 @@ public class SelectBase extends AbstractBaseTest {
         Date date = new Date(localDate.toDateMidnight().getMillis());
 
         for (DatePart dp : dps) {
-            int diff1 = query.select(SQLExpressions.datediff(dp, date, employee.datefield)).fetchFirst();
-            int diff2 = query.select(SQLExpressions.datediff(dp, employee.datefield, date)).fetchFirst();
-            int diff3 = query2.select(SQLExpressions.datediff(dp, employee.datefield, employee2.datefield)).fetchFirst();
+            int diff1 = query.select(SQLExpressions.datediff(dp, date, employee.datefield)).fetchFirst().get();
+            int diff2 = query.select(SQLExpressions.datediff(dp, employee.datefield, date)).fetchFirst().get();
+            int diff3 = query2.select(SQLExpressions.datediff(dp, employee.datefield, employee2.datefield)).fetchFirst().get();
             assertEquals(diff1, -diff2);
         }
 
@@ -588,13 +581,13 @@ public class SelectBase extends AbstractBaseTest {
         LocalDate localDate = new LocalDate(1970, 1, 10);
         Date date = new Date(localDate.toDateMidnight().getMillis());
 
-        int years = query.select(SQLExpressions.datediff(DatePart.year, date, employee.datefield)).fetchFirst();
-        int months = query.select(SQLExpressions.datediff(DatePart.month, date, employee.datefield)).fetchFirst();
+        int years = query.select(SQLExpressions.datediff(DatePart.year, date, employee.datefield)).fetchFirst().get();
+        int months = query.select(SQLExpressions.datediff(DatePart.month, date, employee.datefield)).fetchFirst().get();
         // weeks
-        int days = query.select(SQLExpressions.datediff(DatePart.day, date, employee.datefield)).fetchFirst();
-        int hours = query.select(SQLExpressions.datediff(DatePart.hour, date, employee.datefield)).fetchFirst();
-        int minutes = query.select(SQLExpressions.datediff(DatePart.minute, date, employee.datefield)).fetchFirst();
-        int seconds = query.select(SQLExpressions.datediff(DatePart.second, date, employee.datefield)).fetchFirst();
+        int days = query.select(SQLExpressions.datediff(DatePart.day, date, employee.datefield)).fetchFirst().get();
+        int hours = query.select(SQLExpressions.datediff(DatePart.hour, date, employee.datefield)).fetchFirst().get();
+        int minutes = query.select(SQLExpressions.datediff(DatePart.minute, date, employee.datefield)).fetchFirst().get();
+        int seconds = query.select(SQLExpressions.datediff(DatePart.second, date, employee.datefield)).fetchFirst().get();
 
         assertEquals(949363200, seconds);
         assertEquals(15822720,  minutes);
@@ -703,10 +696,10 @@ public class SelectBase extends AbstractBaseTest {
     @Test
     public void dateTime() {
         SQLQuery<?> query = query().from(employee).orderBy(employee.id.asc());
-        assertEquals(Integer.valueOf(10),     query.select(employee.datefield.dayOfMonth()).fetchFirst());
-        assertEquals(Integer.valueOf(2),      query.select(employee.datefield.month()).fetchFirst());
-        assertEquals(Integer.valueOf(2000),   query.select(employee.datefield.year()).fetchFirst());
-        assertEquals(Integer.valueOf(200002), query.select(employee.datefield.yearMonth()).fetchFirst());
+        assertEquals(Integer.valueOf(10),     query.select(employee.datefield.dayOfMonth()).fetchFirst().orElse(null));
+        assertEquals(Integer.valueOf(2),      query.select(employee.datefield.month()).fetchFirst().orElse(null));
+        assertEquals(Integer.valueOf(2000),   query.select(employee.datefield.year()).fetchFirst().orElse(null));
+        assertEquals(Integer.valueOf(200002), query.select(employee.datefield.yearMonth()).fetchFirst().orElse(null));
     }
 
     @Test
@@ -750,7 +743,7 @@ public class SelectBase extends AbstractBaseTest {
     @Test
     public void factoryExpression_in_groupBy() {
         Expression<Employee> empBean = Projections.bean(Employee.class, employee.id, employee.superiorId);
-        assertTrue(query().from(employee).groupBy(empBean).select(empBean).fetchFirst() != null);
+        assertTrue(query().from(employee).groupBy(empBean).select(empBean).fetchFirst().isPresent());
     }
 
     @Test
@@ -1225,7 +1218,7 @@ public class SelectBase extends AbstractBaseTest {
         NumberTemplate<Double> four = Expressions.numberTemplate(Double.class, "4.0");
         NumberTemplate<Double> five = Expressions.numberTemplate(Double.class, "5.0");
         NumberTemplate<Double> six = Expressions.numberTemplate(Double.class, "6.0");
-        Double num = query().select(one.add(two.multiply(three)).subtract(four.divide(five)).add(six.mod(three))).fetchFirst();
+        Double num = query().select(one.add(two.multiply(three)).subtract(four.divide(five)).add(six.mod(three))).fetchFirst().get();
         assertEquals(6.2, num, 0.001);
     }
 
@@ -1281,7 +1274,7 @@ public class SelectBase extends AbstractBaseTest {
         long result = query()
                 .select(employee.datefield.year().mod(1))
                 .from(employee)
-                .fetchFirst();
+                .fetchFirst().get();
         assertEquals(0, result);
     }
 
@@ -1341,7 +1334,7 @@ public class SelectBase extends AbstractBaseTest {
         assertEquals("Mike", query()
                 .from(employee).where(employee.firstname.eq(name))
                 .set(name, "Mike")
-                .select(employee.firstname).fetchFirst());
+                .select(employee.firstname).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1350,7 +1343,7 @@ public class SelectBase extends AbstractBaseTest {
         assertEquals("Mike", query()
                 .from(employee).where(employee.firstname.eq(name))
                 .set(name, "Mike")
-                .select(employee.firstname).fetchFirst());
+                .select(employee.firstname).fetchFirst().orElse(null));
     }
 
     @Test(expected = ParamNotSetException.class)
@@ -1358,7 +1351,7 @@ public class SelectBase extends AbstractBaseTest {
         Param<String> name = new Param<String>(String.class,"name");
         assertEquals("Mike", query()
                 .from(employee).where(employee.firstname.eq(name))
-                .select(employee.firstname).fetchFirst());
+                .select(employee.firstname).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1574,8 +1567,8 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void select_booleanExpr3() {
-        assertTrue(query().select(Expressions.TRUE).fetchFirst());
-        assertFalse(query().select(Expressions.FALSE).fetchFirst());
+        assertTrue(query().select(Expressions.TRUE).fetchFirst().get());
+        assertFalse(query().select(Expressions.FALSE).fetchFirst().get());
     }
 
     @Test
@@ -1644,12 +1637,12 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void single() {
-        assertNotNull(query().from(survey).select(survey.name).fetchFirst());
+        assertNotNull(query().from(survey).select(survey.name).fetchFirst().orElse(null));
     }
 
     @Test
     public void single_array() {
-        assertNotNull(query().from(survey).select(new Expression<?>[]{survey.name}).fetchFirst());
+        assertNotNull(query().from(survey).select(new Expression<?>[]{survey.name}).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1762,28 +1755,28 @@ public class SelectBase extends AbstractBaseTest {
     @ExcludeIn(SQLITE)
     public void string_left() {
         assertEquals("John", query().from(employee).where(employee.lastname.eq("Johnson"))
-                                    .select(SQLExpressions.left(employee.lastname, 4)).fetchFirst());
+                                    .select(SQLExpressions.left(employee.lastname, 4)).fetchFirst().orElse(null));
     }
 
     @Test
     @ExcludeIn({DERBY, SQLITE})
     public void string_right() {
         assertEquals("son", query().from(employee).where(employee.lastname.eq("Johnson"))
-                                   .select(SQLExpressions.right(employee.lastname, 3)).fetchFirst());
+                                   .select(SQLExpressions.right(employee.lastname, 3)).fetchFirst().orElse(null));
     }
 
     @Test
     @ExcludeIn({DERBY, SQLITE})
     public void string_left_Right() {
         assertEquals("hn", query().from(employee).where(employee.lastname.eq("Johnson"))
-                                  .select(SQLExpressions.right(SQLExpressions.left(employee.lastname, 4), 2)).fetchFirst());
+                                  .select(SQLExpressions.right(SQLExpressions.left(employee.lastname, 4), 2)).fetchFirst().orElse(null));
     }
 
     @Test
     @ExcludeIn({DERBY, SQLITE})
     public void string_right_Left() {
         assertEquals("ns", query().from(employee).where(employee.lastname.eq("Johnson"))
-                                  .select(SQLExpressions.left(SQLExpressions.right(employee.lastname, 4), 2)).fetchFirst());
+                                  .select(SQLExpressions.left(SQLExpressions.right(employee.lastname, 4), 2)).fetchFirst().orElse(null));
     }
 
     @Test
@@ -1877,7 +1870,7 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void unique_Constructor_projection() {
-        IdName idAndName = query().from(survey).limit(1).select(new QIdName(survey.id, survey.name)).fetchFirst();
+        IdName idAndName = query().from(survey).limit(1).select(new QIdName(survey.id, survey.name)).fetchFirst().get();
         assertNotNull(idAndName);
         assertNotNull(idAndName.getId());
         assertNotNull(idAndName.getName());
@@ -1885,14 +1878,14 @@ public class SelectBase extends AbstractBaseTest {
 
     @Test
     public void unique_single() {
-        String s = query().from(survey).limit(1).select(survey.name).fetchFirst();
+        String s = query().from(survey).limit(1).select(survey.name).fetchFirst().get();
         assertNotNull(s);
     }
 
     @Test
     public void unique_wildcard() {
         // unique wildcard
-        Tuple row = query().from(survey).limit(1).select(survey.all()).fetchFirst();
+        Tuple row = query().from(survey).limit(1).select(survey.all()).fetchFirst().get();
         assertNotNull(row);
         assertEquals(3, row.size());
         assertNotNull(row.get(0, Object.class));
@@ -2079,14 +2072,14 @@ public class SelectBase extends AbstractBaseTest {
     @ExcludeIn({DB2, DERBY, H2})
     public void yearWeek() {
         SQLQuery<?> query = query().from(employee).orderBy(employee.id.asc());
-        assertEquals(Integer.valueOf(200006), query.select(employee.datefield.yearWeek()).fetchFirst());
+        assertEquals(Integer.valueOf(200006), query.select(employee.datefield.yearWeek()).fetchFirst().orElse(null));
     }
 
     @Test
     @IncludeIn({H2})
     public void yearWeek_h2() {
         SQLQuery<?> query = query().from(employee).orderBy(employee.id.asc());
-        assertEquals(Integer.valueOf(200007), query.select(employee.datefield.yearWeek()).fetchFirst());
+        assertEquals(Integer.valueOf(200007), query.select(employee.datefield.yearWeek()).fetchFirst().orElse(null));
     }
 
     @Test

--- a/querydsl-sql/src/test/java/com/querydsl/sql/UnionBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/UnionBase.java
@@ -34,7 +34,7 @@ public class UnionBase extends AbstractBaseTest {
             .where(employee.id.in(
                 query().union(query().select(Expressions.ONE),
                               query().select(Expressions.TWO))))
-            .select(Expressions.ONE).fetchFirst() != null);
+            .select(Expressions.ONE).fetchFirst().isPresent());
     }
 
     @Test
@@ -44,8 +44,8 @@ public class UnionBase extends AbstractBaseTest {
         SubQueryExpression<Integer> sq1 = query().from(employee).select(employee.id.max().as("ID"));
         SubQueryExpression<Integer> sq2 = query().from(employee).select(employee.id.min().as("ID"));
         assertEquals(
-                ImmutableList.of(query().select(employee.id.min()).from(employee).fetchFirst(),
-                                 query().select(employee.id.max()).from(employee).fetchFirst()),
+                ImmutableList.of(query().select(employee.id.min()).from(employee).fetchFirst().get(),
+                                 query().select(employee.id.max()).from(employee).fetchFirst().get()),
                 query().union(sq1, sq2).orderBy(employee.id.asc()).fetch());
     }
 


### PR DESCRIPTION
Originally these changes were part of the `java-8` branch, but I've decided to maintain a seperate PR for this as I want to discuss the feature in more detail due to its breaking nature (for example for `spring-data`).