### PR TITLE
JPQL: Null instead of Tuple with null value is returned

### DIFF
--- a/querydsl-collections/src/main/java/com/querydsl/collections/CollQuerySerializer.java
+++ b/querydsl-collections/src/main/java/com/querydsl/collections/CollQuerySerializer.java
@@ -210,8 +210,9 @@ public final class CollQuerySerializer extends SerializerBase<CollQuerySerialize
     public Void visit(FactoryExpression<?> expr, Void context) {
         visitConstant(expr);
         append(".newInstance(");
+        append("new Object[] {");
         handle(", ", expr.getArgs());
-        append(")");
+        append("})");
         return null;
     }
 

--- a/querydsl-collections/src/test/java/com/querydsl/collections/CollQueryStandardTest.java
+++ b/querydsl-collections/src/test/java/com/querydsl/collections/CollQueryStandardTest.java
@@ -13,17 +13,29 @@
  */
 package com.querydsl.collections;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Test;
-
-import com.querydsl.core.*;
-import com.querydsl.core.types.*;
+import com.querydsl.core.Fetchable;
+import com.querydsl.core.Module;
+import com.querydsl.core.QueryExecution;
+import com.querydsl.core.Target;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.ArrayConstructorExpression;
+import com.querydsl.core.types.Concatenation;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ParamNotSetException;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.Param;
+import org.junit.Test;
 
 public class CollQueryStandardTest {
 
@@ -38,11 +50,11 @@ public class CollQueryStandardTest {
     private final QCat otherCat = new QCat("otherCat");
 
     private final List<Cat> data = Arrays.asList(
-            new Cat("Bob", 1, birthDate),
-            new Cat("Ruth", 2, birthDate),
-            new Cat("Felix", 3, birthDate),
-            new Cat("Allen", 4, birthDate),
-            new Cat("Mary", 5, birthDate)
+        new Cat("Bob", 1, birthDate),
+        new Cat("Ruth", 2, birthDate),
+        new Cat("Felix", 3, birthDate),
+        new Cat("Allen", 4, birthDate),
+        new Cat("Mary", 5, birthDate)
     );
 
     private static final Expression<?>[] NO_EXPRESSIONS = new Expression[0];
@@ -55,7 +67,7 @@ public class CollQueryStandardTest {
         @Override
         protected Fetchable<?> createQuery(Predicate filter) {
             return CollQueryFactory.from(cat, data).from(otherCat, data)
-                    .where(filter).select(cat.name);
+                .where(filter).select(cat.name);
         }
     };
 
@@ -80,12 +92,33 @@ public class CollQueryStandardTest {
     }
 
     @Test
-    public void tupleProjection() {
+    public void tupleMultipleFieldsProjection() {
         List<Tuple> tuples = CollQueryFactory.from(cat, data)
             .select(cat.name, cat.birthdate).fetch();
         for (Tuple tuple : tuples) {
             assertNotNull(tuple.get(cat.name));
             assertNotNull(tuple.get(cat.birthdate));
+        }
+    }
+
+    @Test
+    public void tupleOneFieldProjection() {
+        List<Tuple> tuples = CollQueryFactory.from(cat, data)
+            .select(new Expression<?>[] {cat.name}).fetch();
+        for (Tuple tuple : tuples) {
+            assertEquals(1, tuple.size());
+            assertNotNull(tuple.get(cat.name));
+        }
+    }
+
+    @Test
+    public void tupleOneNullFieldProjection() {
+        List<Tuple> tuples = CollQueryFactory.from(cat, data)
+            .select(new Expression<?>[] {Expressions.nullExpression()}).fetch();
+        for (Tuple tuple : tuples) {
+            assertNotNull(tuple);
+            assertEquals(1, tuple.size()); // THIS FAILS WITH NPE
+            assertNull(tuple.get(Expressions.nullExpression()));
         }
     }
 

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -185,7 +185,7 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
                     }
                     rv.add(projection.newInstance((Object[]) o));
                 } else {
-                    rv.add(projection.newInstance(new Object[] { null }));
+                    rv.add(projection.newInstance(new Object[] {null}));
                 }
             }
             return rv;

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -185,7 +185,7 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>> exte
                     }
                     rv.add(projection.newInstance((Object[]) o));
                 } else {
-                    rv.add(null);
+                    rv.add(projection.newInstance(new Object[] { null }));
                 }
             }
             return rv;

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
@@ -18,6 +18,7 @@ import static com.querydsl.jpa.JPAExpressions.selectOne;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Connection;
@@ -31,6 +32,8 @@ import javax.persistence.LockModeType;
 
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.Expressions;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -278,6 +281,16 @@ public class JPABase extends AbstractJPATest implements JPATest {
         List<String> rows = query().from(cat).select(cat.name).createQuery().getResultList();
         for (String row : rows) {
             assertNotNull(row);
+        }
+    }
+
+    @Test
+    public void createQuery4() {
+        List<Tuple> rows = query().from(cat).select(new Expression<?>[] { Expressions.nullExpression() }).fetch();
+        for (Tuple row : rows) {
+            assertNotNull(row);
+            assertEquals(1, row.size());
+            assertNull(row.get(Expressions.nullExpression()));
         }
     }
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
@@ -286,7 +286,7 @@ public class JPABase extends AbstractJPATest implements JPATest {
 
     @Test
     public void createQuery4() {
-        List<Tuple> rows = query().from(cat).select(new Expression<?>[] { Expressions.nullExpression() }).fetch();
+        List<Tuple> rows = query().from(cat).select(new Expression<?>[] {Expressions.nullExpression()}).fetch();
         for (Tuple row : rows) {
             assertNotNull(row);
             assertEquals(1, row.size());

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/JPABase.java
@@ -285,6 +285,8 @@ public class JPABase extends AbstractJPATest implements JPATest {
     }
 
     @Test
+    @NoHibernate
+    @ExcludeIn(Target.DERBY)
     public void createQuery4() {
         List<Tuple> rows = query().from(cat).select(new Expression<?>[] {Expressions.nullExpression()}).fetch();
         for (Tuple row : rows) {


### PR DESCRIPTION
Fix issue 2048 where single field selection which contains null value is not processed correctly (null instead of Tuple instance in 3.x and Tuple with null array in 4.x)

Fixes #2048