### PR TITLE
Fixes #3212 (implement a code template for the @Generated annotation)

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/DefaultConfiguration.java
@@ -282,8 +282,8 @@ public class DefaultConfiguration implements Configuration {
 
         module.loadExtensions();
 
-        Class<? extends Annotation> generatedAnnotationClass = GeneratedAnnotationResolver.resolve(options.get(QUERYDSL_GENERATED_ANNOTATION_CLASS));
-        module.bindInstance(CodegenModule.GENERATED_ANNOTATION_CLASS, generatedAnnotationClass);
+        GeneratedAnnotationClass generatedAnnotationClass = GeneratedAnnotationResolver.resolve(options.get(QUERYDSL_GENERATED_ANNOTATION_CLASS));
+        module.bind(CodegenModule.GENERATED_ANNOTATION_CLASS, generatedAnnotationClass);
 
         defaultSerializerConfig = new SimpleSerializerConfig(entityAccessors, listAccessors,
                 mapAccessors, createDefaultVariable, "");

--- a/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/CodeWriter.java
+++ b/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/CodeWriter.java
@@ -67,6 +67,8 @@ public interface CodeWriter extends Appendable {
 
     CodeWriter imports(Class<?>... imports) throws IOException;
 
+    CodeWriter imports(String... classNames) throws IOException;
+
     CodeWriter imports(Package... imports) throws IOException;
 
     CodeWriter importClasses(String... classes) throws IOException;

--- a/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/JavaWriter.java
+++ b/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/JavaWriter.java
@@ -323,6 +323,16 @@ public final class JavaWriter extends AbstractCodeWriter<JavaWriter> {
     }
 
     @Override
+    public JavaWriter imports(String... classNames) throws IOException {
+        for (String className : classNames) {
+            classes.add(className);
+            line(IMPORT, className, Symbols.SEMICOLON);
+        }
+        nl();
+        return this;
+    }
+
+    @Override
     public JavaWriter imports(Package... imports) throws IOException {
         for (Package p : imports) {
             packages.add(p.getName());

--- a/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ScalaWriter.java
+++ b/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ScalaWriter.java
@@ -441,6 +441,16 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
     }
 
     @Override
+    public ScalaWriter imports(String... classNames) throws IOException {
+        for (String className : classNames) {
+            classes.add(className);
+            line(IMPORT, className);
+        }
+        nl();
+        return this;
+    }
+
+    @Override
     public ScalaWriter imports(Package... imports) throws IOException {
         for (Package p : imports) {
             packages.add(p.getName());

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/BeanSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/BeanSerializer.java
@@ -13,6 +13,7 @@
  */
 package com.querydsl.codegen;
 
+import com.querydsl.codegen.GeneratedAnnotationClass.Context;
 import com.querydsl.codegen.utils.CodeWriter;
 import com.querydsl.codegen.utils.model.ClassType;
 import com.querydsl.codegen.utils.model.Parameter;
@@ -52,7 +53,7 @@ public class BeanSerializer implements Serializer {
             return new Parameter(input.getName(), input.getType());
         }
     };
-    private final Class<? extends Annotation> generatedAnnotationClass;
+    private final GeneratedAnnotationClass generatedAnnotationClass;
 
     private final boolean propertyAnnotations;
 
@@ -90,7 +91,7 @@ public class BeanSerializer implements Serializer {
     @Inject
     public BeanSerializer(
             @Named(CodegenModule.JAVADOC_SUFFIX) String javadocSuffix,
-            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS) Class<? extends Annotation> generatedAnnotationClass) {
+            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS) GeneratedAnnotationClass generatedAnnotationClass) {
         this(DEFAULT_PROPERTY_ANNOTATIONS, javadocSuffix, generatedAnnotationClass);
     }
 
@@ -121,7 +122,7 @@ public class BeanSerializer implements Serializer {
      * @param generatedAnnotationClass the fully qualified class name of the <em>Single-Element Annotation</em> (with {@code String} element) to be used on the generated classes.
      *      * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7.3">Single-Element Annotation</a>
      */
-    public BeanSerializer(boolean propertyAnnotations, String javadocSuffix, Class<? extends Annotation> generatedAnnotationClass) {
+    public BeanSerializer(boolean propertyAnnotations, String javadocSuffix, GeneratedAnnotationClass generatedAnnotationClass) {
         this.propertyAnnotations = propertyAnnotations;
         this.javadocSuffix = javadocSuffix;
         this.generatedAnnotationClass = generatedAnnotationClass;
@@ -169,7 +170,7 @@ public class BeanSerializer implements Serializer {
             writer.annotation(annotation);
         }
 
-        writer.line("@", generatedAnnotationClass.getSimpleName(), "(\"", getClass().getName(), "\")");
+        writer.line("@", generatedAnnotationClass.buildAnnotation(Context.of(getClass().getName())));
 
         if (!interfaces.isEmpty()) {
             Type superType = null;

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/CodegenModule.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/CodegenModule.java
@@ -80,7 +80,7 @@ public class CodegenModule  extends AbstractModule {
         bind(KEYWORDS, Collections.<String>emptySet());
         bind(IMPORTS, Collections.<String>emptySet());
         bind(VARIABLE_NAME_FUNCTION_CLASS, DefaultVariableNameFunction.INSTANCE);
-        bindInstance(GENERATED_ANNOTATION_CLASS, GeneratedAnnotationResolver.resolveDefault());
+        bind(GENERATED_ANNOTATION_CLASS, GeneratedAnnotationResolver.resolveDefault());
         bind(JAVADOC_SUFFIX, DEFAULT_JAVADOC_SUFFIX);
     }
 

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultEmbeddableSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultEmbeddableSerializer.java
@@ -50,7 +50,7 @@ public final class DefaultEmbeddableSerializer extends DefaultEntitySerializer i
     public DefaultEmbeddableSerializer(
             TypeMappings typeMappings,
             @Named(CodegenModule.KEYWORDS) Collection<String> keywords,
-            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS) Class<? extends Annotation> generatedAnnotationClass) {
+            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS) GeneratedAnnotationClass generatedAnnotationClass) {
         super(typeMappings, keywords, generatedAnnotationClass);
     }
 
@@ -93,7 +93,7 @@ public final class DefaultEmbeddableSerializer extends DefaultEntitySerializer i
             writer.annotation(annotation);
         }
 
-        writer.line("@", generatedAnnotationClass.getSimpleName(), "(\"", getClass().getName(), "\")");
+        writer.line("@", generatedAnnotationClass.buildAnnotation(GeneratedAnnotationClass.Context.of(getClass().getName())));
 
         if (category == TypeCategory.BOOLEAN || category == TypeCategory.STRING) {
             writer.beginClass(queryType, new ClassType(pathType));

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultProjectionSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultProjectionSerializer.java
@@ -16,7 +16,6 @@ package com.querydsl.codegen;
 import java.io.IOException;
 
 import java.util.HashSet;
-import java.lang.annotation.Annotation;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -37,7 +36,7 @@ import com.querydsl.core.types.dsl.NumberExpression;
  */
 public final class DefaultProjectionSerializer implements ProjectionSerializer {
 
-    private final Class<? extends Annotation> generatedAnnotationClass;
+    private final GeneratedAnnotationClass generatedAnnotationClass;
     private final TypeMappings typeMappings;
 
     /**
@@ -59,7 +58,7 @@ public final class DefaultProjectionSerializer implements ProjectionSerializer {
     @Inject
     public DefaultProjectionSerializer(
             TypeMappings typeMappings,
-            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS) Class<? extends Annotation> generatedAnnotationClass) {
+            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS)GeneratedAnnotationClass generatedAnnotationClass) {
         this.typeMappings = typeMappings;
         this.generatedAnnotationClass = generatedAnnotationClass;
     }
@@ -75,7 +74,8 @@ public final class DefaultProjectionSerializer implements ProjectionSerializer {
 
         // imports
         writer.imports(NumberExpression.class.getPackage());
-        writer.imports(ConstructorExpression.class, generatedAnnotationClass);
+        writer.imports(ConstructorExpression.class);
+        writer.imports(generatedAnnotationClass.getName());
 
         Set<Integer> sizes = new HashSet<>();
         for (Constructor c : model.getConstructors()) {
@@ -88,7 +88,7 @@ public final class DefaultProjectionSerializer implements ProjectionSerializer {
         // javadoc
         writer.javadoc(queryType + " is a Querydsl Projection type for " + simpleName);
 
-        writer.line("@", generatedAnnotationClass.getSimpleName(), "(\"", getClass().getName(), "\")");
+        writer.line("@", generatedAnnotationClass.buildAnnotation(GeneratedAnnotationClass.Context.of(getClass().getName())));
 
         // class header
 //        writer.suppressWarnings("serial");

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultSupertypeSerializer.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultSupertypeSerializer.java
@@ -13,7 +13,6 @@
  */
 package com.querydsl.codegen;
 
-import java.lang.annotation.Annotation;
 import java.util.Collection;
 
 import javax.inject.Inject;
@@ -38,7 +37,7 @@ public final class DefaultSupertypeSerializer extends DefaultEntitySerializer im
     public DefaultSupertypeSerializer(
             TypeMappings typeMappings,
             @Named(CodegenModule.KEYWORDS) Collection<String> keywords,
-            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS) Class<? extends Annotation> generatedAnnotationClass) {
+            @Named(CodegenModule.GENERATED_ANNOTATION_CLASS) GeneratedAnnotationClass generatedAnnotationClass) {
         super(typeMappings, keywords, generatedAnnotationClass);
     }
     /**

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GeneratedAnnotationClass.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GeneratedAnnotationClass.java
@@ -1,0 +1,103 @@
+package com.querydsl.codegen;
+
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GeneratedAnnotationClass {
+
+    public static final class Context {
+        private final String generatorClassName;
+
+        private Context(String generatorClassName) {
+            this.generatorClassName = generatorClassName;
+        }
+
+        public String replacePlaceholders(String input) {
+            String next = input;
+
+            next = next.replaceAll("\\{\\{queryDSL.generator.className}}", generatorClassName);
+            next = next.replaceAll("\\{\\{queryDSL.timestamp}}", String.valueOf(new Date().getTime()));
+
+            return next;
+        }
+
+        public static Context of(String generatorClassName) {
+            return new Context(generatorClassName);
+        }
+    }
+
+
+    public static final String DEFAULT_CONSTRUCTOR_ARGS = "\"{{queryDSL.generator.className}}\"";
+
+    private static final Pattern JAVA_CLASS_NAME_PATTERN = Pattern.compile(
+            "^((\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)(\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*?)\\.(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)\\s*(\\((.*)\\))?"
+    );
+
+    private final String template;
+    private final String packageName;
+    private final String simpleClassName;
+    private final String fullyQualifiedClassName;
+    private final String constructorArgs;
+
+    public GeneratedAnnotationClass(String template) {
+        this.template = template;
+
+        Matcher matcher = parseClassNameFrom(template);
+        this.packageName = matcher.group(1);
+        this.simpleClassName = matcher.group(4);
+        this.fullyQualifiedClassName = this.packageName + "." + this.simpleClassName;
+        this.constructorArgs = matcher.group(6) != null
+                ? matcher.group(6)
+                : DEFAULT_CONSTRUCTOR_ARGS;
+    }
+
+    private Matcher parseClassNameFrom(String template) {
+        Matcher matcher = JAVA_CLASS_NAME_PATTERN.matcher(template);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Cannot parse template: " + template);
+        }
+        return matcher;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public String getSimpleName() {
+        return simpleClassName;
+    }
+
+    public String getName() {
+        return fullyQualifiedClassName;
+    }
+
+    public String getConstructorArgs() {
+        return constructorArgs;
+    }
+
+    public String buildAnnotation(Context context) {
+        String liveTemplate = simpleClassName + buildAnnotationCtor(context);
+        return liveTemplate;
+    }
+
+    private String buildAnnotationCtor(Context context) {
+        String args = buildAnnotationArgs(context);
+
+        String result = args.isEmpty()
+                ? ""
+                : "(" + args + ")";
+
+        return result;
+    }
+
+    public String buildAnnotationArgs(Context context) {
+        String result = context.replacePlaceholders(getConstructorArgs());
+        return result;
+    }
+
+}

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GeneratedAnnotationResolver.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GeneratedAnnotationResolver.java
@@ -1,8 +1,12 @@
 package com.querydsl.codegen;
 
+import com.querydsl.core.annotations.Generated;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.util.Date;
+
+import static com.querydsl.codegen.GeneratedAnnotationClass.DEFAULT_CONSTRUCTOR_ARGS;
 
 /**
  * {@code GeneratedAnnotationClassResolver} provides class name resolving functionality for resolving the annotation
@@ -10,23 +14,42 @@ import java.lang.annotation.Annotation;
  */
 public final class GeneratedAnnotationResolver {
 
-    private static final Class<? extends Annotation> DEFAULT_GENERATED_ANNOTATION_CLASS = resolveJavaDefault();
+    private static final GeneratedAnnotationClass DEFAULT_GENERATED_ANNOTATION_CLASS = resolveJavaDefault();
 
     /**
-     * Use the {@code generatedAnnotationClass} or use the JDK one.
+     * The annotation (usually: {@code @Generated}) that will get attached to generated classes.
+     * <br>
      * <p>
-     * A {@code null generatedAnnotationClass} will resolve to the java {@code @Generated} annotation (can be of type {@code javax.annotation.Generated}
-     * or {@code javax.annotation.processing.Generated} depending on the java version.
-     *
-     * @param generatedAnnotationClass the fully qualified class name of the <em>Single-Element Annotation</em> (with {@code String} element)
-     *                                 to use or {@code null}.
-     * @return the provided {@code generatedAnnotationClass} if not {@code null} or the one from java. Never {@code null}.
-     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7.3">Single-Element Annotation</a>
+     * Defaults to <code>javax.annotation.Generated</code> or <code>javax.annotation.processing.Generated</code> depending on the java version.
+     * </p>
+     * <p>
+     * Specify one of:
+     * <ul>
+     *  <li>null (default)</li>
+     *  <li>"" (empty string, same as null)</li>
+     *  <li>The fully qualified class name of the <em>Single-Element Annotation</em> (with <code>String</code> element)</li>
+     *  <li>A code template in the form <code>fully.qualified.Annotation()</code></li>
+     *  <li>or <code>fully.qualified.Annotation("with params")</code></li>
+     *  <li>or <code>fully.qualified.Annotation(say="Hello", toWhom="World")</code>.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * </p>
+     * <p>
+     * Parameterized forms also support placeholders for parameters:
+     * <ul>
+     *     <li>"{@code {{queryDSL.generator.className}}}" - the class name of the generator</li>
+     *     <li>"{@code {{queryDSL.timestamp}}}" - A timestamp as returned by {@link Date#getTime()}.</li>
+     * </ul>
+     * Example: {@code fully.qualified.Annotation("{{queryDSL.generator.className}}")} results in e.g. {@code fully.qualified.Annotation("com.querydsl.sql.codegen.ExtendedBeanSerializer")}
+     * </p>
+     * <br>
+     * <em>See also</em> <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7.3">Single-Element Annotation</a>
      */
-    public static Class<?extends Annotation> resolve(@Nullable String generatedAnnotationClass) {
-        if (generatedAnnotationClass != null) {
+    public static GeneratedAnnotationClass resolve(@Nullable String template) {
+        if (template != null && !template.isEmpty()) {
             try {
-                return (Class<? extends Annotation>) Class.forName(generatedAnnotationClass);
+                return new GeneratedAnnotationClass(template);
             } catch (Exception e) {
                 // Try next one
             }
@@ -41,26 +64,38 @@ public final class GeneratedAnnotationResolver {
      *
      * @return the Generated annotation class from java. Never {@code null}.
      */
-    public static Class<? extends Annotation> resolveDefault() {
+    public static GeneratedAnnotationClass resolveDefault() {
         return DEFAULT_GENERATED_ANNOTATION_CLASS;
     }
 
+    public static GeneratedAnnotationClass qeryDSLGenerated() {
+        return forSingleValuedAnnotation(Generated.class);
+    }
+
+    public static GeneratedAnnotationClass forSingleValuedAnnotation(Class<? extends Annotation> annotationClass) {
+        String template = annotationClass.getName() + "(" + DEFAULT_CONSTRUCTOR_ARGS + ")";
+        return new GeneratedAnnotationClass(template);
+    }
+
     @SuppressWarnings("unchecked")
-    private static Class<? extends Annotation> resolveJavaDefault() {
+    private static GeneratedAnnotationClass resolveJavaDefault() {
         try {
-            return (Class<? extends Annotation>) Class.forName("javax.annotation.processing.Generated");
+            Class<? extends Annotation> annotationClass = (Class<? extends Annotation>) Class.forName("javax.annotation.processing.Generated");
+            return GeneratedAnnotationResolver.forSingleValuedAnnotation(annotationClass);
         } catch (Exception e) {
             // Try next one
         }
 
         try {
-            return (Class<? extends Annotation>) Class.forName("javax.annotation.Generated");
+            Class<? extends Annotation> annotationClass = (Class<? extends Annotation>) Class.forName("javax.annotation.Generated");
+            return GeneratedAnnotationResolver.forSingleValuedAnnotation(annotationClass);
         } catch (Exception e) {
             // Try next one
         }
 
         try {
-            return (Class<? extends Annotation>) Class.forName("jakarta.annotation.Generated");
+            Class<? extends Annotation> annotationClass = (Class<? extends Annotation>) Class.forName("jakarta.annotation.Generated");
+            return GeneratedAnnotationResolver.forSingleValuedAnnotation(annotationClass);
         } catch (Exception e) {
             // Try next one
         }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
@@ -824,6 +824,6 @@ public class GenericExporter {
      * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7.3">Single-Element Annotation</a>
      */
     public void setGeneratedAnnotationClass(@Nullable String generatedAnnotationClass) {
-        codegenModule.bindInstance(CodegenModule.GENERATED_ANNOTATION_CLASS, GeneratedAnnotationResolver.resolve(generatedAnnotationClass));
+        codegenModule.bind(CodegenModule.GENERATED_ANNOTATION_CLASS, GeneratedAnnotationResolver.resolve(generatedAnnotationClass));
     }
 }

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/BeanSerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/BeanSerializerTest.java
@@ -196,7 +196,7 @@ public class BeanSerializerTest {
 
     @Test
     public void customGeneratedAnnotation() throws IOException {
-        Serializer serializer = new BeanSerializer(BeanSerializer.DEFAULT_JAVADOC_SUFFIX, Generated.class);
+        Serializer serializer = new BeanSerializer(BeanSerializer.DEFAULT_JAVADOC_SUFFIX, GeneratedAnnotationResolver.forSingleValuedAnnotation(Generated.class));
         serializer.serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
         String generatedSource = String.valueOf(writer);
         assertThat(generatedSource, containsString("import com.querydsl.core.annotations.Generated;"));

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/CodegenModuleTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/CodegenModuleTest.java
@@ -18,8 +18,6 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
-import java.lang.annotation.Annotation;
-
 public class CodegenModuleTest {
 
     private final CodegenModule module = new CodegenModule();
@@ -41,7 +39,7 @@ public class CodegenModuleTest {
 
     @Test
     public void defaultGeneratedClass() {
-        Class<? extends Annotation> o = module.get(Class.class, CodegenModule.GENERATED_ANNOTATION_CLASS);
+        GeneratedAnnotationClass o = module.get(GeneratedAnnotationClass.class, CodegenModule.GENERATED_ANNOTATION_CLASS);
         assertEquals(o, GeneratedAnnotationResolver.resolveDefault());
     }
 

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/EmbeddableSerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/EmbeddableSerializerTest.java
@@ -196,7 +196,7 @@ public class EmbeddableSerializerTest {
         EntityType entityType = new EntityType(type);
         typeMappings.register(entityType, queryTypeFactory.create(entityType));
 
-        new DefaultEmbeddableSerializer(typeMappings, Collections.<String>emptySet(), com.querydsl.core.annotations.Generated.class).serialize(entityType, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
+        new DefaultEmbeddableSerializer(typeMappings, Collections.<String>emptySet(), GeneratedAnnotationResolver.qeryDSLGenerated()).serialize(entityType, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
         String generatedSourceCode = writer.toString();
         assertThat(generatedSourceCode, containsString("@Generated(\"com.querydsl.codegen.DefaultEmbeddableSerializer\")\npublic class"));
         CompileUtils.assertCompiles("QEntity", generatedSourceCode);

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/EntitySerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/EntitySerializerTest.java
@@ -207,7 +207,7 @@ public class EntitySerializerTest {
         EntityType entityType = new EntityType(new ClassType(Entity.class));
         typeMappings.register(entityType, queryTypeFactory.create(entityType));
 
-        new DefaultEntitySerializer(typeMappings, Collections.<String>emptySet(), com.querydsl.core.annotations.Generated.class).serialize(entityType, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
+        new DefaultEntitySerializer(typeMappings, Collections.<String>emptySet(), GeneratedAnnotationResolver.qeryDSLGenerated()).serialize(entityType, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
         String generatedSourceCode = writer.toString();
         assertTrue(generatedSourceCode.contains("import " + com.querydsl.core.annotations.Generated.class.getName() + ";"));
         assertTrue(generatedSourceCode.contains("@" + com.querydsl.core.annotations.Generated.class.getSimpleName() + "(\"com.querydsl.codegen.DefaultEntitySerializer\")\npublic class"));

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/GeneratedAnnotationResolverTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/GeneratedAnnotationResolverTest.java
@@ -2,31 +2,108 @@ package com.querydsl.codegen;
 
 import org.junit.Test;
 
-import javax.annotation.Generated;
-import java.lang.annotation.Annotation;
-
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class GeneratedAnnotationResolverTest {
 
-    private static final String defaultGenerated = Generated.class.getName();
+    private final GeneratedAnnotationClass.Context ctx = GeneratedAnnotationClass.Context.of("my.GeneratorBean");
 
     @Test
     public void resolveCustom() {
         String customClass = "some.random.Class";
-        Class<? extends Annotation> resolvedAnnotationClass = GeneratedAnnotationResolver.resolve(customClass);
+        GeneratedAnnotationClass resolvedAnnotationClass = GeneratedAnnotationResolver.resolve(customClass);
         assertNotNull(resolvedAnnotationClass);
+        assertEquals("some.random", resolvedAnnotationClass.getPackageName());
+        assertEquals("Class", resolvedAnnotationClass.getSimpleName());
+        assertEquals("\"{{queryDSL.generator.className}}\"", resolvedAnnotationClass.getConstructorArgs());
+        assertEquals("\"my.GeneratorBean\"", resolvedAnnotationClass.buildAnnotationArgs(ctx));
+        assertEquals("Class(\"my.GeneratorBean\")", resolvedAnnotationClass.buildAnnotation(ctx));
     }
 
     @Test
     public void resolveNull() {
-        Class<? extends Annotation>  resolvedAnnotationClass = GeneratedAnnotationResolver.resolve(null);
+        GeneratedAnnotationClass  resolvedAnnotationClass = GeneratedAnnotationResolver.resolve(null);
         assertNotNull(resolvedAnnotationClass);
+        assertEquals("javax.annotation.processing", resolvedAnnotationClass.getPackageName());
+        assertEquals("Generated", resolvedAnnotationClass.getSimpleName());
+        assertEquals("\"{{queryDSL.generator.className}}\"", resolvedAnnotationClass.getConstructorArgs());
+        assertEquals("\"my.GeneratorBean\"", resolvedAnnotationClass.buildAnnotationArgs(ctx));
+        assertEquals("Generated(\"my.GeneratorBean\")", resolvedAnnotationClass.buildAnnotation(ctx));
     }
 
     @Test
     public void resolveDefault() {
-        Class<? extends Annotation> resolvedAnnotationClass = GeneratedAnnotationResolver.resolveDefault();
+        GeneratedAnnotationClass resolvedAnnotationClass = GeneratedAnnotationResolver.resolveDefault();
         assertNotNull(resolvedAnnotationClass);
+        assertEquals("javax.annotation.processing", resolvedAnnotationClass.getPackageName());
+        assertEquals("Generated", resolvedAnnotationClass.getSimpleName());
+        assertEquals("\"{{queryDSL.generator.className}}\"", resolvedAnnotationClass.getConstructorArgs());
+        assertEquals("\"my.GeneratorBean\"", resolvedAnnotationClass.buildAnnotationArgs(ctx));
+        assertEquals("Generated(\"my.GeneratorBean\")", resolvedAnnotationClass.buildAnnotation(ctx));
     }
+
+    @Test
+    public void parse_template_without_params() {
+        String template = "foo.bar.Banana";
+
+        GeneratedAnnotationClass resolved = GeneratedAnnotationResolver.resolve(template);
+
+        assertEquals("foo.bar", resolved.getPackageName());
+        assertEquals("Banana", resolved.getSimpleName());
+        assertEquals("\"{{queryDSL.generator.className}}\"", resolved.getConstructorArgs());
+        assertEquals("\"my.GeneratorBean\"", resolved.buildAnnotationArgs(ctx));
+        assertEquals("Banana(\"my.GeneratorBean\")", resolved.buildAnnotation(ctx));
+    }
+
+
+    @Test
+    public void parse_template_with_params() {
+        String template = "foo.bar.MyGenerated(\"{{queryDSL.generator.className}}\")";
+
+        GeneratedAnnotationClass resolved = GeneratedAnnotationResolver.resolve(template);
+
+        assertEquals("foo.bar", resolved.getPackageName());
+        assertEquals("MyGenerated", resolved.getSimpleName());
+        assertEquals("\"{{queryDSL.generator.className}}\"", resolved.getConstructorArgs());
+        assertEquals("\"my.GeneratorBean\"", resolved.buildAnnotationArgs(ctx));
+        assertEquals("MyGenerated(\"my.GeneratorBean\")", resolved.buildAnnotation(ctx));
+    }
+
+    @Test
+    public void parse_template_with_empty_params() {
+        String template = "foo.bar.MyGenerated()";
+
+        GeneratedAnnotationClass resolved = GeneratedAnnotationResolver.resolve(template);
+
+        assertEquals("foo.bar", resolved.getPackageName());
+        assertEquals("MyGenerated", resolved.getSimpleName());
+        assertEquals("", resolved.getConstructorArgs());
+        assertEquals("", resolved.buildAnnotationArgs(ctx));
+        assertEquals("MyGenerated", resolved.buildAnnotation(ctx));
+    }
+
+    @Test
+    public void parse_template_with_many_params() {
+        String template = "foo.bar.MyGenerated(value=\"{{queryDSL.generator.className}}\", description=\"testing\")";
+
+        GeneratedAnnotationClass resolved = GeneratedAnnotationResolver.resolve(template);
+
+        assertEquals("foo.bar", resolved.getPackageName());
+        assertEquals("MyGenerated", resolved.getSimpleName());
+        assertEquals("value=\"{{queryDSL.generator.className}}\", description=\"testing\"", resolved.getConstructorArgs());
+        assertEquals("value=\"my.GeneratorBean\", description=\"testing\"", resolved.buildAnnotationArgs(ctx));
+        assertEquals("MyGenerated(value=\"my.GeneratorBean\", description=\"testing\")", resolved.buildAnnotation(ctx));
+    }
+
+    @Test
+    public void template_using_timestamp_placeholder() {
+        String template = "foo.bar.MyGenerated(timestamp=\"{{queryDSL.timestamp}}\")";
+
+        GeneratedAnnotationClass resolved = GeneratedAnnotationResolver.resolve(template);
+        String actual = resolved.buildAnnotation(ctx);
+
+        assertTrue(actual.matches(".*timestamp=\"\\d{13,}\".*"));
+    }
+
+
 }

--- a/querydsl-codegen/src/test/java/com/querydsl/codegen/ProjectionSerializerTest.java
+++ b/querydsl-codegen/src/test/java/com/querydsl/codegen/ProjectionSerializerTest.java
@@ -72,7 +72,7 @@ public class ProjectionSerializerTest {
         EntityType type = new EntityType(typeModel);
 
         Writer writer = new StringWriter();
-        ProjectionSerializer serializer = new DefaultProjectionSerializer(new JavaTypeMappings(), Generated.class);
+        ProjectionSerializer serializer = new DefaultProjectionSerializer(new JavaTypeMappings(), GeneratedAnnotationResolver.forSingleValuedAnnotation(Generated.class));
         serializer.serialize(type, SimpleSerializerConfig.DEFAULT, new JavaWriter(writer));
         String generatedSource = writer.toString();
         assertThat(generatedSource, containsString("import com.querydsl.core.annotations.Generated"));

--- a/querydsl-kotlin-codegen/src/main/kotlin/com/querydsl/kotlin/codegen/KotlinEmbeddableSerializer.kt
+++ b/querydsl-kotlin-codegen/src/main/kotlin/com/querydsl/kotlin/codegen/KotlinEmbeddableSerializer.kt
@@ -15,6 +15,7 @@ package com.querydsl.kotlin.codegen
 
 import com.querydsl.codegen.CodegenModule
 import com.querydsl.codegen.EmbeddableSerializer
+import com.querydsl.codegen.GeneratedAnnotationClass
 import com.querydsl.codegen.GeneratedAnnotationResolver
 import com.querydsl.codegen.TypeMappings
 import com.querydsl.core.types.Path
@@ -28,7 +29,7 @@ class KotlinEmbeddableSerializer @Inject constructor(
     @Named(CodegenModule.KEYWORDS)
     keywords: Collection<String>,
     @Named(CodegenModule.GENERATED_ANNOTATION_CLASS)
-    generatedAnnotationClass: Class<out Annotation> = GeneratedAnnotationResolver.resolveDefault()
+    generatedAnnotationClass: GeneratedAnnotationClass = GeneratedAnnotationResolver.resolveDefault()
 ) : KotlinEntitySerializer(mappings, keywords, generatedAnnotationClass), EmbeddableSerializer {
     override fun defaultSuperType(): KClass<out Path<*>> = BeanPath::class
 }

--- a/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/EmbeddableSerializerTest.kt
+++ b/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/EmbeddableSerializerTest.kt
@@ -28,7 +28,6 @@ import com.querydsl.codegen.utils.model.ClassType
 import com.querydsl.codegen.utils.model.SimpleType
 import com.querydsl.codegen.utils.model.TypeCategory
 import com.querydsl.codegen.utils.model.Types
-import com.querydsl.core.annotations.Generated
 import com.querydsl.core.annotations.PropertyType
 import com.querydsl.kotlin.codegen.CompileUtils.assertCompiles
 import org.hamcrest.Matchers
@@ -187,7 +186,7 @@ class EmbeddableSerializerTest {
         val type = SimpleType(TypeCategory.ENTITY, "Entity", "", "Entity", false, false)
         val entityType = EntityType(type)
         typeMappings.register(entityType, queryTypeFactory.create(entityType))
-        KotlinEmbeddableSerializer(typeMappings, emptySet(), Generated::class.java).serialize(entityType, SimpleSerializerConfig.DEFAULT, JavaWriter(writer))
+        KotlinEmbeddableSerializer(typeMappings, emptySet(), GeneratedAnnotationResolver.qeryDSLGenerated()).serialize(entityType, SimpleSerializerConfig.DEFAULT, JavaWriter(writer))
         val generatedSourceCode = writer.toString()
         Assert.assertThat(generatedSourceCode, Matchers.containsString("@Generated(\"com.querydsl.kotlin.codegen.KotlinEmbeddableSerializer\")\npublic class"))
         assertCompiles("QEntity", generatedSourceCode)

--- a/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/EntitySerializerTest.kt
+++ b/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/EntitySerializerTest.kt
@@ -195,7 +195,7 @@ class EntitySerializerTest {
     fun customGeneratedAnnotation() {
         val entityType = EntityType(ClassType(Entity::class.java))
         typeMappings.register(entityType, queryTypeFactory.create(entityType))
-        KotlinEntitySerializer(typeMappings, emptySet(), Generated::class.java).serialize(entityType, SimpleSerializerConfig.DEFAULT, JavaWriter(writer))
+        KotlinEntitySerializer(typeMappings, emptySet(), GeneratedAnnotationResolver.qeryDSLGenerated()).serialize(entityType, SimpleSerializerConfig.DEFAULT, JavaWriter(writer))
         val generatedSourceCode = writer.toString()
         Assert.assertTrue(generatedSourceCode.contains("import " + Generated::class.java.name))
         Assert.assertTrue(generatedSourceCode.contains("@${Generated::class.java.simpleName}(\"com.querydsl.kotlin.codegen.KotlinEntitySerializer\")\npublic class"))

--- a/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/ProjectionSerializerTest.kt
+++ b/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/ProjectionSerializerTest.kt
@@ -68,7 +68,7 @@ class ProjectionSerializerTest {
         val typeModel: Type = SimpleType(TypeCategory.ENTITY, "com.querydsl.DomainClass", "com.querydsl", "DomainClass", false, false)
         val type = EntityType(typeModel)
         val writer: Writer = StringWriter()
-        val serializer: ProjectionSerializer = KotlinProjectionSerializer(KotlinTypeMappings(), Generated::class.java)
+        val serializer: ProjectionSerializer = KotlinProjectionSerializer(KotlinTypeMappings(), GeneratedAnnotationResolver.qeryDSLGenerated())
         serializer.serialize(type, SimpleSerializerConfig.DEFAULT, JavaWriter(writer))
         val generatedSource = writer.toString()
         Assert.assertThat(generatedSource, Matchers.containsString("import com.querydsl.core.annotations.Generated"))

--- a/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractExporterMojo.java
+++ b/querydsl-maven-plugin/src/main/java/com/querydsl/maven/AbstractExporterMojo.java
@@ -19,6 +19,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -113,8 +114,29 @@ public abstract class AbstractExporterMojo extends AbstractMojo {
     private boolean skip;
 
     /**
-     * The fully qualified class name of the <em>Single-Element Annotation</em> (with <code>String</code> element) to put on the generated sources. Defaults to
-     * <code>javax.annotation.Generated</code> or <code>javax.annotation.processing.Generated</code> depending on the java version.
+     * The annotation (usually: {@code @Generated}) that will get attached to generated classes.
+     * <br>
+     * <p>
+     * Specify one of:
+     * <ul>
+     *  <li>The fully qualified class name of the <em>Single-Element Annotation</em> (with <code>String</code> element)</li>
+     *  <li>A code template in the form <code>fully.qualified.Annotation()</code></li>
+     *  <li>or <code>fully.qualified.Annotation("with params")</code></li>
+     *  <li>or <code>fully.qualified.Annotation(say="Hello", toWhom="World")</code>.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * Defaults to <code>javax.annotation.Generated</code> or <code>javax.annotation.processing.Generated</code> depending on the java version.
+     * </p>
+     * <p>
+     * Parameterized forms also support placeholders for parameters:
+     * <ul>
+     *     <li>"{@code {{queryDSL.generator.className}}}" - the class name of the generator</li>
+     *     <li>"{@code {{queryDSL.timestamp}}}" - A timestamp as returned by {@link Date#getTime()}.</li>
+     * </ul>
+     * Example: {@code fully.qualified.Annotation("{{queryDSL.generator.className}}")} results in e.g. {@code fully.qualified.Annotation("com.querydsl.sql.codegen.ExtendedBeanSerializer")}
+     * </p>
+     * <br>
      * <em>See also</em> <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7.3">Single-Element Annotation</a>
      *
      * @parameter

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ExtendedBeanSerializer.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ExtendedBeanSerializer.java
@@ -15,6 +15,7 @@ package com.querydsl.sql.codegen;
 
 import com.querydsl.codegen.BeanSerializer;
 import com.querydsl.codegen.EntityType;
+import com.querydsl.codegen.GeneratedAnnotationClass;
 import com.querydsl.codegen.Property;
 import com.querydsl.codegen.utils.CodeWriter;
 import com.querydsl.codegen.utils.model.Parameter;
@@ -25,7 +26,6 @@ import com.querydsl.sql.codegen.support.PrimaryKeyData;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -58,7 +58,7 @@ public class ExtendedBeanSerializer extends BeanSerializer {
     @Inject
     public ExtendedBeanSerializer(
             @Named(SQLCodegenModule.JAVADOC_SUFFIX) String javadocSuffix,
-            @Named(SQLCodegenModule.GENERATED_ANNOTATION_CLASS) Class<? extends Annotation> generatedAnnotationClass) {
+            @Named(SQLCodegenModule.GENERATED_ANNOTATION_CLASS) GeneratedAnnotationClass generatedAnnotationClass) {
         super(javadocSuffix, generatedAnnotationClass);
     }
 

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataExporter.java
@@ -821,7 +821,7 @@ public class MetaDataExporter {
      * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7.3">Single-Element Annotation</a>
      */
     public void setGeneratedAnnotationClass(@Nullable String generatedAnnotationClass) {
-        module.bindInstance(CodegenModule.GENERATED_ANNOTATION_CLASS, GeneratedAnnotationResolver.resolve(generatedAnnotationClass));
+        module.bind(CodegenModule.GENERATED_ANNOTATION_CLASS, GeneratedAnnotationResolver.resolve(generatedAnnotationClass));
     }
 
 }

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
@@ -99,7 +99,7 @@ public class MetaDataSerializer extends DefaultEntitySerializer {
             @Named(SQLCodegenModule.IMPORTS) Set<String> imports,
             @Named(SQLCodegenModule.COLUMN_COMPARATOR) Comparator<Property> columnComparator,
             @Named(SQLCodegenModule.ENTITYPATH_TYPE) Class<?> entityPathType,
-            @Named(SQLCodegenModule.GENERATED_ANNOTATION_CLASS) Class<? extends Annotation> generatedAnnotationClass) {
+            @Named(SQLCodegenModule.GENERATED_ANNOTATION_CLASS) GeneratedAnnotationClass generatedAnnotationClass) {
         super(typeMappings, Collections.<String>emptyList(), generatedAnnotationClass);
         this.namingStrategy = namingStrategy;
         this.innerClassesForKeys = innerClassesForKeys;
@@ -160,7 +160,7 @@ public class MetaDataSerializer extends DefaultEntitySerializer {
     protected void introClassHeader(CodeWriter writer, EntityType model) throws IOException {
         Type queryType = typeMappings.getPathType(model, model, true);
 
-        writer.line("@", generatedAnnotationClass.getSimpleName(), "(\"", getClass().getName(), "\")");
+        writer.line("@", generatedAnnotationClass.buildAnnotation(GeneratedAnnotationClass.Context.of(getClass().getName())));
 
         TypeCategory category = model.getOriginalCategory();
         // serialize annotations only, if no bean types are used


### PR DESCRIPTION
This pr implements a configurable code template for the Generated annotations (see #3212 )

I'd reeeeally like to have custom annotations that do not follow the Single Value Annotation pattern.

Feel free to reject this pr, I had fun implementing it... which is rewarding in and of itself :)
