### PR TITLE
Update DefaultQueryMetadata.java

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/DefaultQueryMetadata.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/DefaultQueryMetadata.java
@@ -289,7 +289,7 @@ public class DefaultQueryMetadata implements QueryMetadata, Cloneable {
     @Override
     public void reset() {
         params = new LinkedHashMap<>();
-        modifiers = QueryModifiers.EMPTY;
+        modifiers = null;
     }
 
     @Override


### PR DESCRIPTION
The method reset() in DefaultQueryMetadata is supposed to reset the projection, not the modifiers. 
It fix the issue https://github.com/querydsl/querydsl/issues/3549