### PR TITLE
changed EntityType#properties to use LinkedHashSet instead of TreeSet

### DIFF
--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Function;
 import org.jetbrains.annotations.Nullable;
 /**
@@ -44,7 +43,7 @@ public class EntityType extends TypeAdapter implements Comparable<EntityType> {
 
     private final Set<Delegate> delegates = new HashSet<Delegate>();
 
-    private final Set<Property> properties = new TreeSet<Property>();
+    private final Set<Property> properties = new LinkedHashSet<>();
 
     private final Set<String> propertyNames = new HashSet<String>();
 


### PR DESCRIPTION
Type of Set on `EntityType#properties` impacts the order of properties in resulting Q class.
The original line dates back to 2010 and @Shredder121 explained to me that this was most likely due to desire to have deterministic behavior. `TypeElement#getEnclosedElements` is also deterministic so it's not exactly clear why this option was picked.The end result is that instead of having order of columns in Q class being in the same order as fields in original class, they instead end up being in ascending order.

This is problematic when, for instance, using constructor projections. IDE's, Lombok, records etc all respect the order of fields when generating full argument constructors and so parameters are in same order as their respective field counterparts. Because of this - Querydsl users that want to use constructor projections can't merely state they want it over some Q class - they need to make sure that either fields are in ascending order or they need to create constructors for which the parameters have ascending order.