### PR TITLE
Add support for MongoDB Document API

### DIFF
--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbOps.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbOps.java
@@ -25,6 +25,7 @@ public enum MongodbOps implements Operator {
     NEAR(Boolean.class),
     GEO_WITHIN_BOX(Boolean.class),
     ELEM_MATCH(Boolean.class),
+    NO_MATCH(Boolean.class),
     NEAR_SPHERE(Boolean.class);
 
     private final Class<?> type;

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractFetchableMongodbQuery.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractFetchableMongodbQuery.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import com.google.common.base.Function;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.core.*;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import org.bson.Document;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link Fetchable} Mongodb query with a pluggable Document to Bean transformation.
+ *
+ * @param <K> result type
+ * @param <Q> concrete subtype
+ * @author Mark Paluch
+ */
+public abstract class AbstractFetchableMongodbQuery<K, Q extends AbstractFetchableMongodbQuery<K, Q>>
+        extends AbstractMongodbQuery<Q> implements Fetchable<K> {
+
+    private final Function<Document, K> transformer;
+
+    private final MongoCollection<Document> collection;
+
+    /**
+     * Create a new MongodbQuery instance
+     * @param collection
+     * @param transformer result transformer
+     * @param serializer serializer
+     */
+    public AbstractFetchableMongodbQuery(MongoCollection<Document> collection, Function<Document, K> transformer, MongodbDocumentSerializer serializer) {
+        super(serializer);
+        this.transformer = transformer;
+        this.collection = collection;
+    }
+
+    /**
+     * Iterate with the specific fields
+     *
+     * @param paths fields to return
+     * @return iterator
+     */
+    public CloseableIterator<K> iterate(Path<?>... paths) {
+        getQueryMixin().setProjection(paths);
+        return iterate();
+    }
+
+    @Override
+    public CloseableIterator<K> iterate() {
+        FindIterable<Document> cursor = createCursor();
+        final MongoCursor<Document> iterator = cursor.iterator();
+
+        return new CloseableIterator<K>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public K next() {
+                return transformer.apply(iterator.next());
+            }
+
+            @Override
+            public void remove() {
+
+            }
+
+            @Override
+            public void close() {
+                iterator.close();
+            }
+        };
+    }
+
+    /**
+     * Fetch with the specific fields
+     *
+     * @param paths fields to return
+     * @return results
+     */
+    public List<K> fetch(Path<?>... paths) {
+        getQueryMixin().setProjection(paths);
+        return fetch();
+    }
+
+    @Override
+    public List<K> fetch() {
+        try {
+            FindIterable<Document> cursor = createCursor();
+            List<K> results = new ArrayList<K>();
+            for (Document document : cursor) {
+                results.add(transformer.apply(document));
+            }
+            return results;
+        } catch (NoResults ex) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Fetch first with the specific fields
+     *
+     * @param paths fields to return
+     * @return first result
+     */
+    public K fetchFirst(Path<?>... paths) {
+        getQueryMixin().setProjection(paths);
+        return fetchFirst();
+    }
+
+    @Override
+    public K fetchFirst() {
+        try {
+            FindIterable<Document> c = createCursor().limit(1);
+            MongoCursor<Document> iterator = c.iterator();
+            try {
+
+                if (iterator.hasNext()) {
+                    return transformer.apply(iterator.next());
+                } else {
+                    return null;
+                }
+            } finally {
+                iterator.close();
+            }
+        } catch (NoResults ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Fetch one with the specific fields
+     *
+     * @param paths fields to return
+     * @return first result
+     */
+    public K fetchOne(Path<?>... paths) {
+        getQueryMixin().setProjection(paths);
+        return fetchOne();
+    }
+
+    @Override
+    public K fetchOne() {
+        try {
+            Long limit = getQueryMixin().getMetadata().getModifiers().getLimit();
+            if (limit == null) {
+                limit = 2L;
+            }
+
+            FindIterable<Document> c = createCursor().limit(limit.intValue());
+            MongoCursor<Document> iterator = c.iterator();
+            try {
+
+                if (iterator.hasNext()) {
+                K rv = transformer.apply(iterator.next());
+                if (iterator.hasNext()) {
+                    throw new NonUniqueResultException();
+                }
+                return rv;
+            } else {
+                return null;
+            }
+            } finally {
+                iterator.close();
+            }
+
+
+        } catch (NoResults ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Fetch results with the specific fields
+     *
+     * @param paths fields to return
+     * @return results
+     */
+    public QueryResults<K> fetchResults(Path<?>... paths) {
+        getQueryMixin().setProjection(paths);
+        return fetchResults();
+    }
+
+    @Override
+    public QueryResults<K> fetchResults() {
+        try {
+            long total = fetchCount();
+            if (total > 0L) {
+                return new QueryResults<K>(fetch(), getQueryMixin().getMetadata().getModifiers(), total);
+            } else {
+                return QueryResults.emptyResults();
+            }
+        } catch (NoResults ex) {
+            return QueryResults.emptyResults();
+        }
+    }
+
+    @Override
+    public long fetchCount() {
+        try {
+            Predicate filter = createFilter(getQueryMixin().getMetadata());
+            return collection.count(createQuery(filter));
+        } catch (NoResults ex) {
+            return 0L;
+        }
+    }
+
+    protected FindIterable<Document> createCursor() {
+        QueryMetadata metadata = getQueryMixin().getMetadata();
+        Predicate filter = createFilter(metadata);
+        return createCursor(collection, filter, metadata.getProjection(), metadata.getModifiers(), metadata.getOrderBy());
+    }
+
+    protected FindIterable<Document> createCursor(MongoCollection<Document> collection, @Nullable Predicate where,
+                                                  Expression<?> projection, QueryModifiers modifiers, List<OrderSpecifier<?>> orderBy) {
+
+        ReadPreference readPreference = getReadPreference();
+        MongoCollection<Document> collectionToUse = readPreference != null ? collection
+                .withReadPreference(readPreference) : collection;
+        FindIterable<Document> cursor = collectionToUse.find(createQuery(where))
+                .projection(createProjection(projection));
+        Integer limit = modifiers.getLimitAsInteger();
+        Integer offset = modifiers.getOffsetAsInteger();
+
+        if (limit != null) {
+            cursor = cursor.limit(limit);
+        }
+        if (offset != null) {
+            cursor = cursor.skip(offset);
+        }
+        if (orderBy.size() > 0) {
+            cursor = cursor.sort(getSerializer().toSort(orderBy));
+        }
+        return cursor;
+    }
+
+    protected abstract MongoCollection<Document> getCollection(Class<?> type);
+
+    @Override
+    protected List<Object> getIds(Class<?> targetType, Predicate condition) {
+        MongoCollection<Document> collection = getCollection(targetType);
+        // TODO : fetch only ids
+        FindIterable<Document> cursor = createCursor(collection, condition, null,
+                QueryModifiers.EMPTY, Collections.<OrderSpecifier<?>>emptyList());
+
+        MongoCursor<Document> iterator = cursor.iterator();
+        try {
+
+            if (iterator.hasNext()) {
+                List<Object> ids = new ArrayList<Object>();
+                for (Document obj : cursor) {
+                    ids.add(obj.get("_id"));
+                }
+                return ids;
+            } else {
+                return Collections.emptyList();
+            }
+        } finally {
+           iterator.close();
+        }
+    }
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractMongodbQuery.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AbstractMongodbQuery.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import java.util.Collection;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.bson.Document;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.mongodb.ReadPreference;
+import com.querydsl.core.DefaultQueryMetadata;
+import com.querydsl.core.JoinExpression;
+import com.querydsl.core.QueryMetadata;
+import com.querydsl.core.QueryModifiers;
+import com.querydsl.core.SimpleQuery;
+import com.querydsl.core.support.QueryMixin;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.Operation;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.ParamExpression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.CollectionPathBase;
+
+/**
+ * {@code AbstractMongodbQuery} provides a base class for general Querydsl query implementation.
+ *
+ * @author Mark Paluch
+ *
+ * @param <Q> concrete subtype
+ */
+public abstract class AbstractMongodbQuery<Q extends AbstractMongodbQuery<Q>> implements SimpleQuery<Q> {
+
+    @SuppressWarnings("serial")
+    static class NoResults extends RuntimeException { }
+
+    private final MongodbDocumentSerializer serializer;
+
+    private final QueryMixin<Q> queryMixin;
+
+    private ReadPreference readPreference;
+
+    /**
+     * Create a new MongodbQuery instance
+     *
+     * @param serializer serializer
+     */
+    @SuppressWarnings("unchecked")
+    public AbstractMongodbQuery(MongodbDocumentSerializer serializer) {
+        @SuppressWarnings("unchecked") // Q is this plus subclass
+        Q query = (Q) this;
+        this.queryMixin = new QueryMixin<Q>(query, new DefaultQueryMetadata(), false);
+        this.serializer = serializer;
+    }
+
+    /**
+     * Define a join
+     *
+     * @param ref reference
+     * @param target join target
+     * @return join builder
+     */
+    public <T> JoinBuilder<Q, T> join(Path<T> ref, Path<T> target) {
+        return new JoinBuilder<Q, T>(queryMixin, ref, target);
+    }
+
+    /**
+     * Define a join
+     *
+     * @param ref reference
+     * @param target join target
+     * @return join builder
+     */
+    public <T> JoinBuilder<Q, T> join(CollectionPathBase<?,T,?> ref, Path<T> target) {
+        return new JoinBuilder<Q, T>(queryMixin, ref, target);
+    }
+
+    /**
+     * Define a constraint for an embedded object
+     *
+     * @param collection collection
+     * @param target target
+     * @return builder
+     */
+    public <T> AnyEmbeddedBuilder<Q> anyEmbedded(Path<? extends Collection<T>> collection, Path<T> target) {
+        return new AnyEmbeddedBuilder<Q>(queryMixin, collection);
+    }
+
+    @Nullable
+    protected Predicate createFilter(QueryMetadata metadata) {
+        Predicate filter;
+        if (!metadata.getJoins().isEmpty()) {
+            filter = ExpressionUtils.allOf(metadata.getWhere(), createJoinFilter(metadata));
+        } else {
+            filter = metadata.getWhere();
+        }
+        return filter;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    protected Predicate createJoinFilter(QueryMetadata metadata) {
+        Multimap<Expression<?>, Predicate> predicates = HashMultimap.create();
+        List<JoinExpression> joins = metadata.getJoins();
+        for (int i = joins.size() - 1; i >= 0; i--) {
+            JoinExpression join = joins.get(i);
+            Path<?> source = (Path) ((Operation<?>) join.getTarget()).getArg(0);
+            Path<?> target = (Path) ((Operation<?>) join.getTarget()).getArg(1);
+            Collection<Predicate> extraFilters = predicates.get(target.getRoot());
+            Predicate filter = ExpressionUtils.allOf(join.getCondition(), allOf(extraFilters));
+            List<? extends Object> ids = getIds(target.getType(), filter);
+            if (ids.isEmpty()) {
+                throw new NoResults();
+            }
+            Path<?> path = ExpressionUtils.path(String.class, source, "$id");
+            predicates.put(source.getRoot(), ExpressionUtils.in((Path<Object>) path, ids));
+        }
+        Path<?> source = (Path) ((Operation) joins.get(0).getTarget()).getArg(0);
+        return allOf(predicates.get(source.getRoot()));
+    }
+
+    private Predicate allOf(Collection<Predicate> predicates) {
+        return predicates != null ? ExpressionUtils.allOf(predicates) : null;
+    }
+
+    protected abstract List<Object> getIds(Class<?> targetType, Predicate condition);
+
+    @Override
+    public Q distinct() {
+        return queryMixin.distinct();
+    }
+
+    public Q where(Predicate e) {
+        return queryMixin.where(e);
+    }
+
+    @Override
+    public Q where(Predicate... e) {
+        return queryMixin.where(e);
+    }
+
+    @Override
+    public Q limit(long limit) {
+        return queryMixin.limit(limit);
+    }
+
+    @Override
+    public Q offset(long offset) {
+        return queryMixin.offset(offset);
+    }
+
+    @Override
+    public Q restrict(QueryModifiers modifiers) {
+        return queryMixin.restrict(modifiers);
+    }
+
+    public Q orderBy(OrderSpecifier<?> o) {
+        return queryMixin.orderBy(o);
+    }
+
+    @Override
+    public Q orderBy(OrderSpecifier<?>... o) {
+        return queryMixin.orderBy(o);
+    }
+
+    @Override
+    public <T> Q set(ParamExpression<T> param, T value) {
+        return queryMixin.set(param, value);
+    }
+
+    protected Document createProjection(Expression<?> projection) {
+        if (projection instanceof FactoryExpression) {
+            Document obj = new Document();
+            for (Object expr : ((FactoryExpression) projection).getArgs()) {
+                if (expr instanceof Expression) {
+                    obj.put((String) serializer.handle((Expression) expr), 1);
+                }
+            }
+            return obj;
+        }
+        return null;
+    }
+
+
+    protected Document createQuery(@Nullable Predicate predicate) {
+        if (predicate != null) {
+            return (Document) serializer.handle(predicate);
+        } else {
+            return new Document();
+        }
+    }
+
+
+    /**
+     * Sets the read preference for this query
+     *
+     * @param readPreference read preference
+     */
+    public void setReadPreference(ReadPreference readPreference) {
+        this.readPreference = readPreference;
+    }
+
+    QueryMixin<Q> getQueryMixin() {
+        return queryMixin;
+    }
+
+    MongodbDocumentSerializer getSerializer() {
+        return serializer;
+    }
+
+    ReadPreference getReadPreference() {
+        return readPreference;
+    }
+
+    /**
+     * Get the where definition as a Document instance
+     *
+     * @return
+     */
+    public Document asDocument() {
+        return createQuery(queryMixin.getMetadata().getWhere());
+    }
+
+    @Override
+    public String toString() {
+        return asDocument().toString();
+    }
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AnyEmbeddedBuilder.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/AnyEmbeddedBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import java.util.Collection;
+
+import com.querydsl.core.support.QueryMixin;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.mongodb.MongodbOps;
+
+/**
+ * {@code AnyEmbeddedBuilder} is a builder for constraints on embedded objects
+ *
+ * @param <Q> query type
+ *
+ * @author Mark Paluch
+ */
+public class AnyEmbeddedBuilder<Q extends AbstractMongodbQuery<Q>> {
+
+    private final QueryMixin<Q> queryMixin;
+
+    private final Path<? extends Collection<?>> collection;
+
+    public AnyEmbeddedBuilder(QueryMixin<Q> queryMixin,
+            Path<? extends Collection<?>> collection) {
+        this.queryMixin = queryMixin;
+        this.collection = collection;
+    }
+
+    public Q on(Predicate... conditions) {
+        return queryMixin.where(ExpressionUtils.predicate(
+                MongodbOps.ELEM_MATCH, collection, ExpressionUtils.allOf(conditions)));
+    }
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/JoinBuilder.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/JoinBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import com.querydsl.core.JoinType;
+import com.querydsl.core.support.QueryMixin;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+
+/**
+ * {@code JoinBuilder} is a builder for join constraints
+ *
+ * @author Mark Paluch
+ *
+ * @param <Q>
+ * @param <T>
+ */
+public class JoinBuilder<Q extends AbstractMongodbQuery<Q>, T> {
+
+    private final QueryMixin<Q> queryMixin;
+
+    private final Path<?> ref;
+
+    private final Path<T> target;
+
+    public JoinBuilder(QueryMixin<Q> queryMixin, Path<?> ref, Path<T> target) {
+        this.queryMixin = queryMixin;
+        this.ref = ref;
+        this.target = target;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Q on(Predicate... conditions) {
+        queryMixin.addJoin(JoinType.JOIN, ExpressionUtils.as((Path) ref, target));
+        queryMixin.on(conditions);
+        return queryMixin.getSelf();
+    }
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
@@ -262,6 +262,8 @@ public abstract class MongodbDocumentSerializer implements Visitor<Object, Void>
 
         } else if (op == MongodbOps.ELEM_MATCH) {
             return asDocument(asDBKey(expr, 0), asDocument("$elemMatch", asDBValue(expr, 1)));
+        } else if (op == MongodbOps.NO_MATCH) {
+            return new Document("$where", new BsonJavaScript("function() { return false }"));
         }
 
         throw new UnsupportedOperationException("Illegal operation " + expr);

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.bson.Document;
+import org.bson.types.ObjectId;
+
+import com.google.common.collect.Sets;
+import com.mongodb.DBRef;
+import com.querydsl.core.types.*;
+import com.querydsl.mongodb.MongodbOps;
+
+/**
+ * Serializes the given Querydsl query to a Document query for MongoDB.
+ *
+ * @author Mark Paluch
+ */
+public abstract class MongodbDocumentSerializer implements Visitor<Object, Void> {
+
+    public Object handle(Expression<?> expression) {
+        return expression.accept(this, null);
+    }
+
+    public Document toSort(List<OrderSpecifier<?>> orderBys) {
+        Document sort = new Document();
+        for (OrderSpecifier<?> orderBy : orderBys) {
+            Object key = orderBy.getTarget().accept(this, null);
+            sort.append(key.toString(), orderBy.getOrder() == Order.ASC ? 1 : -1);
+        }
+        return sort;
+    }
+
+    @Override
+    public Object visit(Constant<?> expr, Void context) {
+        if (Enum.class.isAssignableFrom(expr.getType())) {
+            @SuppressWarnings("unchecked") //Guarded by previous check
+                    Constant<? extends Enum<?>> expectedExpr = (Constant<? extends Enum<?>>) expr;
+            return expectedExpr.getConstant().name();
+        } else {
+            return expr.getConstant();
+        }
+    }
+
+    @Override
+    public Object visit(TemplateExpression<?> expr, Void context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(FactoryExpression<?> expr, Void context) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected String asDBKey(Operation<?> expr, int index) {
+        return (String) asDBValue(expr, index);
+    }
+
+    protected Object asDBValue(Operation<?> expr, int index) {
+        return expr.getArg(index).accept(this, null);
+    }
+
+    private String regexValue(Operation<?> expr, int index) {
+        return Pattern.quote(expr.getArg(index).accept(this, null).toString());
+    }
+
+    protected Document asDocument(String key, Object value) {
+        return new Document(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object visit(Operation<?> expr, Void context) {
+        Operator op = expr.getOperator();
+        if (op == Ops.EQ) {
+            if (expr.getArg(0) instanceof Operation) {
+                Operation<?> lhs = (Operation<?>) expr.getArg(0);
+                if (lhs.getOperator() == Ops.COL_SIZE || lhs.getOperator() == Ops.ARRAY_SIZE) {
+                    return asDocument(asDBKey(lhs, 0), asDocument("$size", asDBValue(expr, 1)));
+                } else {
+                    throw new UnsupportedOperationException("Illegal operation " + expr);
+                }
+            } else if (expr.getArg(0) instanceof Path) {
+                Path<?> path = (Path<?>) expr.getArg(0);
+                Constant<?> constant = (Constant<?>) expr.getArg(1);
+                return asDocument(asDBKey(expr, 0), convert(path, constant));
+            }
+        } else if (op == Ops.STRING_IS_EMPTY) {
+            return asDocument(asDBKey(expr, 0), "");
+
+        } else if (op == Ops.AND) {
+            Map<Object, Object> lhs = (Map<Object, Object>) handle(expr.getArg(0));
+            Map<Object, Object> rhs = (Map<Object, Object>) handle(expr.getArg(1));
+            if (Sets.intersection(lhs.keySet(), rhs.keySet()).isEmpty()) {
+                lhs.putAll(rhs);
+                return lhs;
+            } else {
+                List<Object> list = new ArrayList<Object>(2);
+                list.add(handle(expr.getArg(0)));
+                list.add(handle(expr.getArg(1)));
+                return asDocument("$and", list);
+            }
+
+        } else if (op == Ops.NOT) {
+            //Handle the not's child
+            Operation<?> subOperation = (Operation<?>) expr.getArg(0);
+            Operator subOp = subOperation.getOperator();
+            if (subOp == Ops.IN) {
+                return visit(ExpressionUtils.operation(Boolean.class, Ops.NOT_IN, subOperation.getArg(0),
+                        subOperation.getArg(1)), context);
+            } else {
+                Document arg = (Document) handle(expr.getArg(0));
+                return negate(arg);
+            }
+
+        } else if (op == Ops.OR) {
+            List<Object> list = new ArrayList<Object>(2);
+            list.add(handle(expr.getArg(0)));
+            list.add(handle(expr.getArg(1)));
+            return asDocument("$or", list);
+
+        } else if (op == Ops.NE) {
+            Path<?> path = (Path<?>) expr.getArg(0);
+            Constant<?> constant = (Constant<?>) expr.getArg(1);
+            return asDocument(asDBKey(expr, 0), asDocument("$ne", convert(path, constant)));
+
+        } else if (op == Ops.STARTS_WITH) {
+            return asDocument(asDBKey(expr, 0),
+                    Pattern.compile("^" + regexValue(expr, 1)));
+
+        } else if (op == Ops.STARTS_WITH_IC) {
+            return asDocument(asDBKey(expr, 0),
+                    Pattern.compile("^" + regexValue(expr, 1), Pattern.CASE_INSENSITIVE));
+
+        } else if (op == Ops.ENDS_WITH) {
+            return asDocument(asDBKey(expr, 0), Pattern.compile(regexValue(expr, 1) + "$"));
+
+        } else if (op == Ops.ENDS_WITH_IC) {
+            return asDocument(asDBKey(expr, 0),
+                    Pattern.compile(regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+
+        } else if (op == Ops.EQ_IGNORE_CASE) {
+            return asDocument(asDBKey(expr, 0),
+                    Pattern.compile("^" + regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+
+        } else if (op == Ops.STRING_CONTAINS) {
+            return asDocument(asDBKey(expr, 0), Pattern.compile(".*" + regexValue(expr, 1) + ".*"));
+
+        } else if (op == Ops.STRING_CONTAINS_IC) {
+            return asDocument(asDBKey(expr, 0),
+                    Pattern.compile(".*" + regexValue(expr, 1) + ".*", Pattern.CASE_INSENSITIVE));
+
+        } else if (op == Ops.MATCHES) {
+            return asDocument(asDBKey(expr, 0), Pattern.compile(asDBValue(expr, 1).toString()));
+
+        } else if (op == Ops.MATCHES_IC) {
+            return asDocument(asDBKey(expr, 0), Pattern.compile(asDBValue(expr, 1).toString(), Pattern.CASE_INSENSITIVE));
+
+        } else if (op == Ops.LIKE) {
+            String regex = ExpressionUtils.likeToRegex((Expression) expr.getArg(1)).toString();
+            return asDocument(asDBKey(expr, 0), Pattern.compile(regex));
+
+        } else if (op == Ops.BETWEEN) {
+            Document value = new Document("$gte", asDBValue(expr, 1));
+            value.append("$lte", asDBValue(expr, 2));
+            return asDocument(asDBKey(expr, 0), value);
+
+        } else if (op == Ops.IN) {
+            int constIndex = 0;
+            int exprIndex = 1;
+            if (expr.getArg(1) instanceof Constant<?>) {
+                constIndex = 1;
+                exprIndex = 0;
+            }
+            if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
+                @SuppressWarnings("unchecked") //guarded by previous check
+                Collection<?> values = ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
+                return asDocument(asDBKey(expr, exprIndex), asDocument("$in", values));
+            } else {
+                Path<?> path = (Path<?>) expr.getArg(exprIndex);
+                Constant<?> constant = (Constant<?>) expr.getArg(constIndex);
+                return asDocument(asDBKey(expr, exprIndex), convert(path, constant));
+            }
+
+        } else if (op == Ops.NOT_IN) {
+            int constIndex = 0;
+            int exprIndex = 1;
+            if (expr.getArg(1) instanceof Constant<?>) {
+                constIndex = 1;
+                exprIndex = 0;
+            }
+            if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
+                @SuppressWarnings("unchecked") //guarded by previous check
+                Collection<?> values = ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
+                return asDocument(asDBKey(expr, exprIndex), asDocument("$nin", values));
+            } else {
+                Path<?> path = (Path<?>) expr.getArg(exprIndex);
+                Constant<?> constant = (Constant<?>) expr.getArg(constIndex);
+                return asDocument(asDBKey(expr, exprIndex), asDocument("$ne", convert(path, constant)));
+            }
+
+        } else if (op == Ops.COL_IS_EMPTY) {
+            List<Object> list = new ArrayList<Object>(2);
+            list.add(asDocument(asDBKey(expr, 0), new ArrayList<Object>()));
+            list.add(asDocument(asDBKey(expr, 0), asDocument("$exists", false)));
+            return asDocument("$or", list);
+
+        } else if (op == Ops.LT) {
+            return asDocument(asDBKey(expr, 0), asDocument("$lt", asDBValue(expr, 1)));
+
+        } else if (op == Ops.GT) {
+            return asDocument(asDBKey(expr, 0), asDocument("$gt", asDBValue(expr, 1)));
+
+        } else if (op == Ops.LOE) {
+            return asDocument(asDBKey(expr, 0), asDocument("$lte", asDBValue(expr, 1)));
+
+        } else if (op == Ops.GOE) {
+            return asDocument(asDBKey(expr, 0), asDocument("$gte", asDBValue(expr, 1)));
+
+        } else if (op == Ops.IS_NULL) {
+            return asDocument(asDBKey(expr, 0), asDocument("$exists", false));
+
+        } else if (op == Ops.IS_NOT_NULL) {
+            return asDocument(asDBKey(expr, 0), asDocument("$exists", true));
+
+        } else if (op == Ops.CONTAINS_KEY) {
+            Path<?> path = (Path<?>) expr.getArg(0);
+            Expression<?> key = expr.getArg(1);
+            return asDocument(visit(path, context) + "." + key.toString(), asDocument("$exists", true));
+
+        } else if (op == MongodbOps.NEAR) {
+            return asDocument(asDBKey(expr, 0), asDocument("$near", asDBValue(expr, 1)));
+
+        } else if (op == MongodbOps.NEAR_SPHERE) {
+            return asDocument(asDBKey(expr, 0), asDocument("$nearSphere", asDBValue(expr, 1)));
+
+        } else if (op == MongodbOps.ELEM_MATCH) {
+            return asDocument(asDBKey(expr, 0), asDocument("$elemMatch", asDBValue(expr, 1)));
+        }
+
+        throw new UnsupportedOperationException("Illegal operation " + expr);
+    }
+
+    private Object negate(Document arg) {
+        List<Object> list = new ArrayList<Object>();
+        for (Map.Entry<String, Object> entry : arg.entrySet()) {
+            if (entry.getKey().equals("$or")) {
+                list.add(asDocument("$nor", entry.getValue()));
+
+            } else if (entry.getKey().equals("$and")) {
+                List<Object> list2 = new ArrayList<Object>();
+                for (Object o : ((Collection) entry.getValue())) {
+                    list2.add(negate((Document) o));
+                }
+                list.add(asDocument("$or", list2));
+
+            } else if (entry.getValue() instanceof Pattern) {
+                list.add(asDocument(entry.getKey(), asDocument("$not", entry.getValue())));
+
+            } else if (entry.getValue() instanceof Document) {
+                list.add(negate(entry.getKey(), (Document) entry.getValue()));
+
+            } else {
+                list.add(asDocument(entry.getKey(), asDocument("$ne", entry.getValue())));
+            }
+        }
+        return list.size() == 1 ? list.get(0) : asDocument("$or", list);
+    }
+
+    private Object negate(String key, Document value) {
+        if (value.size() == 1) {
+            return asDocument(key, asDocument("$not", value));
+
+        } else {
+            List<Object> list2 = new ArrayList<Object>();
+            for (Map.Entry<String, Object> entry2 : value.entrySet()) {
+                list2.add(asDocument(key,
+                        asDocument("$not", asDocument(entry2.getKey(), entry2.getValue()))));
+            }
+            return asDocument("$or", list2);
+        }
+    }
+
+    protected Object convert(Path<?> property, Constant<?> constant) {
+        if (isReference(property)) {
+            return asReference(constant.getConstant());
+        } else if (isId(property)) {
+            if (isReference(property.getMetadata().getParent())) {
+                return asReferenceKey(property.getMetadata().getParent().getType(), constant.getConstant());
+            } else if (constant.getType().equals(String.class) && isImplicitObjectIdConversion()) {
+                String id = (String) constant.getConstant();
+                return ObjectId.isValid(id) ? new ObjectId(id) : id;
+            }
+        }
+        return visit(constant, null);
+    }
+
+    protected boolean isImplicitObjectIdConversion() {
+        return true;
+    }
+
+    protected DBRef asReferenceKey(Class<?> entity, Object id) {
+        // TODO override in subclass
+        throw new UnsupportedOperationException();
+    }
+
+    protected abstract DBRef asReference(Object constant);
+
+    protected abstract boolean isReference(Path<?> arg);
+
+    protected boolean isId(Path<?> arg) {
+        // TODO override in subclass
+        return false;
+    }
+
+    @Override
+    public String visit(Path<?> expr, Void context) {
+        PathMetadata metadata = expr.getMetadata();
+        if (metadata.getParent() != null) {
+            Path<?> parent = metadata.getParent();
+            if (parent.getMetadata().getPathType() == PathType.DELEGATE) {
+                parent = parent.getMetadata().getParent();
+            }
+            if (metadata.getPathType() == PathType.COLLECTION_ANY) {
+                return visit(parent, context);
+            } else if (parent.getMetadata().getPathType() != PathType.VARIABLE) {
+                String rv = getKeyForPath(expr, metadata);
+                String parentStr = visit(parent, context);
+                return rv != null ? parentStr + "." + rv : parentStr;
+            }
+        }
+        return getKeyForPath(expr, metadata);
+    }
+
+    protected String getKeyForPath(Path<?> expr, PathMetadata metadata) {
+        return metadata.getElement().toString();
+    }
+
+    @Override
+    public Object visit(SubQueryExpression<?> expr, Void context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(ParamExpression<?> expr, Void context) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
@@ -156,40 +156,35 @@ public abstract class MongodbDocumentSerializer implements Visitor<Object, Void>
             return asDocument(asDBKey(expr, 0), asDocument("$ne", convert(path, constant)));
 
         } else if (op == Ops.STARTS_WITH) {
-            return asDocument(asDBKey(expr, 0),
-                    Pattern.compile("^" + regexValue(expr, 1)));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression("^" + regexValue(expr, 1)));
 
         } else if (op == Ops.STARTS_WITH_IC) {
-            return asDocument(asDBKey(expr, 0),
-                    Pattern.compile("^" + regexValue(expr, 1), Pattern.CASE_INSENSITIVE));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression("^" + regexValue(expr, 1), "i"));
 
         } else if (op == Ops.ENDS_WITH) {
-            return asDocument(asDBKey(expr, 0), Pattern.compile(regexValue(expr, 1) + "$"));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression(regexValue(expr, 1) + "$"));
 
         } else if (op == Ops.ENDS_WITH_IC) {
-            return asDocument(asDBKey(expr, 0),
-                    Pattern.compile(regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression(regexValue(expr, 1) + "$", "i"));
 
         } else if (op == Ops.EQ_IGNORE_CASE) {
-            return asDocument(asDBKey(expr, 0),
-                    Pattern.compile("^" + regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression("^" + regexValue(expr, 1) + "$", "i"));
 
         } else if (op == Ops.STRING_CONTAINS) {
-            return asDocument(asDBKey(expr, 0), Pattern.compile(".*" + regexValue(expr, 1) + ".*"));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression(".*" + regexValue(expr, 1) + ".*"));
 
         } else if (op == Ops.STRING_CONTAINS_IC) {
-            return asDocument(asDBKey(expr, 0),
-                    Pattern.compile(".*" + regexValue(expr, 1) + ".*", Pattern.CASE_INSENSITIVE));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression(".*" + regexValue(expr, 1) + ".*", "i"));
 
         } else if (op == Ops.MATCHES) {
-            return asDocument(asDBKey(expr, 0), Pattern.compile(asDBValue(expr, 1).toString()));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression(asDBValue(expr, 1).toString()));
 
         } else if (op == Ops.MATCHES_IC) {
-            return asDocument(asDBKey(expr, 0), Pattern.compile(asDBValue(expr, 1).toString(), Pattern.CASE_INSENSITIVE));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression(asDBValue(expr, 1).toString(), "i"));
 
         } else if (op == Ops.LIKE) {
             String regex = ExpressionUtils.likeToRegex((Expression) expr.getArg(1)).toString();
-            return asDocument(asDBKey(expr, 0), Pattern.compile(regex));
+            return asDocument(asDBKey(expr, 0), new BsonRegularExpression(regex));
 
         } else if (op == Ops.BETWEEN) {
             Document value = new Document("$gte", asDBValue(expr, 1));
@@ -285,7 +280,7 @@ public abstract class MongodbDocumentSerializer implements Visitor<Object, Void>
                 }
                 list.add(asDocument("$or", list2));
 
-            } else if (entry.getValue() instanceof Pattern) {
+            } else if (entry.getValue() instanceof Pattern || entry.getValue() instanceof BsonRegularExpression) {
                 list.add(asDocument(entry.getKey(), asDocument("$not", entry.getValue())));
 
             } else if (entry.getValue() instanceof Document) {

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbExpressions.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbExpressions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import java.util.Arrays;
+
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.mongodb.MongodbOps;
+
+/**
+ * Mongodb Document-API-specific operations.
+ *
+ * @author tiwe
+ * @author Mark Paluch
+ *
+ */
+public final class MongodbExpressions {
+
+    private MongodbExpressions() { }
+
+    /**
+     * Finds the closest points relative to the given location and orders the results with decreasing proximity
+     *
+     * @param expr location
+     * @param latVal latitude
+     * @param longVal longitude
+     * @return predicate
+     */
+    public static BooleanExpression near(Expression<Double[]> expr, double latVal, double longVal) {
+        return Expressions.booleanOperation(MongodbOps.NEAR, expr, ConstantImpl.create(Arrays.asList(latVal, longVal)));
+    }
+
+    /**
+     * Finds the closest points relative to the given location on a sphere and orders the results with decreasing proximity
+     *
+     * @param expr location
+     * @param latVal latitude
+     * @param longVal longitude
+     * @return predicate
+     */
+    public static BooleanExpression nearSphere(Expression<Double[]> expr, double latVal, double longVal) {
+        return Expressions.booleanOperation(MongodbOps.NEAR_SPHERE, expr, ConstantImpl.create(Arrays.asList(latVal, longVal)));
+    }
+}

--- a/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/package-info.java
+++ b/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * MongoDB Document API support.
+ */
+package com.querydsl.mongodb.document;

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/document/MongodbDocumentSerializerTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/document/MongodbDocumentSerializerTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import static org.junit.Assert.*;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.mongodb.DBRef;
+import com.querydsl.core.types.Path;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.DatePath;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.mongodb.Point;
+import com.querydsl.mongodb.domain.QAddress;
+import com.querydsl.mongodb.domain.QPerson;
+import com.querydsl.mongodb.domain.QUser;
+
+public class MongodbDocumentSerializerTest {
+
+    private PathBuilder<Object> entityPath;
+    private StringPath title;
+    private NumberPath<Integer> year;
+    private NumberPath<Double> gross;
+
+    private NumberPath<Long> longField;
+    private NumberPath<Short> shortField;
+    private NumberPath<Byte> byteField;
+    private NumberPath<Float> floatField;
+
+    private DatePath<Date> date;
+    private final Date dateVal = new Date();
+    private DateTimePath<Timestamp> dateTime;
+    private final Timestamp dateTimeVal = new Timestamp(System.currentTimeMillis());
+
+    private MongodbDocumentSerializer serializer;
+
+    @Before
+    public void before() {
+        serializer = new MongodbDocumentSerializer() {
+            @Override
+            protected DBRef asReference(Object constant) {
+                return null;
+            }
+
+            @Override
+            protected boolean isReference(Path<?> arg) {
+                return false;
+            }
+        };
+
+        entityPath = new PathBuilder<Object>(Object.class, "obj");
+        title = entityPath.getString("title");
+        year = entityPath.getNumber("year", Integer.class);
+        gross = entityPath.getNumber("gross", Double.class);
+        longField = entityPath.getNumber("longField", Long.class);
+        shortField = entityPath.getNumber("shortField", Short.class);
+        byteField = entityPath.getNumber("byteField", Byte.class);
+        floatField = entityPath.getNumber("floatField", Float.class);
+        date = entityPath.getDate("date", Date.class);
+        dateTime = entityPath.getDateTime("dateTime", Timestamp.class);
+    }
+
+    @Test
+    public void paths() {
+        QUser user = QUser.user;
+        assertEquals("user", serializer.visit(user, null));
+        assertEquals("addresses", serializer.visit(user.addresses, null));
+        assertEquals("addresses", serializer.visit(user.addresses.any(), null));
+        assertEquals("addresses.street", serializer.visit(user.addresses.any().street, null));
+        assertEquals("firstName", serializer.visit(user.firstName, null));
+    }
+
+    @Test
+    public void indexedAccess() {
+        QUser user = QUser.user;
+        assertEquals("addresses.0.street", serializer.visit(user.addresses.get(0).street, null));
+    }
+
+    @Test
+    public void collectionAny() {
+        QUser user = QUser.user;
+        assertQuery(user.addresses.any().street.eq("Aakatu"), document("addresses.street","Aakatu"));
+    }
+
+    @Test
+    public void collectionIsEmpty() {
+        Document expected = document("$or",
+            Arrays.asList(
+                document("addresses", Collections.emptyList()),
+                document("addresses",
+                    document("$exists", false))));
+        assertQuery(QUser.user.addresses.isEmpty(), expected);
+    }
+
+    @Test
+    public void collectionIsNotEmpty() {
+        Document expected = document("$nor",
+            Arrays.asList(
+                document("addresses", Collections.emptyList()),
+                document("addresses",
+                    document("$exists", false))));
+        assertQuery(QUser.user.addresses.isNotEmpty(), expected);
+    }
+
+    @Test
+    public void equals() {
+        assertQuery(title.eq("A"), document("title","A"));
+        assertQuery(year.eq(1), document("year",1));
+        assertQuery(gross.eq(1.0D), document("gross", 1.0D));
+        assertQuery(longField.eq(1L), document("longField", 1L));
+        assertQuery(shortField.eq((short) 1), document("shortField", 1));
+        assertQuery(byteField.eq((byte) 1), document("byteField", 1));
+        assertQuery(floatField.eq(1.0F), document("floatField", 1.0F));
+
+        assertQuery(date.eq(dateVal), document("date", dateVal));
+    }
+
+    @Test
+    public void eqAndEq() {
+        assertQuery(
+            title.eq("A").and(year.eq(1)),
+            document("title","A").append("year", 1)
+        );
+
+        assertQuery(
+            title.eq("A").and(year.eq(1).and(gross.eq(1.0D))),
+            document("title","A").append("year", 1).append("gross", 1.0D)
+        );
+    }
+
+    @Test
+    public void notEq() {
+        assertQuery(title.ne("A"), document("title", document("$ne", "A")));
+    }
+
+    @Test
+    public void between() {
+        assertQuery(year.between(1, 10), document("year", document("$gte", 1).append("$lte", 10)));
+    }
+
+    @Test
+    public void lessAndGreaterAndBetween() {
+        assertQuery(title.lt("A"), document("title", document("$lt", "A")));
+        assertQuery(year.gt(1), document("year", document("$gt", 1)));
+
+        assertQuery(title.loe("A"), document("title", document("$lte", "A")));
+        assertQuery(year.goe(1), document("year", document("$gte", 1)));
+
+        assertQuery(
+                year.gt(1).and(year.lt(10)),
+                document("$and", Arrays.asList(
+                  document("year", document("$gt", 1)),
+                  document("year", document("$lt", 10))))
+        );
+
+        assertQuery(
+                year.between(1, 10),
+                document("year", document("$gte", 1).append("$lte", 10))
+        );
+    }
+
+    @Test
+    public void in() {
+        assertQuery(year.in(1,2,3), document("year", document("$in", Arrays.asList(1,2,3))));
+    }
+
+    @Test
+    public void notIn() {
+        assertQuery(year.in(1,2,3).not(), document("year", document("$nin", Arrays.asList(1,2,3))));
+        assertQuery(year.notIn(1,2,3), document("year", document("$nin", Arrays.asList(1,2,3))));
+    }
+
+    @Test
+    public void orderBy() {
+        Document orderBy = serializer.toSort(sortList(year.asc()));
+        assertEquals(document("year", 1), orderBy);
+
+        orderBy = serializer.toSort(sortList(year.desc()));
+        assertEquals(document("year", -1), orderBy);
+
+        orderBy = serializer.toSort(sortList(year.desc(), title.asc()));
+        assertEquals(document("year", -1).append("title", 1), orderBy);
+    }
+
+    @Test
+    public void regexCases() {
+        assertQuery(title.startsWith("A"),
+                document("title", Pattern.compile("^\\QA\\E")));
+        assertQuery(title.startsWithIgnoreCase("A"),
+                document("title", Pattern.compile("^\\QA\\E", Pattern.CASE_INSENSITIVE)));
+
+        assertQuery(title.endsWith("A"),
+                document("title", Pattern.compile("\\QA\\E$")));
+        assertQuery(title.endsWithIgnoreCase("A"),
+                document("title", Pattern.compile("\\QA\\E$", Pattern.CASE_INSENSITIVE)));
+
+        assertQuery(title.equalsIgnoreCase("A"),
+                document("title", Pattern.compile("^\\QA\\E$", Pattern.CASE_INSENSITIVE)));
+
+        assertQuery(title.contains("A"),
+                document("title", Pattern.compile(".*\\QA\\E.*")));
+        assertQuery(title.containsIgnoreCase("A"),
+                document("title", Pattern.compile(".*\\QA\\E.*", Pattern.CASE_INSENSITIVE)));
+
+        assertQuery(title.matches(".*A^"),
+                document("title", Pattern.compile(".*A^")));
+    }
+
+    @Test
+    public void and() {
+        assertQuery(
+            title.startsWithIgnoreCase("a").and(title.endsWithIgnoreCase("b")),
+
+            document("$and", Arrays.asList(
+                document("title", document("$regex", "^\\Qa\\E").append("$options", "i")),
+                document("title", document("$regex", "\\Qb\\E$").append("$options", "i")))));
+
+    }
+
+    @Test
+    public void near() {
+        assertQuery(MongodbExpressions.near(new Point("point"), 1.0, 2.0),
+                document("point", document("$near", Arrays.asList(1.0, 2.0))));
+    }
+
+    @Test
+    public void near_sphere() {
+        assertQuery(MongodbExpressions.nearSphere(new Point("point"), 1.0, 2.0),
+                document("point", document("$nearSphere", Arrays.asList(1.0, 2.0))));
+    }
+
+    @Test
+    public void not() {
+        assertQuery(title.eq("A").not(), document("title", document("$ne","A")));
+
+        assertQuery(title.lt("A").not().and(year.ne(1800)),
+                document("title", document("$not", document("$lt","A"))).
+                append("year", document("$ne", 1800)));
+    }
+
+    @Test
+    public void objectId() {
+        ObjectId id = new ObjectId();
+        QPerson person = QPerson.person;
+        assertQuery(person.id.eq(id), document("id",id));
+        assertQuery(person.addressId.eq(id), document("addressId",id));
+    }
+
+    @Test
+    public void path() {
+        QUser user = QUser.user;
+        assertEquals("firstName", serializer.visit(user.firstName, null));
+        assertEquals("firstName", serializer.visit(user.as(QUser.class).firstName, null));
+        assertEquals("mainAddress.street", serializer.visit(user.mainAddress().street, null));
+        assertEquals("mainAddress.street", serializer.visit(user.mainAddress().as(QAddress.class).street, null));
+    }
+
+
+    private List<OrderSpecifier<?>> sortList(OrderSpecifier<?> ... order) {
+        return Arrays.asList(order);
+    }
+
+    private void assertQuery(Expression<?> e, Document expected) {
+        Document result = (Document) serializer.handle(e);
+        assertEquals(expected.toJson(), result.toJson());
+    }
+
+    public static Document document(String key, Object... value) {
+        if (value.length == 1) {
+            return new Document(key, value[0]);
+        }
+        return new Document(key, value);
+    }
+}

--- a/querydsl-mongodb/src/test/java/com/querydsl/mongodb/document/MongodbQueryTest.java
+++ b/querydsl-mongodb/src/test/java/com/querydsl/mongodb/document/MongodbQueryTest.java
@@ -1,0 +1,729 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.mongodb.document;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.Lists;
+import com.mongodb.DBRef;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoException;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.querydsl.core.NonUniqueResultException;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.testutil.MongoDB;
+import com.querydsl.core.types.*;
+import com.querydsl.core.types.dsl.ListPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.mongodb.domain.*;
+import com.querydsl.mongodb.domain.User.Gender;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Key;
+import org.mongodb.morphia.Morphia;
+import org.mongodb.morphia.annotations.Id;
+import org.mongodb.morphia.annotations.Property;
+import org.mongodb.morphia.annotations.Reference;
+import org.mongodb.morphia.mapping.Mapper;
+
+import java.lang.reflect.AnnotatedElement;
+import java.net.UnknownHostException;
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+
+@Category(MongoDB.class)
+public class MongodbQueryTest {
+
+    private final MongoClient mongo;
+    private final Morphia morphia;
+    private final MongoDatabase database;
+    private final Datastore ds;
+
+    private final String dbname = "testdb";
+    private final QUser user = QUser.user;
+    private final QItem item = QItem.item;
+    private final QAddress address = QAddress.address;
+    private final QMapEntity mapEntity = QMapEntity.mapEntity;
+    private final QDates dates = QDates.dates;
+    private final QCountry country = QCountry.country;
+
+    List<User> users = Lists.newArrayList();
+    List<Document> userDocuments = Lists.newArrayList();
+    User user1, user2, user3, user4;
+    Document u1, u2, u3, u4;
+    City tampere, helsinki;
+
+    public MongodbQueryTest() throws UnknownHostException, MongoException {
+        mongo = new MongoClient();
+        morphia = new Morphia().map(User.class).map(Item.class).map(MapEntity.class).map(Dates.class);
+        database = mongo.getDatabase(dbname);
+        ds = morphia.createDatastore(mongo, dbname);
+    }
+
+    @Before
+    public void before() throws UnknownHostException, MongoException {
+        ds.delete(ds.createQuery(Item.class));
+        ds.delete(ds.createQuery(User.class));
+        ds.delete(ds.createQuery(Country.class));
+        ds.delete(ds.createQuery(MapEntity.class));
+
+        tampere = new City("Tampere", 61.30, 23.50);
+        helsinki = new City("Helsinki", 60.15, 20.03);
+
+        user1 = addUser("Jaakko", "Jantunen", 20, new Address("Aakatu", "00100", helsinki),
+                new Address("Aakatu1", "00100", helsinki),
+                new Address("Aakatu2", "00100", helsinki));
+        user2 = addUser("Jaakki", "Jantunen", 30, new Address("Beekatu", "00200", helsinki));
+        user3 = addUser("Jaana", "Aakkonen", 40, new Address("Ceekatu", "00300", tampere));
+        user4 = addUser("Jaana", "BeekkoNen", 50, new Address("Deekatu", "00400", tampere));
+
+        u1 = asDocument(user1);
+        u2 = asDocument(user2);
+        u3 = asDocument(user3);
+        u4 = asDocument(user4);
+
+        // order users by lastname, firstname
+        userDocuments = Lists.newArrayList(u3, u4, u2, u1);
+    }
+
+    @Test
+    public void query1() {
+        assertEquals(4L, query(user).fetchCount());
+        assertEquals(4L, query(User.class).fetchCount());
+    }
+
+    @Test
+    public void list_keys() {
+        Document u = where(user.firstName.eq("Jaakko")).fetch(user.firstName, user.mainAddress().street).get(0);
+        assertEquals("Jaakko", u.get("firstName"));
+        assertNull(u.get("lastName"));
+        assertEquals("Aakatu", u.get("mainAddress", Document.class).get("street"));
+        assertNull(u.get("mainAddress", Document.class).get("postCode"));
+    }
+
+    @Test
+    public void singleResult_keys() {
+        Document u = where(user.firstName.eq("Jaakko")).fetchFirst(user.firstName);
+        assertEquals("Jaakko", u.get("firstName"));
+        assertNull(u.get("lastName"));
+    }
+
+    @Test
+    public void uniqueResult_keys() {
+        Document u = where(user.firstName.eq("Jaakko")).fetchOne(user.firstName);
+        assertEquals("Jaakko", u.get("firstName"));
+        assertNull(u.get("lastName"));
+    }
+
+    @Test
+    public void list_deep_keys() {
+        Document u = where(user.firstName.eq("Jaakko")).fetchFirst(user.addresses.any().street);
+        List<Document> addresses = u.get("addresses", List.class);
+        for (Document a : addresses) {
+            assertNotNull(a.get("street"));
+            assertNull(a.get("city"));
+        }
+    }
+
+    @Test
+    public void between() {
+        assertQuery(user.age.between(20, 30), u2, u1);
+        assertQuery(user.age.goe(20).and(user.age.loe(30)), u2, u1);
+    }
+
+    @Test
+    public void between_not() {
+        assertQuery(user.age.between(20, 30).not(), u3, u4);
+        assertQuery(user.age.goe(20).and(user.age.loe(30)).not(), u3, u4);
+    }
+
+    @Test
+    public void contains_key() {
+        MapEntity entity = new MapEntity();
+        entity.getProperties().put("key", "value");
+        ds.save(entity);
+
+        assertTrue(query(mapEntity).where(mapEntity.properties.get("key").isNotNull()).fetchCount() > 0);
+        assertFalse(query(mapEntity).where(mapEntity.properties.get("key2").isNotNull()).fetchCount() > 0);
+
+        assertTrue(query(mapEntity).where(mapEntity.properties.containsKey("key")).fetchCount() > 0);
+        assertFalse(query(mapEntity).where(mapEntity.properties.containsKey("key2")).fetchCount() > 0);
+    }
+
+    @Test
+    public void contains_key_not() {
+        MapEntity entity = new MapEntity();
+        entity.getProperties().put("key", "value");
+        ds.save(entity);
+
+        assertFalse(query(mapEntity).where(mapEntity.properties.get("key").isNotNull().not()).fetchCount() > 0);
+        assertTrue(query(mapEntity).where(mapEntity.properties.get("key2").isNotNull().not()).fetchCount() > 0);
+
+        assertFalse(query(mapEntity).where(mapEntity.properties.containsKey("key").not()).fetchCount() > 0);
+        assertTrue(query(mapEntity).where(mapEntity.properties.containsKey("key2").not()).fetchCount() > 0);
+    }
+
+    @Test
+    public void equals_ignore_case() {
+        assertTrue(where(user.firstName.equalsIgnoreCase("jAaKko")).fetchCount() > 0);
+        assertFalse(where(user.firstName.equalsIgnoreCase("AaKk")).fetchCount() > 0);
+    }
+
+    @Test
+    public void equals_ignore_case_not() {
+        assertTrue(where(user.firstName.equalsIgnoreCase("jAaKko").not()).fetchCount() > 0);
+        assertTrue(where(user.firstName.equalsIgnoreCase("AaKk").not()).fetchCount() > 0);
+    }
+
+    @Test
+    public void equals_and_between() {
+        assertQuery(user.firstName.startsWith("Jaa").and(user.age.between(20, 30)), u2, u1);
+        assertQuery(user.firstName.startsWith("Jaa").and(user.age.goe(20).and(user.age.loe(30))), u2, u1);
+    }
+
+    @Test
+    public void equals_and_between_not() {
+        assertQuery(user.firstName.startsWith("Jaa").and(user.age.between(20, 30)).not(), u3, u4);
+        assertQuery(user.firstName.startsWith("Jaa").and(user.age.goe(20).and(user.age.loe(30))).not(), u3, u4);
+    }
+
+    @Test
+    public void exists() {
+        assertTrue(where(user.firstName.eq("Jaakko")).fetchCount() > 0);
+        assertFalse(where(user.firstName.eq("JaakkoX")).fetchCount() > 0);
+    }
+
+    @Test
+    public void find_by_id() {
+        assertNotNull(where(user.id.eq(user1.getId())).fetchFirst() != null);
+    }
+
+    @Test
+    public void notExists() {
+        assertFalse(where(user.firstName.eq("Jaakko")).fetchCount() == 0);
+        assertTrue(where(user.firstName.eq("JaakkoX")).fetchCount() == 0);
+    }
+
+    @Test
+    public void uniqueResult() {
+        assertEquals("Jantunen", where(user.firstName.eq("Jaakko")).fetchOne().get("lastName"));
+    }
+
+    @Test(expected = NonUniqueResultException.class)
+    public void uniqueResultContract() {
+        where(user.firstName.isNotNull()).fetchOne();
+    }
+
+    @Test
+    public void singleResult() {
+        where(user.firstName.isNotNull()).fetchFirst();
+    }
+
+    @Test
+    public void longPath() {
+        assertEquals(2, query().where(user.mainAddress().city().name.eq("Helsinki")).fetchCount());
+        assertEquals(2, query().where(user.mainAddress().city().name.eq("Tampere")).fetchCount());
+    }
+
+    @Test
+    public void collectionPath() {
+        assertEquals(1, query().where(user.addresses.any().street.eq("Aakatu1")).fetchCount());
+        assertEquals(0, query().where(user.addresses.any().street.eq("akatu")).fetchCount());
+    }
+
+    @Test
+    public void dates() {
+        long current = System.currentTimeMillis();
+        int dayInMillis = 24 * 60 * 60 * 1000;
+        Date start = new Date(current);
+        ds.delete(ds.createQuery(Dates.class));
+        Dates d = new Dates();
+        d.setDate(new Date(current + dayInMillis));
+        ds.save(d);
+        Date end = new Date(current + 2 * dayInMillis);
+
+        Document datesDocument = asDocument(d);
+
+        assertEquals(datesDocument, query(dates).where(dates.date.between(start, end)).fetchFirst());
+        assertEquals(0, query(dates).where(dates.date.between(new Date(0), start)).fetchCount());
+    }
+
+    @Test
+    public void elemMatch() {
+//      { "addresses" : { "$elemMatch" : { "street" : "Aakatu1"}}}
+        assertEquals(1, query().anyEmbedded(user.addresses, address).on(address.street.eq("Aakatu1")).fetchCount());
+//      { "addresses" : { "$elemMatch" : { "street" : "Aakatu1" , "postCode" : "00100"}}}
+        assertEquals(1, query().anyEmbedded(user.addresses, address)
+                .on(address.street.eq("Aakatu1"), address.postCode.eq("00100")).fetchCount());
+//      { "addresses" : { "$elemMatch" : { "street" : "akatu"}}}
+        assertEquals(0, query().anyEmbedded(user.addresses, address).on(address.street.eq("akatu")).fetchCount());
+//      { "addresses" : { "$elemMatch" : { "street" : "Aakatu1" , "postCode" : "00200"}}}
+        assertEquals(0, query().anyEmbedded(user.addresses, address)
+                .on(address.street.eq("Aakatu1"), address.postCode.eq("00200")).fetchCount());
+    }
+
+    @Test
+    public void indexedAccess() {
+        assertEquals(1, query().where(user.addresses.get(0).street.eq("Aakatu1")).fetchCount());
+        assertEquals(0, query().where(user.addresses.get(1).street.eq("Aakatu1")).fetchCount());
+    }
+
+    @Test
+    public void count() {
+        assertEquals(4, query().fetchCount());
+    }
+
+    @Test
+    public void order() {
+        List<Document> users = query().orderBy(user.age.asc()).fetch();
+        assertEquals(asList(u1, u2, u3, u4), users);
+
+        users = query().orderBy(user.age.desc()).fetch();
+        assertEquals(asList(u4, u3, u2, u1), users);
+    }
+
+    @Test
+    public void restrict() {
+        assertEquals(asList(u1, u2), query().limit(2).orderBy(user.age.asc()).fetch());
+        assertEquals(asList(u2, u3), query().limit(2).offset(1).orderBy(user.age.asc()).fetch());
+    }
+
+    @Test
+    public void listResults() {
+        QueryResults<Document> results = query().limit(2).orderBy(user.age.asc()).fetchResults();
+        assertEquals(4L, results.getTotal());
+        assertEquals(2, results.getResults().size());
+
+        results = query().offset(2).orderBy(user.age.asc()).fetchResults();
+        assertEquals(4L, results.getTotal());
+        assertEquals(2, results.getResults().size());
+    }
+
+    @Test
+    public void emptyResults() {
+        QueryResults<Document> results = query().where(user.firstName.eq("XXX")).fetchResults();
+        assertEquals(0L, results.getTotal());
+        assertEquals(Collections.emptyList(), results.getResults());
+    }
+
+    @Test
+    public void eqInAndOrderByQueries() {
+        assertQuery(user.firstName.eq("Jaakko"), u1);
+        assertQuery(user.firstName.equalsIgnoreCase("jaakko"), u1);
+        assertQuery(user.lastName.eq("Aakkonen"), u3);
+
+        assertQuery(user.firstName.in("Jaakko", "Teppo"), u1);
+        assertQuery(user.lastName.in("Aakkonen", "BeekkoNen"), u3, u4);
+
+        assertQuery(user.firstName.eq("Jouko"));
+
+        assertQuery(user.firstName.eq("Jaana"), user.lastName.asc(), u3, u4);
+        assertQuery(user.firstName.eq("Jaana"), user.lastName.desc(), u4, u3);
+        assertQuery(user.lastName.eq("Jantunen"), user.firstName.asc(), u2, u1);
+        assertQuery(user.lastName.eq("Jantunen"), user.firstName.desc(), u1, u2);
+
+        assertQuery(user.firstName.eq("Jaana").and(user.lastName.eq("Aakkonen")), u3);
+        //This should produce 'and' also
+        assertQuery(where(user.firstName.eq("Jaana"), user.lastName.eq("Aakkonen")), u3);
+
+        assertQuery(user.firstName.ne("Jaana"), u2, u1);
+    }
+
+    @Test
+    public void regexQueries() {
+        assertQuery(user.firstName.startsWith("Jaan"), u3, u4);
+        assertQuery(user.firstName.startsWith("jaan"));
+        assertQuery(user.firstName.startsWithIgnoreCase("jaan"), u3, u4);
+
+        assertQuery(user.lastName.endsWith("unen"), u2, u1);
+
+        assertQuery(user.lastName.endsWithIgnoreCase("onen"), u3, u4);
+
+        assertQuery(user.lastName.contains("oN"), u4);
+        assertQuery(user.lastName.containsIgnoreCase("on"), u3, u4);
+
+        assertQuery(user.firstName.matches(".*aa.*[^i]$"), u3, u4, u1);
+    }
+
+    @Test
+    public void regexQueries_not() {
+        assertQuery(user.firstName.startsWith("Jaan").not(), u2, u1);
+        assertQuery(user.firstName.startsWith("jaan").not(), u3, u4, u2, u1);
+        assertQuery(user.firstName.startsWithIgnoreCase("jaan").not(), u2, u1);
+
+        assertQuery(user.lastName.endsWith("unen").not(), u3, u4);
+
+        assertQuery(user.lastName.endsWithIgnoreCase("onen").not(), u2, u1);
+
+        assertQuery(user.lastName.contains("oN").not(), u3, u2, u1);
+        assertQuery(user.lastName.containsIgnoreCase("on").not(), u2, u1);
+
+        assertQuery(user.firstName.matches(".*aa.*[^i]$").not(), u2);
+    }
+
+    @Test
+    public void like() {
+        assertQuery(user.firstName.like("Jaan"));
+        assertQuery(user.firstName.like("Jaan%"), u3, u4);
+        assertQuery(user.firstName.like("jaan%"));
+
+        assertQuery(user.lastName.like("%unen"), u2, u1);
+    }
+
+    @Test
+    public void like_not() {
+        assertQuery(user.firstName.like("Jaan").not(), u3, u4, u2, u1);
+        assertQuery(user.firstName.like("Jaan%").not(), u2, u1);
+        assertQuery(user.firstName.like("jaan%").not(), u3, u4, u2, u1);
+
+        assertQuery(user.lastName.like("%unen").not(), u3, u4);
+    }
+
+    @Test
+    public void isNotNull() {
+        assertQuery(user.firstName.isNotNull(), u3, u4, u2, u1);
+    }
+
+    @Test
+    public void isNotNull_not() {
+        assertQuery(user.firstName.isNotNull().not());
+    }
+
+    @Test
+    public void isNull() {
+        assertQuery(user.firstName.isNull());
+    }
+
+    @Test
+    public void isNull_not() {
+        assertQuery(user.firstName.isNull().not(), u3, u4, u2, u1);
+    }
+
+    @Test
+    public void isEmpty() {
+        assertQuery(user.firstName.isEmpty());
+        assertQuery(user.friends.isEmpty(), u1);
+    }
+
+    @Test
+    public void isEmpty_not() {
+        assertQuery(user.firstName.isEmpty().not(), u3, u4, u2, u1);
+        assertQuery(user.friends.isEmpty().not(), u3, u4, u2);
+    }
+
+    @Test
+    public void not() {
+        assertQuery(user.firstName.eq("Jaakko").not(), u3, u4, u2);
+        assertQuery(user.firstName.ne("Jaakko").not(), u1);
+        assertQuery(user.firstName.matches("Jaakko").not(), u3, u4, u2);
+        assertQuery(user.friends.isNotEmpty(), u3, u4, u2);
+    }
+
+    @Test
+    public void or() {
+        assertQuery(user.lastName.eq("Aakkonen").or(user.lastName.eq("BeekkoNen")), u3, u4);
+    }
+
+    @Test
+    public void or_not() {
+        assertQuery(user.lastName.eq("Aakkonen").or(user.lastName.eq("BeekkoNen")).not(), u2, u1);
+    }
+
+    @Test
+    public void iterate() {
+        User a = addUser("A", "A");
+        User b = addUser("A1", "B");
+        User c = addUser("A2", "C");
+
+        Iterator<Document> i = where(user.firstName.startsWith("A"))
+                .orderBy(user.firstName.asc())
+                .iterate();
+
+        assertEquals(a.getId(), i.next().get("_id"));
+        assertEquals(b.getId(), i.next().get("_id"));
+        assertEquals(c.getId(), i.next().get("_id"));
+        assertEquals(false, i.hasNext());
+    }
+
+    @Test
+    public void uniqueResultAndLimitAndOffset() {
+        SimpleMongodbQuery q = query().where(user.firstName.startsWith("Ja")).orderBy(user.age.asc());
+        assertEquals(4, q.fetch().size());
+        assertEquals(u1, q.fetch().get(0));
+    }
+
+    @Test
+    public void references() {
+        for (User u : users) {
+            if (u.getFriend() != null) {
+                assertQuery(user.friend().eq(u.getFriend()), asDocument(u));
+            }
+        }
+    }
+
+    @Test
+    public void references2() {
+        for (User u : users) {
+            if (u.getFriend() != null) {
+                assertQuery(user.enemy().eq(u.getEnemy()), asDocument(u));
+            }
+        }
+    }
+
+    @Test
+    public void various() {
+        ListPath<Address, QAddress> list = user.addresses;
+        StringPath str = user.lastName;
+        List<Predicate> predicates = new ArrayList<Predicate>();
+        predicates.add(str.between("a", "b"));
+        predicates.add(str.contains("a"));
+        predicates.add(str.containsIgnoreCase("a"));
+        predicates.add(str.endsWith("a"));
+        predicates.add(str.endsWithIgnoreCase("a"));
+        predicates.add(str.eq("a"));
+        predicates.add(str.equalsIgnoreCase("a"));
+        predicates.add(str.goe("a"));
+        predicates.add(str.gt("a"));
+        predicates.add(str.in("a", "b", "c"));
+        predicates.add(str.isEmpty());
+        predicates.add(str.isNotNull());
+        predicates.add(str.isNull());
+        predicates.add(str.like("a"));
+        predicates.add(str.loe("a"));
+        predicates.add(str.lt("a"));
+        predicates.add(str.matches("a"));
+        predicates.add(str.ne("a"));
+        predicates.add(str.notBetween("a", "b"));
+        predicates.add(str.notIn("a", "b", "c"));
+        predicates.add(str.startsWith("a"));
+        predicates.add(str.startsWithIgnoreCase("a"));
+        predicates.add(list.isEmpty());
+        predicates.add(list.isNotEmpty());
+
+        for (Predicate predicate : predicates) {
+            long count1 = where(predicate).fetchCount();
+            long count2 = where(predicate.not()).fetchCount();
+            assertEquals(predicate.toString(), 4, count1 + count2);
+        }
+    }
+
+    @Test
+    public void enum_eq() {
+        assertQuery(user.gender.eq(Gender.MALE), u3, u4, u2, u1);
+    }
+
+    @Test
+    public void enum_ne() {
+        assertQuery(user.gender.ne(Gender.MALE));
+    }
+
+    @Test
+    public void in_objectIds() {
+        Item i = new Item();
+        i.setCtds(Arrays.asList(ObjectId.get(), ObjectId.get(), ObjectId.get()));
+        ds.save(i);
+
+        assertTrue(where(item, item.ctds.contains(i.getCtds().get(0))).fetchCount() > 0);
+        assertTrue(where(item, item.ctds.contains(ObjectId.get())).fetchCount() == 0);
+    }
+
+    @Test
+    public void in_objectIds2() {
+        Item i = new Item();
+        i.setCtds(Arrays.asList(ObjectId.get(), ObjectId.get(), ObjectId.get()));
+        ds.save(i);
+
+        assertTrue(where(item, item.ctds.any().in(i.getCtds())).fetchCount() > 0);
+        assertTrue(where(item, item.ctds.any().in(Arrays.asList(ObjectId.get(), ObjectId.get()))).fetchCount() == 0);
+    }
+
+    @Test
+    public void size() {
+        assertQuery(user.addresses.size().eq(2), u1);
+    }
+
+    @Test
+    public void size_not() {
+        assertQuery(user.addresses.size().eq(2).not(), u3, u4, u2);
+    }
+
+    @Test
+    public void readPreference() {
+        SimpleMongodbQuery query = query();
+        query.setReadPreference(ReadPreference.primary());
+        assertEquals(4, query.fetchCount());
+    }
+
+    @Test
+    public void asDBObject() {
+        SimpleMongodbQuery query = query();
+        query.where(user.firstName.eq("Bob"), user.lastName.eq("Wilson"));
+        assertEquals(
+                new Document().append("firstName", "Bob").append("lastName", "Wilson"),
+                query.asDocument());
+    }
+
+    private Document asDocument(AbstractEntity entity) {
+        return database.getCollection(ds.getCollection(entity.getClass()).getName())
+                .find(new Document("_id", entity.getId())).first();
+    }
+
+    private void assertQuery(Predicate e, Document... expected) {
+        assertQuery(where(e).orderBy(user.lastName.asc(), user.firstName.asc()), expected);
+    }
+
+    private void assertQuery(Predicate e, OrderSpecifier<?> orderBy, Document... expected) {
+        assertQuery(where(e).orderBy(orderBy), expected);
+    }
+
+    private <T> SimpleMongodbQuery where(EntityPath<T> entity, Predicate... e) {
+        return new SimpleMongodbQuery(morphia, ds, entity.getType(), database).where(e);
+    }
+
+    private SimpleMongodbQuery where(Predicate... e) {
+        return query().where(e);
+    }
+
+    private SimpleMongodbQuery query() {
+        return new SimpleMongodbQuery(morphia, ds, user.getType(), database);
+    }
+
+    private <T> SimpleMongodbQuery query(EntityPath<T> path) {
+        return new SimpleMongodbQuery(morphia, ds, path.getType(), database);
+    }
+
+    private <T> SimpleMongodbQuery query(Class<? extends T> clazz) {
+        return new SimpleMongodbQuery(morphia, ds, clazz, database);
+    }
+
+    private void assertQuery(SimpleMongodbQuery query, Document... expected) {
+        String toString = query.toString();
+        List<Document> results = query.fetch();
+
+        assertNotNull(toString, results);
+        if (expected == null) {
+            assertEquals("Should get empty result", 0, results.size());
+            return;
+        }
+        assertEquals(toString, expected.length, results.size());
+        int i = 0;
+        for (Document u : expected) {
+            assertEquals(toString, u, results.get(i++));
+        }
+    }
+
+    private User addUser(String first, String last) {
+        User user = new User(first, last);
+        ds.save(user);
+        return user;
+    }
+
+    private User addUser(String first, String last, int age, Address mainAddress, Address... addresses) {
+        User user = new User(first, last, age, new Date());
+        user.setGender(Gender.MALE);
+        user.setMainAddress(mainAddress);
+        for (Address address : addresses) {
+            user.addAddress(address);
+        }
+        for (User u : users) {
+            user.addFriend(u);
+        }
+        if (!users.isEmpty()) {
+            user.setFriend(users.get(users.size() - 1));
+            user.setEnemy(users.get(users.size() - 1));
+        }
+        ds.save(user);
+        users.add(user);
+
+        return user;
+    }
+
+    private static class SimpleMongodbQuery extends AbstractFetchableMongodbQuery<Document, SimpleMongodbQuery> {
+
+        private final Datastore datastore;
+        private final MongoDatabase database;
+
+        SimpleMongodbQuery(final Morphia morphia, final Datastore datastore, final Class<?> entityType,
+                           final MongoDatabase database) {
+            super(database.getCollection(datastore.getCollection(entityType).getName()), Functions.<Document>identity(),
+                    new SampleSerializer(morphia));
+            this.datastore = datastore;
+            this.database = database;
+        }
+
+        @Override
+        protected MongoCollection<Document> getCollection(Class<?> type) {
+            return database.getCollection(datastore.getCollection(type).getName());
+        }
+    }
+
+    static class SampleSerializer extends MongodbDocumentSerializer {
+        private final Morphia morphia;
+
+        SampleSerializer(Morphia morphia) {
+            this.morphia = morphia;
+        }
+
+        @Override
+        protected boolean isReference(Path<?> arg) {
+            return arg.getAnnotatedElement().isAnnotationPresent(Reference.class);
+        }
+
+        @Override
+        protected DBRef asReference(Object constant) {
+            Key<?> key = morphia.getMapper().getKey(constant);
+            return morphia.getMapper().keyToDBRef(key);
+        }
+
+        @Override
+        protected DBRef asReferenceKey(Class<?> entity, Object id) {
+            String collection = morphia.getMapper().getCollectionName(entity);
+            Key<?> key = new Key<Object>(entity, collection, id);
+            return morphia.getMapper().keyToDBRef(key);
+        }
+
+        @Override
+        protected String getKeyForPath(Path<?> expr, PathMetadata metadata) {
+            AnnotatedElement annotations = expr.getAnnotatedElement();
+            if (annotations.isAnnotationPresent(Id.class)) {
+                Path<?> parent = expr.getMetadata().getParent();
+                if (parent.getAnnotatedElement().isAnnotationPresent(Reference.class)) {
+                    return null; // go to parent
+                } else {
+                    return "_id";
+                }
+            } else if (annotations.isAnnotationPresent(Property.class)) {
+                Property property = annotations.getAnnotation(Property.class);
+                if (!property.value().equals(Mapper.IGNORED_FIELDNAME)) {
+                    return property.value();
+                }
+            } else if (annotations.isAnnotationPresent(Reference.class)) {
+                Reference reference = annotations.getAnnotation(Reference.class);
+                if (!reference.value().equals(Mapper.IGNORED_FIELDNAME)) {
+                    return reference.value();
+                }
+            }
+            return super.getKeyForPath(expr, metadata);
+        }
+    }
+}


### PR DESCRIPTION
his pull request introduces `Document` API support for MongoDB (see #2215) as an additional implementation, without changing `DBObject` support.

Document support is related to newer MongoDB driver versions and recommended for MongoDB 4.x usage (see #2681).

The design decouples  `Fetchable` from the actual query creation (`AbstractFetchableMongodbQuery `, `AbstractMongodbQuery`) so that MongoDB query creation isn't tied to the actual method of how the query will be run (e.g. Async, Reactive).

Supersedes #2239.

Fixes #2215