### PR TITLE
kotlin-codegen: Improved Kotlin compatibility

### DIFF
--- a/querydsl-kotlin-codegen/src/main/kotlin/com/querydsl/kotlin/codegen/KotlinEntitySerializer.kt
+++ b/querydsl-kotlin-codegen/src/main/kotlin/com/querydsl/kotlin/codegen/KotlinEntitySerializer.kt
@@ -169,7 +169,10 @@ open class KotlinEntitySerializer @Inject constructor(
                     TypeCategory.DATE -> serialize(model, property, queryType, "createDate", classStatement)
                     TypeCategory.DATETIME -> serialize(model, property, queryType, "createDateTime", classStatement)
                     TypeCategory.TIME -> serialize(model, property, queryType, "createTime", classStatement)
-                    TypeCategory.NUMERIC -> serialize(model, property, queryType, "createNumber", classStatement)
+                    TypeCategory.NUMERIC -> {
+                        val numberClassStatement = property.type.asClassNameStatement(KotlinClassType.JAVA_OBJECT_TYPE)
+                        serialize(model, property, queryType, "createNumber", numberClassStatement)
+                    }
                     TypeCategory.CUSTOM -> customField(model, property, config)
                     TypeCategory.ARRAY -> serialize(model, property, ArrayPath::class.parameterizedBy(property.type, property.type.componentType), "createArray", classStatement)
                     TypeCategory.COLLECTION -> collectionField(model, property, "createCollection", CollectionPath::class)

--- a/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/PrimitiveTypeTest.kt
+++ b/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/PrimitiveTypeTest.kt
@@ -1,0 +1,46 @@
+package com.querydsl.kotlin.codegen
+
+import com.querydsl.core.util.MathUtils
+import org.junit.Assert
+import kotlin.test.Test
+
+internal class PrimitiveTypeTest {
+
+    @Test()
+    fun castPrimitiveType() {
+        Assert.assertThrows("Unsupported target type : double", IllegalArgumentException::class.java) {
+            checkCast(1, Double::class.java)
+        }
+        Assert.assertThrows("Unsupported target type : float", IllegalArgumentException::class.java) {
+            checkCast(1, Float::class.java)
+        }
+        Assert.assertThrows("Unsupported target type : int", IllegalArgumentException::class.java) {
+            checkCast(1, Int::class.java)
+        }
+        Assert.assertThrows("Unsupported target type : long", IllegalArgumentException::class.java) {
+            checkCast(1, Long::class.java)
+        }
+        Assert.assertThrows("Unsupported target type : short", IllegalArgumentException::class.java) {
+            checkCast(1, Short::class.java)
+        }
+        Assert.assertThrows("Unsupported target type : byte", IllegalArgumentException::class.java) {
+            checkCast(1, Byte::class.java)
+        }
+    }
+
+    @Test
+    fun castJavaObjectType() {
+        checkCast(1, Double::class.javaObjectType)
+        checkCast(1, Float::class.javaObjectType)
+        checkCast(1, Int::class.javaObjectType)
+        checkCast(1, Long::class.javaObjectType)
+        checkCast(1, Short::class.javaObjectType)
+        checkCast(1, Byte::class.javaObjectType)
+    }
+
+    private fun checkCast(value: Number, targetClass: Class<out Number>) {
+        val target = MathUtils.cast(value, targetClass)
+        Assert.assertSame(targetClass, target.javaClass)
+    }
+
+}


### PR DESCRIPTION
In Kotlin, `Long::class.java` is java Primitive Type.
In `kotlin-codegen`, Using ` T::class.java` will cause exception, because `Number` type is Primitive type.
```kotlin
// com.querydsl.kotlin.codegen.Extensions.kt
fun ClassName.asClassStatement() = CodeBlock.of("%T::class.java", this)

// com.querydsl.core.util.MathUtils.kt
    public static <D extends Number> D cast(Number num, Class<D> type) {
        D rv;
        if (num == null || type.isInstance(num)) {
            rv = type.cast(num);
        } else if (type.equals(Byte.class)) {
            rv = type.cast(num.byteValue());
        } else if (type.equals(Double.class)) {
            rv = type.cast(num.doubleValue());
        } else if (type.equals(Float.class)) {
            rv = type.cast(num.floatValue());
        } else if (type.equals(Integer.class)) {
            rv = type.cast(num.intValue());
        } else if (type.equals(Long.class)) {
            rv = type.cast(num.longValue());
        } else if (type.equals(Short.class)) {
            rv = type.cast(num.shortValue());
        } else if (type.equals(BigDecimal.class)) {
            rv = type.cast(new BigDecimal(num.toString()));
        } else if (type.equals(BigInteger.class)) {
            if (num instanceof BigDecimal) {
                rv = type.cast(((BigDecimal) num).toBigInteger());
            } else {
                rv = type.cast(new BigInteger(num.toString()));
            }
        } else {
            throw new IllegalArgumentException(String.format("Unsupported target type : %s", type.getSimpleName()));
        }
        return rv;
    }
```



see kotlin source code:
```kotlin
public val <T : Any> KClass<T>.javaObjectType: Class<T>
    get() {
        val thisJClass = (this as ClassBasedDeclarationContainer).jClass
        if (!thisJClass.isPrimitive) return thisJClass as Class<T>

        return when (thisJClass.name) {
            "boolean" -> JavaLangBoolean::class.java
            "char"    -> JavaLangCharacter::class.java
            "byte"    -> JavaLangByte::class.java
            "short"   -> JavaLangShort::class.java
            "int"     -> JavaLangInteger::class.java
            "float"   -> JavaLangFloat::class.java
            "long"    -> JavaLangLong::class.java
            "double"  -> JavaLangDouble::class.java
            "void"    -> Void::class.java
            else -> thisJClass
        } as Class<T>
    }
```

We need use `Long::class.javaObjectType`