### PR TITLE
Add `clearGroupBy` and `clearHaving` to `QueryMetadata`

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/DefaultQueryMetadata.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/DefaultQueryMetadata.java
@@ -197,6 +197,16 @@ public class DefaultQueryMetadata implements QueryMetadata, Cloneable {
     }
 
     @Override
+    public void clearGroupBy() {
+        groupBy.clear();
+    }
+
+    @Override
+    public void clearHaving() {
+        having = new BooleanBuilder();
+    }
+
+    @Override
     public void clearOrderBy() {
         orderBy.clear();
     }

--- a/querydsl-core/src/main/java/com/querydsl/core/QueryMetadata.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/QueryMetadata.java
@@ -85,6 +85,20 @@ public interface QueryMetadata extends Serializable {
     void addWhere(Predicate o);
 
     /**
+     * Clear the group by expressions
+     */
+    default void clearGroupBy() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Clear the having expressions
+     */
+    default void clearHaving() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Clear the order expressions
      */
     void clearOrderBy();


### PR DESCRIPTION
There are `clearOrderBy()` and `clearWhere()`, but `clearGroupBy()` and `clearHaving()` don't exist.

When someone needs to manipulate `QueryMetadata`, this unbalance may cause inconvenience. (Actually, I suffered.) I declared new methods as `default` methods (although it is not pretty) because I'm afraid of causing compile errors to other existing subclasses.

Please give me advice if you have better idea.