### PR TITLE
Fixing issue 2223

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/WindowRows.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/WindowRows.java
@@ -58,8 +58,8 @@ public class WindowRows<A> {
 
         public BetweenAnd preceding(Expression<Integer> expr) {
             args.add(expr);
-            str.append(PRECEDING);
             str.append(" {").append(offset++).append("}");
+            str.append(PRECEDING);
             return new BetweenAnd();
         }
 
@@ -69,8 +69,8 @@ public class WindowRows<A> {
 
         public BetweenAnd following(Expression<Integer> expr) {
             args.add(expr);
-            str.append(FOLLOWING);
             str.append(" {").append(offset++).append("}");
+            str.append(FOLLOWING);
             return new BetweenAnd();
         }
 
@@ -112,8 +112,8 @@ public class WindowRows<A> {
 
         public WindowFunction<A> following(Expression<Integer> expr) {
             args.add(expr);
-            str.append(FOLLOWING);
             str.append(" {").append(offset++).append("}");
+            str.append(FOLLOWING);
             return rv.withRowsOrRange(str.toString(), args);
         }
 
@@ -154,8 +154,8 @@ public class WindowRows<A> {
 
     public WindowFunction<A> preceding(Expression<Integer> expr) {
         args.add(expr);
-        str.append(PRECEDING);
         str.append(" {").append(offset++).append("}");
+        str.append(PRECEDING);
         return rv.withRowsOrRange(str.toString(), args);
     }
 

--- a/querydsl-sql/src/test/java/com/querydsl/sql/WindowFunctionTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/WindowFunctionTest.java
@@ -90,9 +90,9 @@ public class WindowFunctionTest {
 
         assertEquals("sum(path) over (order by path asc rows between current row and unbounded following)",
                 toString(wf.rows().between().currentRow().unboundedFollowing()));
-        assertEquals("sum(path) over (order by path asc rows between preceding intPath and following intPath)",
+        assertEquals("sum(path) over (order by path asc rows between intPath preceding and intPath following)",
                 toString(wf.rows().between().preceding(intPath).following(intPath)));
-        assertEquals("sum(path) over (order by path asc rows between preceding ? and following ?)",
+        assertEquals("sum(path) over (order by path asc rows between ? preceding and ? following)",
                 toString(wf.rows().between().preceding(1).following(3)));
     }
 
@@ -120,9 +120,9 @@ public class WindowFunctionTest {
         NumberPath<Integer> intPath = Expressions.numberPath(Integer.class, "intPath");
         WindowFunction<Long> wf = SQLExpressions.sum(path).over().orderBy(path);
 
-        assertEquals("sum(path) over (order by path asc rows preceding intPath)",
+        assertEquals("sum(path) over (order by path asc rows intPath preceding)",
                 toString(wf.rows().preceding(intPath)));
-        assertEquals("sum(path) over (order by path asc rows preceding ?)",
+        assertEquals("sum(path) over (order by path asc rows ? preceding)",
                 toString(wf.rows().preceding(3)));
     }
 


### PR DESCRIPTION
Updated tests to match desired sql syntax for preceding and following
Updated WindowRows to produce the proper syntax for preceding and
following

NOTE: I looked up several documents on the expected sql syntax for preceding and following, and all of them had the integers prior to the keyword.

Here is an example: https://www.sqlite.org/windowfunctions.html


