### PR TITLE
Dokka for Kotlin modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,9 @@
     <morphia.version>1.3.2</morphia.version>
     <jmh.version>1.32</jmh.version>
     <hamcrest.veresion>2.2</hamcrest.veresion>
-    
+    <kotlin.version>1.5.10</kotlin.version>
+    <dokka.version>1.4.32</dokka.version>
+
     <!-- Import-Package definitions for maven-bundle-plugin -->
     <osgi.import.package.root>
       *
@@ -202,6 +204,18 @@
         <artifactId>geolatte-geom</artifactId>
         <version>1.8.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-bom</artifactId>
+        <version>${kotlin.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-scripting-jsr223</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -332,6 +346,27 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.jetbrains.dokka</groupId>
+          <artifactId>dokka-maven-plugin</artifactId>
+          <version>${dokka.version}</version>
+          <executions>
+            <execution>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>javadocJar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-maven-plugin</artifactId>
+          <version>${kotlin.version}</version>
+          <configuration>
+            <jvmTarget>1.8</jvmTarget>
+          </configuration>
         </plugin>
       </plugins>      
     </pluginManagement>

--- a/querydsl-kotlin-codegen/pom.xml
+++ b/querydsl-kotlin-codegen/pom.xml
@@ -13,26 +13,8 @@
     <name>Querydsl - Kotlin codegen support</name>
 
     <properties>
-        <kotlin.version>1.5.10</kotlin.version>
         <surefire.useManifestOnlyJar>false</surefire.useManifestOnlyJar>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>${kotlin.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-scripting-jsr223</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -90,7 +72,6 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -105,9 +86,10 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <jvmTarget>1.8</jvmTarget>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/querydsl-kotlin/pom.xml
+++ b/querydsl-kotlin/pom.xml
@@ -12,10 +12,6 @@
     <artifactId>querydsl-kotlin</artifactId>
     <name>Querydsl - Kotlin extensions</name>
 
-    <properties>
-        <kotlin.version>1.5.10</kotlin.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.querydsl</groupId>
@@ -32,12 +28,10 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit</artifactId>
-            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -63,7 +57,6 @@
                             <classifier>general</classifier>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
-                    <jvmTarget>1.8</jvmTarget>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -130,6 +123,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Dokka is the Kotlin equivalent of javadoc. It generates `*-javadoc.jar`s for maven central.

Also moved the kotlin version definition up to root, differing versions in the two modules don't make too much sense.