### PR TITLE
Removal of java < 8 compatibility code

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/JavaTypeMapping.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/JavaTypeMapping.java
@@ -60,6 +60,13 @@ class JavaTypeMapping {
         registerDefault(new URLType());
         registerDefault(new UtilDateType());
         registerDefault(new UtilUUIDType(false));
+        registerDefault(new JSR310InstantType());
+        registerDefault(new JSR310LocalDateTimeType());
+        registerDefault(new JSR310LocalDateType());
+        registerDefault(new JSR310LocalTimeType());
+        registerDefault(new JSR310OffsetDateTimeType());
+        registerDefault(new JSR310OffsetTimeType());
+        registerDefault(new JSR310ZonedDateTimeType());
 
         // initialize Joda-Time converters only if Joda-Time is available
         try {
@@ -73,22 +80,6 @@ class JavaTypeMapping {
         } catch (InstantiationException e) {
             throw new RuntimeException(e);
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-
-        // initialize java time api (JSR 310) converters only if java 8 is available
-        try {
-            Class.forName("java.time.Instant");
-            registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310InstantType").newInstance());
-            registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310LocalDateTimeType").newInstance());
-            registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310LocalDateType").newInstance());
-            registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310LocalTimeType").newInstance());
-            registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310OffsetDateTimeType").newInstance());
-            registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310OffsetTimeType").newInstance());
-            registerDefault((Type<?>) Class.forName("com.querydsl.sql.types.JSR310ZonedDateTimeType").newInstance());
-        } catch (ClassNotFoundException e) {
-            // converters for JSR 310 are not loaded
-        } catch (InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Java 8 minimal requirement for QueryDSL 5