### PR TITLE
Firebird: upgrade container to version 4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       start_period: 60s
 
   firebird:
-    image: jacobalberty/firebird:2.5.9-ss
+    image: jacobalberty/firebird:v4
     ports:
       - "3050:3050"
     environment:

--- a/querydsl-sql/src/main/java/com/querydsl/sql/FirebirdTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/FirebirdTemplates.java
@@ -72,6 +72,8 @@ public class FirebirdTemplates extends SQLTemplates {
         add(Ops.StringOps.LOCATE2, "position({0},{1},{2})");
         add(Ops.STRING_LENGTH, "char_length({0})");
         add(Ops.STRING_IS_EMPTY, "char_length({0}) = 0");
+        add(Ops.StringOps.LTRIM, "trim (leading from {0})");
+        add(Ops.StringOps.RTRIM, "trim (trailing from {0})");
 
         add(Ops.AggOps.BOOLEAN_ANY, "any({0})");
         add(Ops.AggOps.BOOLEAN_ALL, "all({0})");


### PR DESCRIPTION
Firebird 2.5 is EOL, and version 4 adds support for TIME WITH TIME ZONE and TIMESTAMP WITH TIME ZONE (related to #3402).

Changes to LTRIM and RTRIM are necessary to fix string tests. The new syntax is supported in both Firebird 3.x and 4.x according to the docs.