### PR TITLE
Add one-arg overloads for coalesce

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
@@ -178,17 +178,44 @@ public abstract class BooleanExpression extends LiteralExpression<Boolean> imple
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    public BooleanExpression coalesce(Expression<Boolean> expr) {
+        Coalesce<Boolean> coalesce = new Coalesce<Boolean>(getType(), mixin);
+        coalesce.add(expr);
+        return coalesce.asBoolean();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public BooleanExpression coalesce(Expression<Boolean>... exprs) {
         Coalesce<Boolean> coalesce = new Coalesce<Boolean>(getType(), mixin);
         for (Expression<Boolean> expr : exprs) {
             coalesce.add(expr);
         }
+        return coalesce.asBoolean();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    public BooleanExpression coalesce(Boolean arg) {
+        Coalesce<Boolean> coalesce = new Coalesce<Boolean>(getType(), mixin);
+        coalesce.add(arg);
         return coalesce.asBoolean();
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/BooleanExpression.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
 import com.querydsl.core.types.*;
 
 /**
- * {@code BooleanExpression} represents {@code java.lang.Boolean} expressions
+ * {@code BooleanExpression} represents {@link java.lang.Boolean} expressions
  *
  * @author tiwe
  * @see java.lang.Boolean
@@ -197,10 +197,10 @@ public abstract class BooleanExpression extends LiteralExpression<Boolean> imple
      * @return coalesce
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public BooleanExpression coalesce(Expression<Boolean>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public BooleanExpression coalesce(Expression<?>... exprs) {
         Coalesce<Boolean> coalesce = new Coalesce<Boolean>(getType(), mixin);
-        for (Expression<Boolean> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return coalesce.asBoolean();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Coalesce.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/Coalesce.java
@@ -39,6 +39,11 @@ public class Coalesce<T extends Comparable> extends MutableExpressionBase<T> {
 
     private transient volatile ComparableExpression<T> value;
 
+    public Coalesce(Class<? extends T> type, Expression<T> expr) {
+        super(type);
+        add(expr);
+    }
+
     public Coalesce(Class<? extends T> type, Expression<?>... exprs) {
         super(type);
         // NOTE : type parameters for the varargs, would result in compiler warnings

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
@@ -429,10 +429,10 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
      * @return coalesce
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public ComparableExpression<T> coalesce(Expression<T>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public ComparableExpression<T> coalesce(Expression<?>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
-        for (Expression<T> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return coalesce.getValue();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpression.java
@@ -410,17 +410,44 @@ public abstract class ComparableExpression<T extends Comparable> extends Compara
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    public ComparableExpression<T> coalesce(Expression<T> expr) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(expr);
+        return coalesce.getValue();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public ComparableExpression<T> coalesce(Expression<T>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (Expression<T> expr : exprs) {
             coalesce.add(expr);
         }
+        return coalesce.getValue();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    public ComparableExpression<T> coalesce(T arg) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(arg);
         return coalesce.getValue();
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
@@ -70,10 +70,10 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
      * @param exprs additional arguments
      * @return coalesce
      */
-    @SuppressWarnings("unchecked")
-    public ComparableExpressionBase<T> coalesce(Expression<T>...exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public ComparableExpressionBase<T> coalesce(Expression<?>...exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
-        for (Expression<T> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return coalesce.getValue();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/ComparableExpressionBase.java
@@ -53,11 +53,24 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    public ComparableExpressionBase<T> coalesce(Expression<T> expr) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(expr);
+        return coalesce.getValue();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
+    @SuppressWarnings("unchecked")
     public ComparableExpressionBase<T> coalesce(Expression<T>...exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (Expression<T> expr : exprs) {
@@ -67,11 +80,24 @@ public abstract class ComparableExpressionBase<T extends Comparable> extends Sim
     }
 
     /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    public ComparableExpressionBase<T> coalesce(T arg) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(arg);
+        return coalesce.getValue();
+    }
+
+    /**
      * Create a {@code coalesce(this, args...)} expression
      *
      * @param args additional arguments
      * @return coalesce
      */
+    @SuppressWarnings("unchecked")
     public ComparableExpressionBase<T> coalesce(T... args) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (T arg : args) {

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateExpression.java
@@ -248,10 +248,10 @@ public abstract class DateExpression<T extends Comparable> extends TemporalExpre
      * @return coalesce
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public DateExpression<T> coalesce(Expression<T>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public DateExpression<T> coalesce(Expression<?>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
-        for (Expression<T> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return coalesce.asDate();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateExpression.java
@@ -229,17 +229,44 @@ public abstract class DateExpression<T extends Comparable> extends TemporalExpre
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    public DateExpression<T> coalesce(Expression<T> expr) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(expr);
+        return coalesce.asDate();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public DateExpression<T> coalesce(Expression<T>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (Expression<T> expr : exprs) {
             coalesce.add(expr);
         }
+        return coalesce.asDate();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    public DateExpression<T> coalesce(T arg) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(arg);
         return coalesce.asDate();
     }
 
@@ -250,6 +277,7 @@ public abstract class DateExpression<T extends Comparable> extends TemporalExpre
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public DateExpression<T> coalesce(T... args) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (T arg : args) {

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateTimeExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateTimeExpression.java
@@ -318,10 +318,10 @@ public abstract class DateTimeExpression<T extends Comparable> extends TemporalE
      * @return coalesce
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public DateTimeExpression<T> coalesce(Expression<T>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public DateTimeExpression<T> coalesce(Expression<?>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
-        for (Expression<T> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return coalesce.asDateTime();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateTimeExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/DateTimeExpression.java
@@ -299,17 +299,44 @@ public abstract class DateTimeExpression<T extends Comparable> extends TemporalE
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    public DateTimeExpression<T> coalesce(Expression<T> expr) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(expr);
+        return coalesce.asDateTime();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public DateTimeExpression<T> coalesce(Expression<T>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (Expression<T> expr : exprs) {
             coalesce.add(expr);
         }
+        return coalesce.asDateTime();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    public DateTimeExpression<T> coalesce(T arg) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(arg);
         return coalesce.asDateTime();
     }
 
@@ -320,6 +347,7 @@ public abstract class DateTimeExpression<T extends Comparable> extends TemporalE
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public DateTimeExpression<T> coalesce(T... args) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (T arg : args) {

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EnumExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EnumExpression.java
@@ -81,17 +81,46 @@ public abstract class EnumExpression<T extends Enum<T>> extends LiteralExpressio
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public EnumExpression<T> coalesce(Expression<T> expr) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(expr);
+        return (EnumExpression<T>) coalesce.asEnum();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
     @Override
+    @SuppressWarnings({"unchecked"})
     public EnumExpression<T> coalesce(Expression<T>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (Expression<T> expr : exprs) {
             coalesce.add(expr);
         }
+        return (EnumExpression<T>) coalesce.asEnum();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public EnumExpression<T> coalesce(T arg) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(arg);
         return (EnumExpression<T>) coalesce.asEnum();
     }
 
@@ -102,6 +131,7 @@ public abstract class EnumExpression<T extends Enum<T>> extends LiteralExpressio
      * @return coalesce
      */
     @Override
+    @SuppressWarnings({"unchecked"})
     public EnumExpression<T> coalesce(T... args) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (T arg : args) {

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EnumExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/EnumExpression.java
@@ -101,10 +101,10 @@ public abstract class EnumExpression<T extends Enum<T>> extends LiteralExpressio
      * @return coalesce
      */
     @Override
-    @SuppressWarnings({"unchecked"})
-    public EnumExpression<T> coalesce(Expression<T>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public EnumExpression<T> coalesce(Expression<?>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
-        for (Expression<T> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return (EnumExpression<T>) coalesce.asEnum();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -825,10 +825,10 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
      * @return coalesce
      */
     @Override
-    @SuppressWarnings({"unchecked"})
-    public NumberExpression<T> coalesce(Expression<T>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public NumberExpression<T> coalesce(Expression<?>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
-        for (Expression<T> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return (NumberExpression<T>) coalesce.asNumber();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -805,6 +805,20 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public NumberExpression<T> coalesce(Expression<T> expr) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(expr);
+        return (NumberExpression<T>) coalesce.asNumber();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
@@ -817,6 +831,20 @@ public abstract class NumberExpression<T extends Number & Comparable<?>> extends
         for (Expression<T> expr : exprs) {
             coalesce.add(expr);
         }
+        return (NumberExpression<T>) coalesce.asNumber();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public NumberExpression<T> coalesce(T arg) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(arg);
         return (NumberExpression<T>) coalesce.asNumber();
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
@@ -864,17 +864,44 @@ public abstract class StringExpression extends LiteralExpression<String> {
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    public StringExpression coalesce(Expression<String> expr) {
+        Coalesce<String> coalesce = new Coalesce<String>(getType(), mixin);
+        coalesce.add(expr);
+        return coalesce.asString();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public StringExpression coalesce(Expression<String>... exprs) {
         Coalesce<String> coalesce = new Coalesce<String>(getType(), mixin);
         for (Expression<String> expr : exprs) {
             coalesce.add(expr);
         }
+        return coalesce.asString();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    public StringExpression coalesce(String arg) {
+        Coalesce<String> coalesce = new Coalesce<String>(getType(), mixin);
+        coalesce.add(arg);
         return coalesce.asString();
     }
 

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
@@ -883,10 +883,10 @@ public abstract class StringExpression extends LiteralExpression<String> {
      * @return coalesce
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public StringExpression coalesce(Expression<String>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public StringExpression coalesce(Expression<?>... exprs) {
         Coalesce<String> coalesce = new Coalesce<String>(getType(), mixin);
-        for (Expression<String> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return coalesce.asString();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TimeExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TimeExpression.java
@@ -164,10 +164,10 @@ public abstract class TimeExpression<T extends Comparable> extends TemporalExpre
      * @return coalesce
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public TimeExpression<T> coalesce(Expression<T>... exprs) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public TimeExpression<T> coalesce(Expression<?>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
-        for (Expression<T> expr : exprs) {
+        for (Expression expr : exprs) {
             coalesce.add(expr);
         }
         return coalesce.asTime();

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TimeExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/TimeExpression.java
@@ -145,17 +145,44 @@ public abstract class TimeExpression<T extends Comparable> extends TemporalExpre
     }
 
     /**
+     * Create a {@code coalesce(this, expr)} expression
+     *
+     * @param expr additional argument
+     * @return coalesce
+     */
+    @Override
+    public TimeExpression<T> coalesce(Expression<T> expr) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(expr);
+        return coalesce.asTime();
+    }
+
+    /**
      * Create a {@code coalesce(this, exprs...)} expression
      *
      * @param exprs additional arguments
      * @return coalesce
      */
     @Override
+    @SuppressWarnings("unchecked")
     public TimeExpression<T> coalesce(Expression<T>... exprs) {
         Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
         for (Expression<T> expr : exprs) {
             coalesce.add(expr);
         }
+        return coalesce.asTime();
+    }
+
+    /**
+     * Create a {@code coalesce(this, arg)} expression
+     *
+     * @param arg additional argument
+     * @return coalesce
+     */
+    @Override
+    public TimeExpression<T> coalesce(T arg) {
+        Coalesce<T> coalesce = new Coalesce<T>(getType(), mixin);
+        coalesce.add(arg);
         return coalesce.asTime();
     }
 


### PR DESCRIPTION
Related discussion: https://querydsl.slack.com/archives/C06KLG1BP/p1623048740053800?thread_ts=1622940119.038500&cid=C06KLG1BP

This has two advantages:
 - no "generic array creation" warnings for users with only one arg
 - no implicit array creation in this case, improving performance