### PR TITLE
Switch from Slf4j to JUL to reduce transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,17 +127,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
         <version>1</version>

--- a/querydsl-apt/src/main/onejar.xml
+++ b/querydsl-apt/src/main/onejar.xml
@@ -27,8 +27,6 @@
       <unpack>true</unpack>
       <excludes>
         <exclude>cglib:cglib</exclude>
-        <exclude>org.slf4j:slf4j-api</exclude>
-        <exclude>org.slf4j:slf4j-log4j12</exclude>              
       </excludes>
     </dependencySet>
     <dependencySet>

--- a/querydsl-collections/README.md
+++ b/querydsl-collections/README.md
@@ -18,11 +18,6 @@ The Collections module provides integration with Java Collections and Beans.
   <artifactId>querydsl-collections</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>   
 ```
 
 If you are not using JPA or JDO you can generate Querydsl query types for your domain types by annotating them with the com.querydsl.core.annotations.QueryEntity annotation and adding the following plugin configuration into your Maven configuration (pom.xml) :

--- a/querydsl-collections/pom.xml
+++ b/querydsl-collections/pom.xml
@@ -40,15 +40,6 @@
       <version>${project.version}</version>
     </dependency>
     <!-- alias dependencies -->
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>    
     
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/collections.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/collections.xml
@@ -147,12 +147,6 @@ for (String name : select(cat.name).from(cat,cats)
   <artifactId>querydsl-collections</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ]]></programlisting>
 
 

--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/jdo.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/jdo.xml
@@ -31,12 +31,6 @@
   <artifactId>querydsl-jdo</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ]]></programlisting>
 
     <para>

--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
@@ -37,12 +37,6 @@
   <artifactId>querydsl-jpa</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ]]></programlisting>
 
     <para>

--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/lucene.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/lucene.xml
@@ -22,12 +22,6 @@
   <artifactId>querydsl-lucene3</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ]]></programlisting>
 
   <para>Lucene 4:</para>
@@ -37,12 +31,6 @@
   <groupId>com.querydsl</groupId>
   <artifactId>querydsl-lucene4</artifactId>
   <version>${querydsl.version}</version>
-</dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
 </dependency>
 ]]></programlisting>
 
@@ -54,12 +42,6 @@
   <groupId>com.querydsl</groupId>
   <artifactId>querydsl-lucene5</artifactId>
   <version>${querydsl.version}</version>
-</dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
 </dependency>
 ]]></programlisting>
   </sect2>

--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/mongodb.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/mongodb.xml
@@ -26,12 +26,6 @@
   <artifactId>querydsl-mongodb</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ]]></programlisting>
 
     <para>

--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/sql.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/sql.xml
@@ -27,12 +27,6 @@
   <version>${querydsl.version}</version>
   <scope>provided</scope>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ]]></programlisting>
 
     <para>The querydsl-sql-codegen dependency can be skipped, if code generation happens

--- a/querydsl-examples/pom.xml
+++ b/querydsl-examples/pom.xml
@@ -37,6 +37,27 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.querydsl</groupId>

--- a/querydsl-examples/querydsl-example-jpa-guice/pom.xml
+++ b/querydsl-examples/querydsl-example-jpa-guice/pom.xml
@@ -52,17 +52,14 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
     </dependency>
 
     <!-- persistence -->

--- a/querydsl-examples/querydsl-example-sql-guice/pom.xml
+++ b/querydsl-examples/querydsl-example-sql-guice/pom.xml
@@ -34,17 +34,14 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
     </dependency>
 
     <!-- persistence -->

--- a/querydsl-examples/querydsl-example-sql-spring/pom.xml
+++ b/querydsl-examples/querydsl-example-sql-spring/pom.xml
@@ -79,17 +79,14 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
     </dependency>
 
     <!-- TEST dependencies -->

--- a/querydsl-hibernate-search/pom.xml
+++ b/querydsl-hibernate-search/pom.xml
@@ -63,12 +63,6 @@
       <artifactId>hibernate-validator</artifactId>
       <version>${hibernate.validator.version}</version>
       <scope>provided</scope>
-      <exclusions>    
-        <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>      
     </dependency>    
  
     <dependency>

--- a/querydsl-jdo/README.md
+++ b/querydsl-jdo/README.md
@@ -19,12 +19,6 @@ The JDO module provides integration with the JDO API.
   <artifactId>querydsl-jdo</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ```
 
 And now, configure the Maven APT plugin which generates the query types used by Querydsl :

