### PR TITLE
SQLServer2012Templates for SQL Servers newer than 2012

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplatesRegistry.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplatesRegistry.java
@@ -64,14 +64,7 @@ public class SQLTemplatesRegistry {
         } else if (name.startsWith("teradata")) {
             return TeradataTemplates.builder();
         } else if (name.equals("microsoft sql server")) {
-            switch (md.getDatabaseMajorVersion()) {
-                case 13:
-                case 12:
-                case 11: return SQLServer2012Templates.builder();
-                case 10: return SQLServer2008Templates.builder();
-                case 9:  return SQLServer2005Templates.builder();
-                default: return SQLServerTemplates.builder();
-            }
+            return getMssqlSqlTemplates(md);
         } else {
             return new SQLTemplates.Builder() {
                 @Override
@@ -82,4 +75,21 @@ public class SQLTemplatesRegistry {
         }
     }
 
+    private SQLTemplates.Builder getMssqlSqlTemplates(DatabaseMetaData md) throws SQLException {
+        int databaseMajorVersion = md.getDatabaseMajorVersion();
+
+        if(databaseMajorVersion < 9) {
+            return SQLServerTemplates.builder();
+        }
+
+        if(databaseMajorVersion == 9) {
+            return SQLServer2005Templates.builder();
+        }
+
+        if(databaseMajorVersion == 10) {
+            return SQLServer2008Templates.builder();
+        }
+
+        return SQLServer2012Templates.builder();
+    }
 }

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplatesRegistry.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplatesRegistry.java
@@ -78,15 +78,15 @@ public class SQLTemplatesRegistry {
     private SQLTemplates.Builder getMssqlSqlTemplates(DatabaseMetaData md) throws SQLException {
         int databaseMajorVersion = md.getDatabaseMajorVersion();
 
-        if(databaseMajorVersion < 9) {
+        if (databaseMajorVersion < 9) {
             return SQLServerTemplates.builder();
         }
 
-        if(databaseMajorVersion == 9) {
+        if (databaseMajorVersion == 9) {
             return SQLServer2005Templates.builder();
         }
 
-        if(databaseMajorVersion == 10) {
+        if (databaseMajorVersion == 10) {
             return SQLServer2008Templates.builder();
         }
 


### PR DESCRIPTION
Currently the logic is to fallback to regular SQLServerTemplates which I believe is not ideal.