### PR TITLE
Maven profile introduced in order to be able to switch off jpa integration tests against certain databases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.8.115</version>
+        <version>4.8.116</version>
         <exclusions>
           <exclusion>
             <groupId>org.javassist</groupId>

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -313,7 +313,7 @@
         <configuration>
           <includes>
             <include>**/*Test.java</include>
-          </includes> 
+          </includes>
           <systemProperties>
             <property>
                 <name>derby.stream.error.file</name>
@@ -322,6 +322,22 @@
             <property>
                 <name>org.jboss.logging.provider</name>
                 <value>slf4j</value>
+            </property>
+            <property>
+              <name>querydsl-enable-jpa-postgresql-test</name>
+              <value>${querydsl-enable-jpa-postgresql-test.value}</value>
+            </property>
+            <property>
+              <name>querydsl-enable-jpa-oracle-test</name>
+              <value>${querydsl-enable-jpa-oracle-test.value}</value>
+            </property>
+            <property>
+              <name>querydsl-enable-jpa-mysql-test</name>
+              <value>${querydsl-enable-jpa-mysql-test.value}</value>
+            </property>
+            <property>
+              <name>querydsl-enable-jpa-mssql-test</name>
+              <value>${querydsl-enable-jpa-mssql-test.value}</value>
             </property>
           </systemProperties>
         </configuration>
@@ -405,6 +421,30 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>enable-jpa-postgresql-test</id>
+      <properties>
+        <querydsl-enable-jpa-postgresql-test.value>true</querydsl-enable-jpa-postgresql-test.value>
+      </properties>
+    </profile>
+    <profile>
+      <id>enable-jpa-oracle-test</id>
+      <properties>
+        <querydsl-enable-jpa-oracle-test.value>true</querydsl-enable-jpa-oracle-test.value>
+      </properties>
+    </profile>
+    <profile>
+      <id>enable-jpa-mysql-test</id>
+      <properties>
+        <querydsl-enable-jpa-mysql-test.value>true</querydsl-enable-jpa-mysql-test.value>
+      </properties>
+    </profile>
+    <profile>
+      <id>enable-jpa-mssql-test</id>
+      <properties>
+        <querydsl-enable-jpa-mssql-test.value>true</querydsl-enable-jpa-mssql-test.value>
+      </properties>
+    </profile>
     <profile>
       <id>java-11</id>
       <activation>

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MSSQLSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MSSQLSuiteTest.java
@@ -7,6 +7,8 @@ import com.querydsl.core.Target;
 import com.querydsl.core.testutil.SQLServer;
 import com.querydsl.jpa.*;
 
+import static org.junit.Assume.assumeTrue;
+
 @Category(SQLServer.class)
 public class MSSQLSuiteTest extends AbstractSuite {
 
@@ -19,6 +21,8 @@ public class MSSQLSuiteTest extends AbstractSuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        assumeTrue("MSSQLSuiteTest is disabled (Maven Profile 'enable-jpa-mssql-test' is not enabled)",
+                "true".equalsIgnoreCase(System.getProperty("querydsl-enable-jpa-mssql-test", "false")));
         Mode.mode.set("mssql");
         Mode.target.set(Target.SQLSERVER);
     }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLEclipseLinkTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLEclipseLinkTest.java
@@ -7,6 +7,8 @@ import com.querydsl.core.Target;
 import com.querydsl.core.testutil.MySQL;
 import com.querydsl.jpa.*;
 
+import static org.junit.Assume.assumeTrue;
+
 @Category(MySQL.class)
 public class MySQLEclipseLinkTest extends AbstractJPASuite {
 
@@ -51,6 +53,8 @@ public class MySQLEclipseLinkTest extends AbstractJPASuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        assumeTrue("MySQLEclipseLinkTest is disabled (Maven Profile 'enable-jpa-mysql-test' is not enabled)",
+                "true".equalsIgnoreCase(System.getProperty("querydsl-enable-jpa-mysql-test", "false")));
         Mode.mode.set("mysql-eclipselink");
         Mode.target.set(Target.MYSQL);
     }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/MySQLSuiteTest.java
@@ -7,6 +7,8 @@ import com.querydsl.core.Target;
 import com.querydsl.core.testutil.MySQL;
 import com.querydsl.jpa.*;
 
+import static org.junit.Assume.assumeTrue;
+
 @Category(MySQL.class)
 public class MySQLSuiteTest extends AbstractSuite {
 
@@ -29,6 +31,8 @@ public class MySQLSuiteTest extends AbstractSuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        assumeTrue("MySQLSuiteTest is disabled (Maven Profile 'enable-jpa-mysql-test' is not enabled)",
+                "true".equalsIgnoreCase(System.getProperty("querydsl-enable-jpa-mysql-test", "false")));
         Mode.mode.set("mysql");
         Mode.target.set(Target.MYSQL);
     }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/OracleSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/OracleSuiteTest.java
@@ -7,6 +7,8 @@ import com.querydsl.core.Target;
 import com.querydsl.core.testutil.Oracle;
 import com.querydsl.jpa.*;
 
+import static org.junit.Assume.assumeTrue;
+
 @Category(Oracle.class)
 public class OracleSuiteTest extends AbstractSuite {
 
@@ -19,6 +21,8 @@ public class OracleSuiteTest extends AbstractSuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        assumeTrue("OracleSuiteTest is disabled (Maven Profile 'enable-jpa-oracle-test' is not enabled)",
+                "true".equalsIgnoreCase(System.getProperty("querydsl-enable-jpa-oracle-test", "false")));
         Mode.mode.set("oracle");
         Mode.target.set(Target.ORACLE);
     }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLEclipseLinkSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLEclipseLinkSuiteTest.java
@@ -7,6 +7,8 @@ import com.querydsl.core.Target;
 import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.jpa.*;
 
+import static org.junit.Assume.assumeTrue;
+
 @Category(PostgreSQL.class)
 public class PostgreSQLEclipseLinkSuiteTest extends AbstractJPASuite {
 
@@ -17,6 +19,8 @@ public class PostgreSQLEclipseLinkSuiteTest extends AbstractJPASuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        assumeTrue("PostgreSQLEclipseLinkSuiteTest is disabled (Maven Profile 'enable-jpa-postgresql-test' is not enabled)",
+                "true".equalsIgnoreCase(System.getProperty("querydsl-enable-jpa-postgresql-test", "false")));
         Mode.mode.set("postgresql-eclipselink");
         Mode.target.set(Target.POSTGRESQL);
     }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLSuiteTest.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/suites/PostgreSQLSuiteTest.java
@@ -7,6 +7,8 @@ import com.querydsl.core.Target;
 import com.querydsl.core.testutil.PostgreSQL;
 import com.querydsl.jpa.*;
 
+import static org.junit.Assume.assumeTrue;
+
 @Category(PostgreSQL.class)
 public class PostgreSQLSuiteTest extends AbstractSuite {
 
@@ -19,6 +21,8 @@ public class PostgreSQLSuiteTest extends AbstractSuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        assumeTrue("PostgreSQLSuiteTest is disabled (Maven Profile 'enable-jpa-postgresql-test' is not enabled)",
+                "true".equalsIgnoreCase(System.getProperty("querydsl-enable-jpa-postgresql-test", "false")));
         Mode.mode.set("postgresql");
         Mode.target.set(Target.POSTGRESQL);
     }


### PR DESCRIPTION
Since not every contributor has installed all databases for which there are integration tests in the JPA module, it should be possible to switch the integration tests of certain databases on or off if necessary.

This pull request enables integration tests of certain databases to be switched on or off.