### PR TITLE
JSR310LocalDate getValue #3001

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/JSR310LocalDateType.java
@@ -37,8 +37,7 @@ public class JSR310LocalDateType extends AbstractJSR310DateTimeType<LocalDate> {
     @Override
     public LocalDate getValue(ResultSet rs, int startIndex) throws SQLException {
         Date date = rs.getDate(startIndex, utc());
-        return date != null ? LocalDateTime.ofInstant(Instant.ofEpochMilli(date.getTime()),
-                ZoneOffset.UTC).toLocalDate() : null;
+        return date != null ? date.toLocalDate() : null;
     }
 
     @Override

--- a/querydsl-sql/src/test/java/com/querydsl/sql/types/AbstractJSR310DateTimeTypeTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/types/AbstractJSR310DateTimeTypeTest.java
@@ -103,4 +103,16 @@ public abstract class AbstractJSR310DateTimeTypeTest<T extends Temporal> {
         get();
     }
 
+    @Test
+    public void get_europe_paris() throws SQLException {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris")); // +2:00
+        get();
+    }
+
+    @Test
+    public void set_europe_paris() throws SQLException {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris")); // +2:00
+        set();
+    }
+
 }

--- a/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310LocalDateTypeTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/types/JSR310LocalDateTypeTest.java
@@ -48,7 +48,7 @@ public class JSR310LocalDateTypeTest extends AbstractJSR310DateTimeTypeTest<Loca
     @Test
     public void get() throws SQLException {
         ResultSet resultSet = EasyMock.createNiceMock(ResultSet.class);
-        EasyMock.expect(resultSet.getDate(1, UTC)).andReturn(new Date(UTC.getTimeInMillis()));
+        EasyMock.expect(resultSet.getDate(1, UTC)).andReturn(new Date(70, 0, 1));
         EasyMock.replay(resultSet);
 
         LocalDate result = type.getValue(resultSet, 1);


### PR DESCRIPTION
### JSR310LocalDateType getValue() was sometime giving a result with a one day offset

Added a test that uses Europe/Paris, to show that date were not correctly interpreted in this timezone (And possibly others ?)

In the mock used for the JSR310LocalDateTypeTest instead of returning a date using UTC calendar with millis set to 0, we use the deprecated constructor that is used under the hood when retrieving date from the ResultSet.

To correct the issue, we use the toLocalDate method of java.sql.Date