### PR TITLE
Use maven-compiler-plugin for annotation processing

### DIFF
--- a/querydsl-jpa/README.md
+++ b/querydsl-jpa/README.md
@@ -22,27 +22,34 @@ And now, configure the Maven APT plugin :
     <plugins>
       ...
       <plugin>
-        <groupId>com.mysema.maven</groupId>
-        <artifactId>apt-maven-plugin</artifactId>
-        <version>1.1.3</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>target/generated-sources/java</outputDirectory>
-              <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.querydsl</groupId>
-            <artifactId>querydsl-apt</artifactId>
-            <version>${querydsl.version}</version>
-          </dependency>
-        </dependencies>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+            <annotationProcessors>
+                <annotationProcessor>com.querydsl.apt.jpa.JPAAnnotationProcessor</annotationProcessor>
+            </annotationProcessors>
+            <annotationProcessorPaths>
+                <path>
+                    <groupId>com.querydsl</groupId>
+                    <artifactId>querydsl-apt</artifactId>
+                    <version>${querydsl.version}</version>
+                    <classifier>jpa</classifier>
+                </path>
+                <path>
+                    <groupId>jakarta.persistence</groupId>
+                    <artifactId>jakarta.persistence-api</artifactId>
+                    <version>2.2.3</version>
+                </path>
+                <!-- Only necessary when using JDK 11+ -->
+                <path>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                    <version>1.3.5</version>
+                </path>
+            </annotationProcessorPaths>
+        </configuration>
+        ...
       </plugin>
       ...
     </plugins>

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -223,7 +223,7 @@
   </dependencies>
   
   <build>
-    <plugins> 
+    <plugins>
     
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -348,22 +348,34 @@
       </plugin>
                
       <plugin>
-        <groupId>com.mysema.maven</groupId>
-        <artifactId>apt-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-process</goal>
-              <goal>add-test-sources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>target/generated-test-sources/java</outputDirectory>
-              <processor>com.querydsl.apt.hibernate.HibernateAnnotationProcessor</processor>
-              <logOnlyOnError>true</logOnlyOnError>
-            </configuration>            
-          </execution>
-        </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessors>
+            <annotationProcessor>com.querydsl.apt.jpa.JPAAnnotationProcessor</annotationProcessor>
+          </annotationProcessors>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.querydsl</groupId>
+              <artifactId>querydsl-apt</artifactId>
+              <version>${querydsl.version}</version>
+              <classifier>jpa</classifier>
+            </path>
+            <path>
+              <groupId>jakarta.persistence</groupId>
+              <artifactId>jakarta.persistence-api</artifactId>
+              <version>2.2.3</version>
+            </path>
+            <!-- Only necessary when using JDK 11+ -->
+            <path>
+              <groupId>jakarta.annotation</groupId>
+              <artifactId>jakarta.annotation-api</artifactId>
+              <version>1.3.5</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
+
       <plugin>
         <groupId>com.querydsl</groupId>
         <artifactId>querydsl-maven-plugin</artifactId>


### PR DESCRIPTION
...instead of the unsupported apt-maven-plugin.

The main advantage of this change is that Intelij IDEA would automatically pick up the annotation processor and run it when building inside IDE. Thus eliminating the need to manually run `mvn generate-sources` or `mvn compile` to get the generated classes every time after changing the branch. maven-compiler-plugin also properly cleans up the generated sources whenever a model is removed, unlike the apt-maven-plugin, where user has to manually go and remove the no-longer-needed Q-class from the build folder as otherwise compilation will fail.

Closes #2091

Creating the PR as a draft just to demonstrate the idea and get feedback. If you think that this is the right approach, I can extend it to all querydsl modules and update documentation.