### PR TITLE
added flatten plugin to remove parent from generated pom.xml in bom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ derby.log
 /devops/*.rpm.zip
 /devops/**/*.semaphore
 /devops/test-connection/.lein-repl-history
+**/.flattened-pom.xml

--- a/querydsl-bom/pom.xml
+++ b/querydsl-bom/pom.xml
@@ -54,6 +54,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>querydsl-guava</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>querydsl-sql</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -85,6 +90,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>querydsl-jdo</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>querydsl-kotlin-codegen</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/querydsl-bom/pom.xml
+++ b/querydsl-bom/pom.xml
@@ -144,6 +144,7 @@
                             <pomElements>
                                 <properties>keep</properties>
                                 <repositories>remove</repositories>
+                                <dependencies>remove</dependencies>
                             </pomElements>
                         </configuration>
                     </execution>

--- a/querydsl-bom/pom.xml
+++ b/querydsl-bom/pom.xml
@@ -142,7 +142,7 @@
                             <updatePomFile>true</updatePomFile>
                             <flattenMode>bom</flattenMode>
                             <pomElements>
-                                <properties>keep</properties>
+                                <properties>remove</properties>
                                 <repositories>remove</repositories>
                                 <dependencies>remove</dependencies>
                             </pomElements>

--- a/querydsl-bom/pom.xml
+++ b/querydsl-bom/pom.xml
@@ -16,6 +16,10 @@
     <url>${project.homepage}</url>
     <packaging>pom</packaging>
 
+    <properties>
+        <flatten-maven-plugin.version>1.2.7</flatten-maven-plugin.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -120,4 +124,38 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>bom</flattenMode>
+                            <pomElements>
+                                <properties>keep</properties>
+                                <repositories>remove</repositories>
+                            </pomElements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Flattening bom in order to prevent issues like https://github.com/querydsl/querydsl/issues/2921 or that is - to have a clear and simple bom.