### PR TITLE
Fixes "parameter 'catalogPattern' is not set for querydsl-maven-plugin

### DIFF
--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractMetaDataExportMojo.java
@@ -142,6 +142,7 @@ public class AbstractMetaDataExportMojo extends AbstractMojo {
      *      is stored in the database; "" retrieves those without a catalog;
      *      <code>null</code> means that the catalog name should not be used to narrow
      *      the search
+     * @parameter
      */
     private String catalogPattern;
 


### PR DESCRIPTION
Fixes "parameter 'catalogPattern' is not set for querydsl-maven-plugin" (#3174)