### PR TITLE
[#2612] Support Jakarta EE through Eclipse Transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ A huge thanks goes out to all contributors that made this release possible in th
 * [#2106](https://github.com/querydsl/querydsl/issues/2106) - Support NullsLast ordering in `querydsl-collections`.
 * [#2404](https://github.com/querydsl/querydsl/issues/2404) - Upgrade of JTS / Geolatte in `querydsl-spatial`
 * [#2320](https://github.com/querydsl/querydsl/issues/2320) - Make Spatial support available to `HibernateDomainExporter` and `JPADomainExporter`. 
+* [#2612](https://github.com/querydsl/querydsl/issues/2612) - Support jakarta.* packages for new Jakarta EE releases (available through the`jakarta` classifiers for Maven)
 
 #### Bugfixes
 

--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -149,7 +149,25 @@
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
-      </plugin>  
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.transformer</groupId>
+        <artifactId>org.eclipse.transformer.maven</artifactId>
+        <version>0.2.0</version>
+        <executions>
+          <execution>
+            <id>jakarta-ee</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>jakarta</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -184,6 +184,7 @@
                 <descriptor>src/main/hibernate.xml</descriptor>
                 <descriptor>src/main/jdo.xml</descriptor>
                 <descriptor>src/main/jpa.xml</descriptor>
+                <descriptor>src/main/jakarta.xml</descriptor>
                 <descriptor>src/main/morphia.xml</descriptor>
                 <descriptor>src/main/roo.xml</descriptor>
                 <descriptor>src/main/onejar.xml</descriptor>

--- a/querydsl-apt/src/main/jakarta.xml
+++ b/querydsl-apt/src/main/jakarta.xml
@@ -1,0 +1,29 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>jakarta</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>${project.groupId}:${project.artifactId}</include>
+      </includes>
+      <binaries>
+        <unpack>true</unpack>
+        <includeDependencies>false</includeDependencies>
+        <attachmentClassifier>jakarta</attachmentClassifier>
+        <outputDirectory>/</outputDirectory>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+  <fileSets>
+    <fileSet>
+      <directory>src/apt/jpa</directory>    
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/hibernate/HibernateAnnotationProcessor.java
@@ -29,7 +29,7 @@ import com.querydsl.apt.jpa.JPAAnnotationProcessor;
  * @author tiwe
  * @see JPAAnnotationProcessor
  */
-@SupportedAnnotationTypes({"com.querydsl.core.annotations.*","javax.persistence.*", "org.hibernate.annotations.*"})
+@SupportedAnnotationTypes({"com.querydsl.core.annotations.*", "javax.persistence.*", "jakarta.persistence.*", "org.hibernate.annotations.*"})
 public class HibernateAnnotationProcessor extends JPAAnnotationProcessor {
 
     @Override

--- a/querydsl-apt/src/main/java/com/querydsl/apt/jpa/JPAAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/jpa/JPAAnnotationProcessor.java
@@ -29,7 +29,7 @@ import com.querydsl.apt.Configuration;
  * @author tiwe
  *
  */
-@SupportedAnnotationTypes({"com.querydsl.core.annotations.*","javax.persistence.*"})
+@SupportedAnnotationTypes({"com.querydsl.core.annotations.*", "jakarta.persistence.*", "javax.persistence.*"})
 public class JPAAnnotationProcessor extends AbstractQuerydslProcessor {
 
     @Override

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/PropertyHandling.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/PropertyHandling.java
@@ -88,9 +88,11 @@ public enum PropertyHandling {
             boolean methods = false;
             for (Field field : type.getDeclaredFields()) {
                 fields |= hasAnnotations(field, "javax.persistence.");
+                fields |= hasAnnotations(field, "jakarta.persistence.");
             }
             for (Method method : type.getDeclaredMethods()) {
                 methods |= hasAnnotations(method, "javax.persistence.");
+                methods |= hasAnnotations(method, "jakarta.persistence.");
             }
             return Config.of(fields, methods, Config.ALL);
         }

--- a/querydsl-jpa-codegen/pom.xml
+++ b/querydsl-jpa-codegen/pom.xml
@@ -112,7 +112,24 @@
   </dependencies>
 
   <build>
-    <plugins>     
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.transformer</groupId>
+        <artifactId>org.eclipse.transformer.maven</artifactId>
+        <version>0.2.0</version>
+        <executions>
+          <execution>
+            <id>jakarta-ee</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>jakarta</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -262,8 +262,24 @@
             </goals>
           </execution>
         </executions>
-      </plugin>      
-            
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.transformer</groupId>
+        <artifactId>org.eclipse.transformer.maven</artifactId>
+        <version>0.2.0</version>
+        <executions>
+          <execution>
+            <id>jakarta-ee</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>jakarta</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Allow Jakarta EE API's to be used through a transformed artefact. ln order to use the transformed modules, use the `jakarta` classifier for the dependencies to `querydsl-jpa`, `querydsl-apt` and `querydsl-jpa-codegen`.

- [x] Would be nice if we can somehow embed `src/apt/jpa/META-INF/services/javax.annotation.processing.Processor` in the produced jar...

Fixes #2612