### PR TITLE
Fix the expression for week truncation for MySQL, Oracle and SQL Server

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/MySQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/MySQLTemplates.java
@@ -121,7 +121,7 @@ public class MySQLTemplates extends SQLTemplates {
 
         add(Ops.DateTimeOps.TRUNC_YEAR,   "str_to_date(concat(date_format({0},'%Y'),'-1-1'),'%Y-%m-%d')");
         add(Ops.DateTimeOps.TRUNC_MONTH,  "str_to_date(concat(date_format({0},'%Y-%m'),'-1'),'%Y-%m-%d')");
-        add(Ops.DateTimeOps.TRUNC_WEEK,   "str_to_date(concat(date_format({0},'%Y-%u'),'-2'),'%Y-%u-%w')");
+        add(Ops.DateTimeOps.TRUNC_WEEK,   "str_to_date(concat(date_format({0},'%Y-%u'),'-1'),'%Y-%u-%w')");
         add(Ops.DateTimeOps.TRUNC_DAY,    "str_to_date(date_format({0},'%Y-%m-%d'),'%Y-%m-%d')");
         add(Ops.DateTimeOps.TRUNC_HOUR,   "str_to_date(date_format({0},'%Y-%m-%d %k'),'%Y-%m-%d %k')");
         add(Ops.DateTimeOps.TRUNC_MINUTE, "str_to_date(date_format({0},'%Y-%m-%d %k:%i'),'%Y-%m-%d %k:%i')");

--- a/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
@@ -135,7 +135,7 @@ public class OracleTemplates extends SQLTemplates {
 
         add(Ops.DateTimeOps.TRUNC_YEAR, "trunc({0}, 'year')");
         add(Ops.DateTimeOps.TRUNC_MONTH, "trunc({0}, 'month')");
-        add(Ops.DateTimeOps.TRUNC_WEEK, "trunc({0}, 'w')");
+        add(Ops.DateTimeOps.TRUNC_WEEK, "trunc({0}, 'day')");
         add(Ops.DateTimeOps.TRUNC_DAY, "trunc({0}, 'dd')");
         add(Ops.DateTimeOps.TRUNC_HOUR, "trunc({0}, 'hh')");
         add(Ops.DateTimeOps.TRUNC_MINUTE, "trunc({0}, 'mi')");

--- a/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/OracleTemplates.java
@@ -135,7 +135,7 @@ public class OracleTemplates extends SQLTemplates {
 
         add(Ops.DateTimeOps.TRUNC_YEAR, "trunc({0}, 'year')");
         add(Ops.DateTimeOps.TRUNC_MONTH, "trunc({0}, 'month')");
-        add(Ops.DateTimeOps.TRUNC_WEEK, "trunc({0}, 'day')");
+        add(Ops.DateTimeOps.TRUNC_WEEK, "trunc({0}, 'iw')");
         add(Ops.DateTimeOps.TRUNC_DAY, "trunc({0}, 'dd')");
         add(Ops.DateTimeOps.TRUNC_HOUR, "trunc({0}, 'hh')");
         add(Ops.DateTimeOps.TRUNC_MINUTE, "trunc({0}, 'mi')");

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLServerTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLServerTemplates.java
@@ -151,7 +151,7 @@ public class SQLServerTemplates extends SQLTemplates {
         // truncates timestamps by replacing suffix
         add(Ops.DateTimeOps.TRUNC_YEAR,   "CONVERT(DATETIME, CONVERT(VARCHAR(4), {0}, 120) + '-01-01')");
         add(Ops.DateTimeOps.TRUNC_MONTH,  "CONVERT(DATETIME, CONVERT(VARCHAR(7), {0}, 120) + '-01')");
-        add(Ops.DateTimeOps.TRUNC_WEEK, "cast(floor(cast(dateadd(dd, 2 - datepart(dw, {0}), {0}) as float)) as datetime");
+        add(Ops.DateTimeOps.TRUNC_WEEK, "DATEADD(WEEK, DATEDIFF(WEEK, 0, {0} - 1), 0)");
         add(Ops.DateTimeOps.TRUNC_DAY,    "CONVERT(DATETIME, CONVERT(VARCHAR(10), {0}, 120))");
         add(Ops.DateTimeOps.TRUNC_HOUR,   "CONVERT(DATETIME, CONVERT(VARCHAR(13), {0}, 120) + ':00:00')");
         add(Ops.DateTimeOps.TRUNC_MINUTE, "CONVERT(DATETIME, CONVERT(VARCHAR(16), {0}, 120) + ':00')");

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLServerTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLServerTemplates.java
@@ -151,7 +151,7 @@ public class SQLServerTemplates extends SQLTemplates {
         // truncates timestamps by replacing suffix
         add(Ops.DateTimeOps.TRUNC_YEAR,   "CONVERT(DATETIME, CONVERT(VARCHAR(4), {0}, 120) + '-01-01')");
         add(Ops.DateTimeOps.TRUNC_MONTH,  "CONVERT(DATETIME, CONVERT(VARCHAR(7), {0}, 120) + '-01')");
-        // TODO week
+        add(Ops.DateTimeOps.TRUNC_WEEK, "cast(floor(cast(dateadd(dd, 2 - datepart(dw, {0}), {0}) as float)) as datetime");
         add(Ops.DateTimeOps.TRUNC_DAY,    "CONVERT(DATETIME, CONVERT(VARCHAR(10), {0}, 120))");
         add(Ops.DateTimeOps.TRUNC_HOUR,   "CONVERT(DATETIME, CONVERT(VARCHAR(13), {0}, 120) + ':00:00')");
         add(Ops.DateTimeOps.TRUNC_MINUTE, "CONVERT(DATETIME, CONVERT(VARCHAR(16), {0}, 120) + ':00')");

--- a/querydsl-sql/src/test/java/com/querydsl/sql/MySQLTemplatesTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/MySQLTemplatesTest.java
@@ -16,6 +16,7 @@ package com.querydsl.sql;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.querydsl.core.types.dsl.Expressions;
 import org.junit.Test;
 
 import com.querydsl.core.types.Ops;
@@ -89,4 +90,13 @@ public class MySQLTemplatesTest extends AbstractSQLTemplatesTest {
         assertTrue(p7 < p8);
     }
 
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void truncateWeek() {
+        final SQLQuery<Comparable> expression = query.select(
+                SQLExpressions.datetrunc(DatePart.week,
+                        Expressions.dateTimeTemplate(Comparable.class, "dateExpression")));
+        assertEquals("select str_to_date(concat(date_format(dateExpression,'%Y-%u'),'-1'),'%Y-%u-%w') from dual",
+                expression.toString());
+    }
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/OracleTemplatesTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/OracleTemplatesTest.java
@@ -126,19 +126,13 @@ public class OracleTemplatesTest extends AbstractSQLTemplatesTest {
         assertTrue(p7 < p8);
     }
 
-    /**
-     * According to Oracle documentation, 'day' expression truncates to the start of the
-     * start of the week.
-     *
-     * <a href="https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions230.htm#i1002084">Link to documentation</a>
-     */
     @SuppressWarnings("rawtypes")
     @Test
     public void truncateWeek() {
         final SQLQuery<Comparable> expression = query.select(
                 SQLExpressions.datetrunc(DatePart.week,
                         Expressions.dateTimeTemplate(Comparable.class, "dateExpression")));
-        assertEquals("select trunc(dateExpression, 'day') from dual",
+        assertEquals("select trunc(dateExpression, 'iw') from dual",
                 expression.toString());
     }
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/OracleTemplatesTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/OracleTemplatesTest.java
@@ -13,15 +13,6 @@
  */
 package com.querydsl.sql;
 
-import static com.querydsl.sql.SQLExpressions.select;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
-
 import com.querydsl.core.QueryFlag;
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.ExpressionUtils;
@@ -30,6 +21,14 @@ import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.core.types.dsl.SimpleExpression;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.querydsl.sql.SQLExpressions.select;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class OracleTemplatesTest extends AbstractSQLTemplatesTest {
 
@@ -127,4 +126,19 @@ public class OracleTemplatesTest extends AbstractSQLTemplatesTest {
         assertTrue(p7 < p8);
     }
 
+    /**
+     * According to Oracle documentation, 'day' expression truncates to the start of the
+     * start of the week.
+     *
+     * <a href="https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions230.htm#i1002084">Link to documentation</a>
+     */
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void truncateWeek() {
+        final SQLQuery<Comparable> expression = query.select(
+                SQLExpressions.datetrunc(DatePart.week,
+                        Expressions.dateTimeTemplate(Comparable.class, "dateExpression")));
+        assertEquals("select trunc(dateExpression, 'day') from dual",
+                expression.toString());
+    }
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLServerTemplatesTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLServerTemplatesTest.java
@@ -79,7 +79,7 @@ public class SQLServerTemplatesTest extends AbstractSQLTemplatesTest {
         final SQLQuery<Comparable> expression = query.select(
                 SQLExpressions.datetrunc(DatePart.week,
                         Expressions.dateTimeTemplate(Comparable.class, "dateExpression")));
-        assertEquals("select cast(floor(cast(dateadd(dd, 2 - datepart(dw, dateExpression), dateExpression) as float)) as datetime",
+        assertEquals("select DATEADD(WEEK, DATEDIFF(WEEK, 0, dateExpression - 1), 0)",
                 expression.toString());
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLServerTemplatesTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLServerTemplatesTest.java
@@ -73,4 +73,14 @@ public class SQLServerTemplatesTest extends AbstractSQLTemplatesTest {
         assertEquals("myseq.nextval", new SQLSerializer(new Configuration(new SQLServerTemplates())).handle(nextval).toString());
     }
 
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void truncateWeek() {
+        final SQLQuery<Comparable> expression = query.select(
+                SQLExpressions.datetrunc(DatePart.week,
+                        Expressions.dateTimeTemplate(Comparable.class, "dateExpression")));
+        assertEquals("select cast(floor(cast(dateadd(dd, 2 - datepart(dw, dateExpression), dateExpression) as float)) as datetime",
+                expression.toString());
+    }
+
 }


### PR DESCRIPTION
QueryDSL has problems with generating expressions which truncate the date to the start of the week.
This PR fixes them for:
* MySQL
* Oracle
* SQL Server

Please see internal comments for explanation of what's wrong with current implementation.

I've added unit tests for new statements, but I haven't found a way to add a proper integration test which checks things on real DBMS and actually truncates dates. Please point me in the right direction. 