### PR TITLE
Build querydsl with java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         target: [test]
-        java: [1.8, 11]
+        java: [1.8, 11, 17]
         include:
           - target: test
             containers: db2 mysql postgresql mongo sqlserver oracle cubrid firebird

--- a/querydsl-scala/src/test/scala/com/querydsl/scala/ReflectionUtilsTest.scala
+++ b/querydsl-scala/src/test/scala/com/querydsl/scala/ReflectionUtilsTest.scala
@@ -12,8 +12,10 @@ class ReflectionUtilsTest {
 
   @Test
   def getImplementedInterfaces {
-    assertEquals(Set(classOf[java.io.Serializable],classOf[Comparable[_]],classOf[CharSequence]),
-        ReflectionUtils.getImplementedInterfaces(classOf[String]))
+    var setToTest = ReflectionUtils.getImplementedInterfaces(classOf[String])
+    assertTrue(setToTest.contains(classOf[java.io.Serializable]))
+    assertTrue(setToTest.contains(classOf[Comparable[_]]))
+    assertTrue(setToTest.contains(classOf[CharSequence]))
   }
 
   @Test


### PR DESCRIPTION
This PR can help querydsl java 17 support.

Related to #3296

I had to change ReflectionUtilsTest.getImplementedInterfaces test because java.lang.String implements two new interfaces (Constable and ConstantDesc) on java 17.
