### PR TITLE
Copy the connection provider when cloning AbstractSQLQuery

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
@@ -55,10 +55,10 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
     private static final QueryFlag rowCountFlag = new QueryFlag(QueryFlag.Position.AFTER_PROJECTION, ", count(*) over() ");
 
     @Nullable
-    private Supplier<Connection> connProvider;
+    protected Supplier<Connection> connProvider;
 
     @Nullable
-    private Connection conn;
+    protected Connection conn;
 
     protected SQLListeners listeners;
 
@@ -633,7 +633,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
         }
     }
 
-    private Connection connection() {
+    protected Connection connection() {
         if (conn == null) {
             if (connProvider != null) {
                 conn = connProvider.get();
@@ -661,11 +661,17 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>> exte
         super.clone(query);
         this.useLiterals = query.useLiterals;
         this.listeners = new SQLListeners(query.listeners);
+        if (conn == null) {
+            connProvider = query.connProvider;
+            if (connProvider == null) {
+                conn = query.conn;
+            }
+        }
     }
 
     @Override
     public Q clone() {
-        return this.clone(this.conn);
+        return this.clone((Connection) null);
     }
 
     public abstract Q clone(Connection connection);

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLQueryTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLQueryTest.java
@@ -1,5 +1,12 @@
 package com.querydsl.sql;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.sql.Connection;
+
+import org.easymock.EasyMock;
 import org.junit.Test;
 
 import com.querydsl.sql.domain.QSurvey;
@@ -10,6 +17,39 @@ public class SQLQueryTest {
     public void noConnection() {
         QSurvey survey = QSurvey.survey;
         SQLExpressions.select(survey.id).from(survey).fetch();
+    }
+    
+    @Test
+    public void cloneNoArgHavingConnection() {
+        Connection connection = EasyMock.createMock(Connection.class);
+        SQLQuery<?> query = new SQLQuery<>(connection, new Configuration(SQLTemplates.DEFAULT));
+        SQLQuery<?> clone = query.clone();
+        assertSame(connection, clone.connection());
+    }
+    
+    @Test
+    public void cloneConnectionArgHavingConnection() {
+        Connection connection1 = EasyMock.createMock(Connection.class);
+        Connection connection2 = EasyMock.createMock(Connection.class);
+        SQLQuery<?> query = new SQLQuery<>(connection1, new Configuration(SQLTemplates.DEFAULT));
+        SQLQuery<?> clone = query.clone(connection2);
+        assertSame(connection2, clone.connection());
+    }
+    
+    @Test
+    public void cloneNoArgHavingConnectionProvider() {
+        SQLQuery<?> query = new SQLQuery<>(() -> EasyMock.createMock(Connection.class), new Configuration(SQLTemplates.DEFAULT));
+        SQLQuery<?> clone = query.clone();
+        assertNotNull(clone.connection());
+        assertNotSame(query.connection(), clone.connection());
+    }
+    
+    @Test
+    public void cloneConnectionArgHavingConnectionProvider() {
+        Connection connection = EasyMock.createMock(Connection.class);
+        SQLQuery<?> query = new SQLQuery<>(() -> EasyMock.createMock(Connection.class), new Configuration(SQLTemplates.DEFAULT));
+        SQLQuery<?> clone = query.clone(connection);
+        assertSame(connection, clone.connection());
     }
 
 }


### PR DESCRIPTION
Fixes bug when cloning a query that uses a connection provider. Without this change, the clone has neither a connection nor a connection provider, so the clone cannot be executed.