### PR TITLE
Backport of the automatic modules names.

### DIFF
--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -134,6 +134,19 @@
         </configuration>
       </plugin>
        -->
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.apt</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/querydsl-codegen/pom.xml
+++ b/querydsl-codegen/pom.xml
@@ -73,6 +73,13 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.codegen</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/querydsl-collections/pom.xml
+++ b/querydsl-collections/pom.xml
@@ -80,6 +80,17 @@
   <build>
     <plugins>      
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.collections</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>    

--- a/querydsl-core/pom.xml
+++ b/querydsl-core/pom.xml
@@ -123,6 +123,13 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.core</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/querydsl-hibernate-search/pom.xml
+++ b/querydsl-hibernate-search/pom.xml
@@ -124,6 +124,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.hibernate.search</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>     

--- a/querydsl-jdo/pom.xml
+++ b/querydsl-jdo/pom.xml
@@ -149,6 +149,13 @@
             </configuration>              
           </execution>            
         </executions>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.jdo</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin> 
         
       <!-- this plugin does the JDO class enhancement -->

--- a/querydsl-jpa-codegen/pom.xml
+++ b/querydsl-jpa-codegen/pom.xml
@@ -123,6 +123,17 @@
   <build>
     <plugins>     
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.jpa.codegen</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>           

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -254,7 +254,14 @@
             </goals>
           </execution>               
         </executions>
-      </plugin>            
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.jpa</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <executions>

--- a/querydsl-lucene3/pom.xml
+++ b/querydsl-lucene3/pom.xml
@@ -90,6 +90,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.lucene3</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>   

--- a/querydsl-lucene4/pom.xml
+++ b/querydsl-lucene4/pom.xml
@@ -96,6 +96,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.lucene4</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>   

--- a/querydsl-lucene5/pom.xml
+++ b/querydsl-lucene5/pom.xml
@@ -103,6 +103,17 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.lucene5</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>

--- a/querydsl-mongodb/pom.xml
+++ b/querydsl-mongodb/pom.xml
@@ -79,6 +79,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.mongodb</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>

--- a/querydsl-spatial/pom.xml
+++ b/querydsl-spatial/pom.xml
@@ -61,6 +61,13 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.spatial</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/querydsl-sql-codegen/pom.xml
+++ b/querydsl-sql-codegen/pom.xml
@@ -164,6 +164,13 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.sql.codegen</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/querydsl-sql-spatial/pom.xml
+++ b/querydsl-sql-spatial/pom.xml
@@ -228,6 +228,13 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.sql.spatial</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/querydsl-sql/pom.xml
+++ b/querydsl-sql/pom.xml
@@ -237,6 +237,13 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.querydsl.sql</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Hi. This is a back port of d651911bd592526e34f70a50778954810e88f11b into the 4.x branch. It would be really beneficial to release a 4.4.1 patch release so that QueryDSL can be used in modular world without relying on file based generated modules names. This doesn't change anything when run on the class path and doesn't add any further Java modules system capabilities to QueryDSL.

Thank you for considering this.