### PR TITLE
MS SQL Server: replace old, unmaintained jTDS driver with mssql-jdbc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <postgresql.version>42.3.4</postgresql.version>
     <oracle.version>11.2.0.4</oracle.version>
     <mysql.version>8.0.29</mysql.version>
-    <jtds.version>1.3.1</jtds.version>
+    <mssql.version>11.2.1.jre8</mssql.version>
     <cubrid.version>9.3.9.0002</cubrid.version>
     <sqlite.version>3.36.0.3</sqlite.version>
     <teradata.version>13.10.00.35</teradata.version>
@@ -431,7 +431,7 @@
                     <exclude>com.h2database:h2:*:*:compile</exclude>
                     <exclude>org.apche.derby:derby:*:*:compile</exclude>
                     <exclude>mysql:mysql-connector-java:*:*:compile</exclude>
-                    <exclude>net.sourceforge.jtds:jtds:*:*:compile</exclude>
+                    <exclude>com.microsoft.sqlserver:mssql-jdbc:*:*:compile</exclude>
                     <exclude>com.oracle:ojdbc6:*:*:compile</exclude>
                     <exclude>org.postgresql:postgresql:*:*:compile</exclude>
                     <exclude>cubrid:cubrid-jdbc:*:*:compile</exclude>

--- a/querydsl-jpa/pom.xml
+++ b/querydsl-jpa/pom.xml
@@ -187,9 +187,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.jtds</groupId>
-      <artifactId>jtds</artifactId>
-      <version>${jtds.version}</version>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>${mssql.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/querydsl-jpa/src/test/resources/META-INF/persistence.xml
+++ b/querydsl-jpa/src/test/resources/META-INF/persistence.xml
@@ -235,8 +235,8 @@
     <properties>
       <property name="hibernate.archive.autodetection" value="class" />
       <property name="hibernate.dialect" value="com.querydsl.jpa.support.QSQLServer2008Dialect" />
-      <property name="hibernate.connection.driver_class" value="net.sourceforge.jtds.jdbc.Driver" />
-      <property name="hibernate.connection.url" value="jdbc:jtds:sqlserver://localhost:1433/tempdb" />
+      <property name="hibernate.connection.driver_class" value="com.microsoft.sqlserver.jdbc.SQLServerDriver" />
+      <property name="hibernate.connection.url" value="jdbc:sqlserver://localhost:1433;databaseName=tempdb;sendTimeAsDatetime=false;trustServerCertificate=true" />
       <property name="hibernate.connection.username" value="sa" />
       <property name="hibernate.connection.password" value="Password1!" />
       <!-- <property name="hibernate.show_sql" value="true"/> -->

--- a/querydsl-jpa/src/test/resources/com/querydsl/jpa/testutil/mssql.properties
+++ b/querydsl-jpa/src/test/resources/com/querydsl/jpa/testutil/mssql.properties
@@ -1,7 +1,7 @@
 ## MSSQL
 hibernate.dialect=com.querydsl.jpa.support.QSQLServer2008Dialect
-hibernate.connection.driver_class=net.sourceforge.jtds.jdbc.Driver
-hibernate.connection.url=jdbc:jtds:sqlserver://localhost:1433/tempdb
+hibernate.connection.driver_class=com.microsoft.sqlserver.jdbc.SQLServerDriver
+hibernate.connection.url=jdbc:sqlserver://localhost:1433;databaseName=tempdb;sendTimeAsDatetime=false;trustServerCertificate=true
 hibernate.connection.username=sa
 hibernate.connection.password=Password1!
 

--- a/querydsl-sql-codegen/pom.xml
+++ b/querydsl-sql-codegen/pom.xml
@@ -103,9 +103,9 @@
     </dependency>
           
     <dependency>
-      <groupId>net.sourceforge.jtds</groupId>
-      <artifactId>jtds</artifactId>
-      <version>${jtds.version}</version>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>${mssql.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/querydsl-sql-spatial/pom.xml
+++ b/querydsl-sql-spatial/pom.xml
@@ -130,9 +130,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.jtds</groupId>
-      <artifactId>jtds</artifactId>
-      <version>${jtds.version}</version>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>${mssql.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/querydsl-sql/pom.xml
+++ b/querydsl-sql/pom.xml
@@ -118,9 +118,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.jtds</groupId>
-      <artifactId>jtds</artifactId>
-      <version>${jtds.version}</version>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>${mssql.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/Connections.java
@@ -136,14 +136,9 @@ public final class Connections {
     }
 
     private static Connection getSQLServer() throws ClassNotFoundException, SQLException {
-        Class.forName("net.sourceforge.jtds.jdbc.Driver");
-        Properties props = new Properties();
-        props.put("user", "sa");
-        props.put("password", "Password1!");
-        props.put("sendTimeAsDatetime", "false");
-        String url = "jdbc:jtds:sqlserver://localhost:1433/tempdb";
-//        return DriverManager.getConnection(url, "querydsl", "querydsl");
-        return DriverManager.getConnection(url, props);
+        Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        String url = "jdbc:sqlserver://localhost:1433;databaseName=tempdb;sendTimeAsDatetime=false;trustServerCertificate=true";
+        return DriverManager.getConnection(url, "sa", "Password1!");
     }
 
     private static Connection getCubrid() throws ClassNotFoundException, SQLException {

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -1687,8 +1687,7 @@ public class SelectBase extends AbstractBaseTest {
 
         standardTest.runStringTests(employee.firstname, employee2.firstname, "Jennifer");
         Target target = Connections.getTarget();
-        if (target != SQLITE && target != SQLSERVER) {
-            // jTDS driver does not support TIME SQL data type
+        if (target != SQLITE) {
             standardTest.runTimeTests(employee.timefield, employee2.timefield, time);
         }
 


### PR DESCRIPTION
The jTDS driver has not been updated in many years and is not JDBC 4.2 (Java 8) compliant. Since Microsoft has open-sourced their official JDBC driver, it makes sense to switch to that instead.

This PR is a prerequisite for #3402, as mentioned in that PR.

In case there are any questions about the use of `sendTimeAsDatetime=false` in the connection string: this is necessary for tests related to `java.sql.Time` to work, as per footnote 1 in the [official MS docs](https://learn.microsoft.com/en-us/sql/connect/jdbc/using-basic-data-types?view=sql-server-ver16).