### PR TITLE
Fix yml error on issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,6 @@ contact_links:
   - name: Querydsl's Google Group
     url: https://groups.google.com/forum/#!forum/querydsl
     about: Ask questions, suggest changes and provide feedback.
-- name: Querydsl on Stackoverflow
+  - name: Querydsl on Stackoverflow
     url: https://stackoverflow.com/questions/tagged/querydsl
     about: Seek help on setup and usage.


### PR DESCRIPTION
<img width="1389" alt="Screen Shot 2022-06-13 at 18 48 27" src="https://user-images.githubusercontent.com/63502128/173393404-2caa7746-598b-4109-b17d-d543e48b2e37.png">

Due to syntax error on the config.yml, the links are not seen