### PR TITLE
use isNull() when the only one elemnet is null

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/SimpleExpression.java
@@ -190,7 +190,7 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      */
     public BooleanExpression in(Collection<? extends T> right) {
         if (right.size() == 1) {
-            return eq(right.iterator().next());
+            return  right.iterator().next() != null ? eq(right.iterator().next()) : isNull();
         } else {
             return Expressions.booleanOperation(Ops.IN, mixin, ConstantImpl.create(right));
         }
@@ -204,7 +204,7 @@ public abstract class SimpleExpression<T> extends DslExpression<T> {
      */
     public BooleanExpression in(T... right) {
         if (right.length == 1) {
-            return eq(right[0]);
+            return right[0] != null ? eq(right[0]) : isNull();
         } else {
             return Expressions.booleanOperation(Ops.IN, mixin, ConstantImpl.create(CollectionUtils.unmodifiableList(Arrays.asList(right))));
         }


### PR DESCRIPTION

<img width="832" alt="image" src="https://user-images.githubusercontent.com/17310896/176811616-a112c621-8376-450c-ac7f-2d9c2f8904a9.png">

    public void testQuery() {
        List<Long> list = new ArrayList<>();
        list.add(null);
        try{
            roleRepository.findAll(QRole.role.id.in(list));
            logger.info("[null] success");
        }catch (Exception e){
            logger.info("[null] exception {}", e.getMessage());
        }

        list.add(null);
        try{
            roleRepository.findAll(QRole.role.id.in(list));
            logger.info("[null, null] success");
        }catch (Exception e){
            logger.info("[null, null] exception {}", e.getMessage());
        }
    }

in [null, null] is ok, but in [null] is error.