--- a/querydsl-jdo/pom.xml
+++ b/querydsl-jdo/pom.xml
@@ -64,16 +64,7 @@
       <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional> 
-    </dependency>      
-    
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>    
 
     <!-- test -->
 

--- a/querydsl-jdo/src/main/assembly.xml
+++ b/querydsl-jdo/src/main/assembly.xml
@@ -20,8 +20,6 @@
         <exclude>cglib:cglib</exclude>
         <exclude>com.querydsl:querydsl-sql</exclude>
         <exclude>com.querydsl:querydsl-jdo</exclude>
-        <exclude>org.slf4j:slf4j-api</exclude>
-        <exclude>org.slf4j:slf4j-log4j12</exclude>                    
       </excludes>
     </dependencySet>
     <dependencySet>

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/AbstractJDOQuery.java
@@ -16,16 +16,14 @@ package com.querydsl.jdo;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
 import javax.jdo.JDOUserException;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
@@ -43,7 +41,7 @@ import com.querydsl.core.types.*;
  */
 public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> extends FetchableSubQueryBase<T, Q> implements JDOQLQuery<T> {
 
-    private static final Logger logger = LoggerFactory.getLogger(JDOQuery.class);
+    private static final Logger logger =  Logger.getLogger(JDOQuery.class.getName());
 
     private final Closeable closeable = new Closeable() {
         @Override
@@ -161,17 +159,10 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        if (logger.isDebugEnabled()) {
+        if (logger.isLoggable(Level.FINE)) {
             String normalizedQuery = queryString.replace('\n', ' ');
-            MDC.put(MDC_QUERY, normalizedQuery);
-            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
-            logger.debug(normalizedQuery);
+            logger.fine(normalizedQuery);
         }
-    }
-
-    protected void cleanupMDC() {
-        MDC.remove(MDC_QUERY);
-        MDC.remove(MDC_PARAMETERS);
     }
 
     @SuppressWarnings("unchecked")
@@ -279,7 +270,6 @@ public abstract class AbstractJDOQuery<T, Q extends AbstractJDOQuery<T, Q>> exte
     }
 
     private void reset() {
-        cleanupMDC();
     }
 
     /**

--- a/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
+++ b/querydsl-jdo/src/main/java/com/querydsl/jdo/sql/AbstractSQLQuery.java
@@ -19,13 +19,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Nullable;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
@@ -49,7 +48,7 @@ import com.querydsl.sql.SQLSerializer;
 @SuppressWarnings("rawtypes")
 public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> extends ProjectableSQLQuery<T, Q> {
 
-    private static final Logger logger = LoggerFactory.getLogger(JDOSQLQuery.class);
+    private static final Logger logger = Logger.getLogger(JDOSQLQuery.class.getName());
 
     private final Closeable closeable = new Closeable() {
         @Override
@@ -113,8 +112,8 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
 
 
         // create Query
-        if (logger.isDebugEnabled()) {
-            logger.debug(serializer.toString());
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine(serializer.toString());
         }
         Query query = persistenceManager.newQuery("javax.jdo.query.SQL", serializer.toString());
         orderedConstants = serializer.getConstants();

--- a/querydsl-jpa-codegen/pom.xml
+++ b/querydsl-jpa-codegen/pom.xml
@@ -61,12 +61,6 @@
       <artifactId>hibernate-validator</artifactId>
       <version>${hibernate4.validator.version}</version>
       <scope>provided</scope>
-    <exclusions>
-        <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </exclusion>
-    </exclusions>      
     </dependency>    
  
     <dependency>
@@ -113,16 +107,7 @@
       <artifactId>h2</artifactId>
       <version>${h2.version}</version>
       <scope>test</scope>
-    </dependency>              
-    
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>    
         
   </dependencies>
 

--- a/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/AbstractDomainExporter.java
+++ b/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/AbstractDomainExporter.java
@@ -38,8 +38,6 @@ import com.querydsl.core.annotations.QueryType;
 import com.querydsl.core.util.Annotations;
 import com.querydsl.core.util.ReflectionUtils;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
@@ -61,6 +59,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@code AbstractDomainExporter} is a common supertype for domain exporters
@@ -70,7 +70,7 @@ import java.util.function.Function;
  */
 public abstract class AbstractDomainExporter {
 
-    private static final Logger logger = LoggerFactory.getLogger(HibernateDomainExporter.class);
+    private static final Logger logger = Logger.getLogger(HibernateDomainExporter.class.getName());
 
     private final File targetFolder;
 
@@ -342,7 +342,7 @@ public abstract class AbstractDomainExporter {
 
     private Writer writerFor(File file) {
         if (!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
-            logger.error("Folder " + file.getParent() + " could not be created");
+            logger.log(Level.WARNING, "Folder " + file.getParent() + " could not be created");
         }
         try {
             return new OutputStreamWriter(new FileOutputStream(file), charset);

--- a/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/HibernateDomainExporter.java
+++ b/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/HibernateDomainExporter.java
@@ -18,14 +18,13 @@ import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
 import java.nio.charset.Charset;
 import java.util.Iterator;
+import java.util.logging.Logger;
 
 import javax.xml.stream.XMLStreamException;
 
 import org.hibernate.MappingException;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.mapping.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.codegen.utils.model.SimpleType;
 import com.querydsl.codegen.utils.model.Type;
@@ -43,7 +42,7 @@ import com.querydsl.codegen.SimpleSerializerConfig;
  */
 public class HibernateDomainExporter extends AbstractDomainExporter {
 
-    private static final Logger logger = LoggerFactory.getLogger(HibernateDomainExporter.class);
+    private static final Logger logger = Logger.getLogger(HibernateDomainExporter.class.getName());
 
     private final Configuration configuration;
 

--- a/querydsl-jpa/README.md
+++ b/querydsl-jpa/README.md
@@ -12,12 +12,6 @@ The JPA module provides integration with the JPA 2 persistence API.
   <artifactId>querydsl-jpa</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ```
 
 And now, configure the Maven APT plugin :

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -60,12 +60,6 @@
       <artifactId>hibernate-validator</artifactId>
       <version>${hibernate.validator.version}</version>
       <optional>true</optional>
-      <exclusions>
-        <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>      
     </dependency>
     <dependency>
       <groupId>javax.el</groupId>
@@ -110,15 +104,6 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
-    
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>    
 
     <!-- test -->
     <dependency>

--- a/querydsl-jpa/src/main/assembly-hibernate.xml
+++ b/querydsl-jpa/src/main/assembly-hibernate.xml
@@ -23,8 +23,6 @@
         <exclude>cglib:cglib</exclude>
         <exclude>com.querydsl:querydsl-sql</exclude>
         <exclude>com.querydsl:querydsl-jpa</exclude>
-        <exclude>org.slf4j:slf4j-api</exclude>
-        <exclude>org.slf4j:slf4j-log4j12</exclude>                    
       </excludes>
     </dependencySet>
     <dependencySet>

--- a/querydsl-jpa/src/main/assembly.xml
+++ b/querydsl-jpa/src/main/assembly.xml
@@ -29,8 +29,6 @@
         <exclude>cglib:cglib</exclude>
         <exclude>com.querydsl:querydsl-sql</exclude>
         <exclude>com.querydsl:querydsl-jpa</exclude>
-        <exclude>org.slf4j:slf4j-api</exclude>
-        <exclude>org.slf4j:slf4j-log4j12</exclude>                
       </excludes>
     </dependencySet>
     <dependencySet>

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
@@ -16,15 +16,14 @@ package com.querydsl.jpa.hibernate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
 
 import org.hibernate.*;
 import org.hibernate.Query;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.*;
@@ -45,7 +44,7 @@ import com.querydsl.jpa.*;
  */
 public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery<T, Q>> extends JPAQueryBase<T, Q> {
 
-    private static final Logger logger = LoggerFactory.getLogger(HibernateQuery.class);
+    private static final Logger logger = Logger.getLogger(HibernateQuery.class.getName());
 
     @Nullable
     protected Boolean cacheable, readOnly;
@@ -210,22 +209,14 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        if (logger.isDebugEnabled()) {
+        if (logger.isLoggable(Level.FINE)) {
             String normalizedQuery = queryString.replace('\n', ' ');
-            MDC.put(MDC_QUERY, normalizedQuery);
-            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
-            logger.debug(normalizedQuery);
+            logger.fine(normalizedQuery);
         }
-    }
-
-    protected void cleanupMDC() {
-        MDC.remove(MDC_QUERY);
-        MDC.remove(MDC_PARAMETERS);
     }
 
     @Override
     protected void reset() {
-        cleanupMDC();
     }
 
     /**

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/sql/AbstractHibernateSQLQuery.java
@@ -17,15 +17,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
 
 import org.hibernate.Query;
 import org.hibernate.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.*;
@@ -53,7 +52,7 @@ import com.querydsl.sql.SQLSerializer;
  */
 public abstract class AbstractHibernateSQLQuery<T, Q extends AbstractHibernateSQLQuery<T, Q>> extends AbstractSQLQuery<T, Q> {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractHibernateSQLQuery.class);
+    private static final Logger logger = Logger.getLogger(AbstractHibernateSQLQuery.class.getName());
 
     protected Boolean cacheable, readOnly;
 
@@ -203,21 +202,13 @@ public abstract class AbstractHibernateSQLQuery<T, Q extends AbstractHibernateSQ
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        if (logger.isDebugEnabled()) {
+        if (logger.isLoggable(Level.FINE)) {
             String normalizedQuery = queryString.replace('\n', ' ');
-            MDC.put(MDC_QUERY, normalizedQuery);
-            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
-            logger.debug(normalizedQuery);
+            logger.fine(normalizedQuery);
         }
     }
 
-    protected void cleanupMDC() {
-        MDC.remove(MDC_QUERY);
-        MDC.remove(MDC_PARAMETERS);
-    }
-
     protected void reset() {
-        cleanupMDC();
     }
 
     @SuppressWarnings("unchecked")

--- a/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
+++ b/querydsl-jpa/src/main/java/com/querydsl/jpa/sql/AbstractJPASQLQuery.java
@@ -19,6 +19,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
@@ -26,10 +28,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.Query;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.*;
@@ -53,7 +51,7 @@ import com.querydsl.sql.SQLSerializer;
  */
 public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>> extends AbstractSQLQuery<T, Q> {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractJPASQLQuery.class);
+    private static final Logger logger = Logger.getLogger(AbstractJPASQLQuery.class.getName());
 
     private final EntityManager entityManager;
 
@@ -283,21 +281,13 @@ public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>
     }
 
     protected void logQuery(String queryString, Map<Object, String> parameters) {
-        if (logger.isDebugEnabled()) {
+        if (logger.isLoggable(Level.FINE)) {
             String normalizedQuery = queryString.replace('\n', ' ');
-            MDC.put(MDC_QUERY, normalizedQuery);
-            MDC.put(MDC_PARAMETERS, String.valueOf(parameters));
-            logger.debug(normalizedQuery);
+            logger.fine(normalizedQuery);
         }
     }
 
-    protected void cleanupMDC() {
-        MDC.remove(MDC_QUERY);
-        MDC.remove(MDC_PARAMETERS);
-    }
-
     protected void reset() {
-        cleanupMDC();
     }
 
     @Override
@@ -312,7 +302,7 @@ public abstract class AbstractJPASQLQuery<T, Q extends AbstractJPASQLQuery<T, Q>
         try {
             return getSingleResult(query);
         } catch (javax.persistence.NoResultException e) {
-            logger.trace(e.getMessage(),e);
+            logger.log(Level.FINEST, e.getMessage(),e);
             return null;
         } catch (javax.persistence.NonUniqueResultException e) {
             throw new NonUniqueResultException(e);

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/QueryHelper.java
@@ -17,12 +17,11 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Nullable;
 
 import org.hibernate.hql.internal.ast.HqlParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.querydsl.core.DefaultQueryMetadata;
@@ -38,7 +37,7 @@ import antlr.collections.AST;
 
 class QueryHelper<T> extends JPAQueryBase<T, QueryHelper<T>> {
 
-    private static final Logger logger = LoggerFactory.getLogger(QueryHelper.class);
+    private static final Logger logger = Logger.getLogger(QueryHelper.class.getName());
 
     public QueryHelper(JPQLTemplates templates) {
         this(new DefaultQueryMetadata(), templates);
@@ -75,7 +74,7 @@ class QueryHelper<T> extends JPAQueryBase<T, QueryHelper<T>> {
 
     public void parse() throws RecognitionException, TokenStreamException {
         String input = toString();
-        logger.debug("input: " + input.replace('\n', ' '));
+        logger.fine("input: " + input.replace('\n', ' '));
         HqlParser parser = HqlParser.getInstance(input);
         parser.setFilter(false);
         parser.statement();

--- a/querydsl-lucene3/README.md
+++ b/querydsl-lucene3/README.md
@@ -12,12 +12,6 @@ The Lucene module provides integration with the Lucene 3 indexing library.
   <artifactId>querydsl-lucene3</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ```
 
 **Creating the query types**

--- a/querydsl-lucene3/pom.xml
+++ b/querydsl-lucene3/pom.xml
@@ -55,15 +55,6 @@
       <version>${project.version}</version>
     </dependency>
     
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    
     <!-- test -->
     <dependency>
       <groupId>cglib</groupId>

--- a/querydsl-lucene4/README.md
+++ b/querydsl-lucene4/README.md
@@ -11,12 +11,6 @@ The Lucene module provides integration with the Lucene 4 indexing library.
   <artifactId>querydsl-lucene4</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ```
 
 **Creating the query types**

--- a/querydsl-lucene4/pom.xml
+++ b/querydsl-lucene4/pom.xml
@@ -67,15 +67,6 @@
       <version>${project.version}</version>
     </dependency>
     
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    
     <!-- test -->
     <dependency>
       <groupId>com.querydsl</groupId>

--- a/querydsl-lucene5/README.md
+++ b/querydsl-lucene5/README.md
@@ -11,12 +11,6 @@ The Lucene module provides integration with the Lucene 5 indexing library.
   <artifactId>querydsl-lucene5</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ```
 
 **Creating the query types**

--- a/querydsl-lucene5/pom.xml
+++ b/querydsl-lucene5/pom.xml
@@ -67,15 +67,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-
     <!-- test -->
     <dependency>
       <groupId>com.querydsl</groupId>

--- a/querydsl-maven-plugin/pom.xml
+++ b/querydsl-maven-plugin/pom.xml
@@ -74,12 +74,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
-        </dependency>
-
         <!-- annotations -->
         <dependency>
             <groupId>javax.jdo</groupId>

--- a/querydsl-mongodb/README.md
+++ b/querydsl-mongodb/README.md
@@ -12,12 +12,6 @@ The Mongodb module provides integration with the Mongodb API.
   <artifactId>querydsl-mongodb</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ```
 
 And now, configure the Maven APT plugin which generates the query types used by Querydsl :

--- a/querydsl-mongodb/pom.xml
+++ b/querydsl-mongodb/pom.xml
@@ -63,15 +63,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-
     <!-- test -->
     <dependency>
       <groupId>com.querydsl</groupId>

--- a/querydsl-scala/pom.xml
+++ b/querydsl-scala/pom.xml
@@ -122,12 +122,6 @@
       <scope>test</scope>
     </dependency>
     
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>provided</scope>      
-    </dependency>      
-    
   </dependencies>
   
   <build>

--- a/querydsl-sql-codegen/pom.xml
+++ b/querydsl-sql-codegen/pom.xml
@@ -37,16 +37,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-        <scope>provided</scope>      
-    </dependency>    
-
     <!-- ANT integration -->    
     <dependency>
         <groupId>org.apache.ant</groupId>

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
@@ -39,8 +39,6 @@ import com.querydsl.sql.codegen.support.NotNullImpl;
 import com.querydsl.sql.codegen.support.PrimaryKeyData;
 import com.querydsl.sql.codegen.support.SizeImpl;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 /**
  * {@code MetadataExporter} exports JDBC metadata to Querydsl query types
@@ -79,7 +78,7 @@ import java.util.function.Function;
  */
 public class MetaDataExporter {
 
-    private static final Logger logger = LoggerFactory.getLogger(MetaDataExporter.class);
+    private static final Logger logger = Logger.getLogger(MetaDataExporter.class.getName());
 
     private final SQLTemplatesRegistry sqlTemplatesRegistry = new SQLTemplatesRegistry();
 

--- a/querydsl-sql-spatial/pom.xml
+++ b/querydsl-sql-spatial/pom.xml
@@ -55,12 +55,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- test -->
     <dependency>
       <groupId>joda-time</groupId>

--- a/querydsl-sql/README.md
+++ b/querydsl-sql/README.md
@@ -12,11 +12,6 @@ The SQL module provides integration with the JDBC API.
   <artifactId>querydsl-sql</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-log4j12</artifactId>
-  <version>1.6.1</version>
-</dependency>
 ```
 
 **Code generation via Maven**

--- a/querydsl-sql/pom.xml
+++ b/querydsl-sql/pom.xml
@@ -49,17 +49,7 @@
       <artifactId>validation-api</artifactId>
       <version>1.1.0.Final</version>
     </dependency>
-       
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>provided</scope>      
-    </dependency>    
-    
+
     <dependency>  
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>

--- a/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
@@ -22,12 +22,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.util.PrimitiveUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.core.types.Path;
 import com.querydsl.sql.namemapping.ChainedNameMapping;
@@ -45,7 +44,7 @@ import com.querydsl.sql.types.Type;
  */
 public final class Configuration {
 
-    private static final Logger logger = LoggerFactory.getLogger(Configuration.class);
+    private static final Logger logger = Logger.getLogger(Configuration.class.getName());
 
     static final Configuration DEFAULT = new Configuration(SQLTemplates.DEFAULT);
 
@@ -168,7 +167,7 @@ public final class Configuration {
 
                 Integer sqlComponentType = templates.getCodeForTypeName(typeName);
                 if (sqlComponentType == null) {
-                    logger.warn("Found no JDBC type for " + typeName + " using OTHER instead");
+                    logger.warning("Found no JDBC type for " + typeName + " using OTHER instead");
                     sqlComponentType = Types.OTHER;
                 }
                 Class<?> componentType = jdbcTypeMapping.get(sqlComponentType, size, digits);

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLBindings.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLBindings.java
@@ -14,10 +14,9 @@
 package com.querydsl.sql;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import com.querydsl.core.util.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * {@code SQLBindings} provides the SQL query string and bindings
@@ -27,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SQLBindings {
 
-    private static final Logger log = LoggerFactory.getLogger(SQLBindings.class);
+    private static final Logger log = Logger.getLogger(SQLBindings.class.getName());
 
     private final String sql;
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLClause.java
@@ -18,16 +18,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
-import org.slf4j.Logger;
-import org.slf4j.MDC;
-
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.dml.DMLClause;
-import com.querydsl.core.support.QueryBase;
 import com.querydsl.core.types.ParamExpression;
 import com.querydsl.core.types.ParamNotSetException;
 import com.querydsl.core.types.Path;
@@ -227,21 +225,13 @@ public abstract class AbstractSQLClause<C extends AbstractSQLClause<C>> implemen
     }
 
     protected void logQuery(Logger logger, String queryString, Collection<Object> parameters) {
-        if (logger.isDebugEnabled()) {
+        if (logger.isLoggable(Level.FINE)) {
             String normalizedQuery = queryString.replace('\n', ' ');
-            MDC.put(QueryBase.MDC_QUERY, normalizedQuery);
-            MDC.put(QueryBase.MDC_PARAMETERS, String.valueOf(parameters));
-            logger.debug(normalizedQuery);
+            logger.fine(normalizedQuery);
         }
     }
 
-    protected void cleanupMDC() {
-        MDC.remove(QueryBase.MDC_QUERY);
-        MDC.remove(QueryBase.MDC_PARAMETERS);
-    }
-
     protected void reset() {
-        cleanupMDC();
     }
 
     protected Connection connection() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLDeleteClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLDeleteClause.java
@@ -17,12 +17,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Range;
 import javax.inject.Provider;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.core.*;
 import com.querydsl.core.QueryFlag.Position;
@@ -44,7 +42,7 @@ import com.querydsl.sql.SQLSerializer;
  */
 public abstract class AbstractSQLDeleteClause<C extends AbstractSQLDeleteClause<C>> extends AbstractSQLClause<C> implements DeleteClause<C> {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractSQLDeleteClause.class);
+    protected static final Logger logger = Logger.getLogger(AbstractSQLDeleteClause.class.getName());
 
     protected static final ValidatingVisitor validatingVisitor = new ValidatingVisitor("Undeclared path '%s'. " +
             "A delete operation can only reference a single table. " +

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLInsertClause.java
@@ -15,13 +15,12 @@ package com.querydsl.sql.dml;
 
 import java.sql.*;
 import java.util.*;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
 import com.querydsl.core.util.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.core.DefaultQueryMetadata;
 import com.querydsl.core.JoinType;
@@ -43,7 +42,7 @@ import com.querydsl.sql.types.Null;
  */
 public abstract class AbstractSQLInsertClause<C extends AbstractSQLInsertClause<C>> extends AbstractSQLClause<C> implements InsertClause<C> {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractSQLInsertClause.class);
+    protected static final Logger logger = Logger.getLogger(AbstractSQLInsertClause.class.getName());
 
     protected final RelationalPath<?> entity;
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLUpdateClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/AbstractSQLUpdateClause.java
@@ -17,12 +17,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Range;
 import javax.inject.Provider;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.core.*;
 import com.querydsl.core.QueryFlag.Position;
@@ -46,7 +44,7 @@ import com.querydsl.sql.types.Null;
  */
 public abstract class AbstractSQLUpdateClause<C extends AbstractSQLUpdateClause<C>> extends AbstractSQLClause<C> implements UpdateClause<C> {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractSQLUpdateClause.class);
+    protected static final Logger logger = Logger.getLogger(AbstractSQLUpdateClause.class.getName());
 
     protected final RelationalPath<?> entity;
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
@@ -15,13 +15,12 @@ package com.querydsl.sql.dml;
 
 import java.sql.*;
 import java.util.*;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
 import com.querydsl.core.util.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.core.*;
 import com.querydsl.core.QueryFlag.Position;
@@ -40,7 +39,7 @@ import com.querydsl.sql.types.Null;
  */
 public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements StoreClause<SQLMergeClause> {
 
-    protected static final Logger logger = LoggerFactory.getLogger(SQLMergeClause.class);
+    protected static final Logger logger = Logger.getLogger(SQLMergeClause.class.getName());
 
     protected final List<Path<?>> columns = new ArrayList<Path<?>>();
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/AbstractBaseTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/AbstractBaseTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.sql.Connection;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -24,8 +25,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.core.DefaultQueryMetadata;
 import com.querydsl.core.QueryMetadata;
@@ -41,7 +40,7 @@ import com.querydsl.sql.types.XMLAsStringType;
 
 public abstract class AbstractBaseTest {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractBaseTest.class);
+    protected static final Logger logger = Logger.getLogger(AbstractBaseTest.class.getName());
 
     protected final class TestQuery<T> extends SQLQuery<T>  {
 
@@ -61,7 +60,7 @@ public abstract class AbstractBaseTest {
                 assertEquals(expectedQuery, rv.replace('\n', ' '));
                 expectedQuery = null;
             }
-            logger.debug(rv);
+            logger.fine(rv);
             return serializer;
         }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectOracleBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectOracleBase.java
@@ -5,12 +5,11 @@ import static com.querydsl.sql.Constants.employee;
 import static com.querydsl.sql.oracle.OracleGrammar.level;
 
 import java.sql.SQLException;
+import java.util.logging.Logger;
 
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.querydsl.core.testutil.IncludeIn;
 import com.querydsl.sql.domain.QEmployee;
@@ -18,7 +17,7 @@ import com.querydsl.sql.oracle.OracleQuery;
 
 public class SelectOracleBase extends AbstractBaseTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractSQLQuery.class);
+    private static final Logger logger = Logger.getLogger(AbstractSQLQuery.class.getName());
 
     protected OracleQuery<?> oracleQuery() {
         return new OracleQuery<Void>(connection, configuration) {
@@ -30,7 +29,7 @@ public class SelectOracleBase extends AbstractBaseTest {
                    Assert.assertEquals(expectedQuery, rv.replace('\n', ' '));
                    expectedQuery = null;
                 }
-                logger.debug(rv);
+                logger.fine(rv);
                 return serializer;
             }
         };

--- a/querydsl-sql/src/test/java/com/querydsl/sql/ddl/CreateTableClause.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/ddl/CreateTableClause.java
@@ -10,9 +10,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 import com.querydsl.core.QueryException;
 import com.querydsl.sql.Configuration;
@@ -26,7 +24,7 @@ import com.querydsl.sql.SQLTemplates;
  */
 public class CreateTableClause {
 
-    private static final Logger logger = LoggerFactory.getLogger(CreateTableClause.class);
+    private static final Logger logger = Logger.getLogger(CreateTableClause.class.getName());
 
     private final Connection connection;
 


### PR DESCRIPTION
I have not entirely decided on this patch yet.

Yes, users _often_ have and want Slf4j for better performance and configurability. Most applications will have or will want to have some implementation of Slf4j on their classpath anyway. (https://stackoverflow.com/a/11360517/2104280)

However, what if QueryDSL is the only dependency bringing a dependency to Slf4j? And hereby forces projects to adapt to Slf4j?

In the same spirit of the removal of Guava, JSR305, etc. it would be nice to decrease the number of dependencies forced on our users to an absolute minimum. JUL is included in the JRE (since 1.4) and can easily be bridged to Slf4j should users so desire.

Furthermore, we don't really need the performance anyway. We log very seldomly. We never use variable substitution in log statements. We mostly log when executing a query, in which case the latency of the log statement will be negligable compared to the roundtrip of the query anyways.
