### PR TITLE
Append system default new line when generating code.

### DIFF
--- a/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/AbstractCodeWriter.java
+++ b/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/AbstractCodeWriter.java
@@ -93,7 +93,7 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>> implem
 
     @Override
     public T nl() throws IOException {
-        return append("\n");
+        return append(System.lineSeparator());
     }
 
 }

--- a/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JavaWriterTest.java
+++ b/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JavaWriterTest.java
@@ -55,7 +55,7 @@ public class JavaWriterTest {
                 textBuilder.append((char) c);
             }
         }
-        String expected = textBuilder.toString().replace("\r\n", "\n").trim();
+        String expected = textBuilder.toString().replace("\r\n", System.lineSeparator()).trim();
         String actual = text.trim();
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
Changed AbstractCodeWriter to append system default line separator when appending new lines to code generated by querydsl.

This PR fixes #2352