### PR TITLE
Use patched skip duplicate actions action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: f43nd1r/skip-duplicate-actions@master
         with:
           concurrent_skipping: 'same_content_newer'
 


### PR DESCRIPTION
I've forked and fixed the action, use my fork until https://github.com/fkirc/skip-duplicate-actions/pull/116 is merged.