### PR TITLE
Merge using extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -805,6 +805,7 @@
         <module>querydsl-core</module>
         <module>querydsl-codegen</module>
         <module>querydsl-codegen-utils</module>
+        <module>querydsl-apt</module>
         <module>querydsl-spatial</module>
         <module>querydsl-sql</module>
         <module>querydsl-sql-spatial</module>

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLBaseListener.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLBaseListener.java
@@ -19,9 +19,12 @@ import java.util.Map;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.sql.dml.SQLInsertBatch;
 import com.querydsl.sql.dml.SQLMergeBatch;
+import com.querydsl.sql.dml.SQLMergeUsingCase;
 import com.querydsl.sql.dml.SQLUpdateBatch;
 
 /**
@@ -97,6 +100,11 @@ public class SQLBaseListener implements SQLDetailedListener {
 
     @Override
     public void notifyMerges(RelationalPath<?> entity, QueryMetadata md, List<SQLMergeBatch> batches) {
+
+    }
+
+    @Override
+    public void notifyMergeUsing(RelationalPath<?> entity, QueryMetadata md, SimpleExpression<?> usingExpression, Predicate usingOn, List<SQLMergeUsingCase> whens) {
 
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLListener.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLListener.java
@@ -19,9 +19,12 @@ import java.util.Map;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.sql.dml.SQLInsertBatch;
 import com.querydsl.sql.dml.SQLMergeBatch;
+import com.querydsl.sql.dml.SQLMergeUsingCase;
 import com.querydsl.sql.dml.SQLUpdateBatch;
 
 /**
@@ -76,6 +79,18 @@ public interface SQLListener {
      * @param batches metadata of batches
      */
     void notifyMerges(RelationalPath<?> entity, QueryMetadata md, List<SQLMergeBatch> batches);
+
+    /**
+     * Notify about a merge using
+     *
+     * @param entity table to be merged
+     * @param md metadata of merge
+     * @param usingExpression expression containing update data
+     * @param usingOn join conditions between new and existing data
+     * @param whens actions based on matching
+     */
+    void notifyMergeUsing(RelationalPath<?> entity, QueryMetadata md, SimpleExpression<?> usingExpression,
+            Predicate usingOn, List<SQLMergeUsingCase> whens);
 
     /**
      * Notify about an insertion

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerAdapter.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLListenerAdapter.java
@@ -19,9 +19,12 @@ import java.util.Map;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.sql.dml.SQLInsertBatch;
 import com.querydsl.sql.dml.SQLMergeBatch;
+import com.querydsl.sql.dml.SQLMergeUsingCase;
 import com.querydsl.sql.dml.SQLUpdateBatch;
 
 /**
@@ -127,6 +130,11 @@ class SQLListenerAdapter implements SQLDetailedListener {
     @Override
     public void notifyMerges(final RelationalPath<?> entity, final QueryMetadata md, final List<SQLMergeBatch> batches) {
         sqlListener.notifyMerges(entity, md, batches);
+    }
+
+    @Override
+    public void notifyMergeUsing(RelationalPath<?> entity, QueryMetadata md, SimpleExpression<?> usingExpression, Predicate usingOn, List<SQLMergeUsingCase> whens) {
+        sqlListener.notifyMergeUsing(entity, md, usingExpression, usingOn, whens);
     }
 
     @Override

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLListeners.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLListeners.java
@@ -18,6 +18,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.sql.dml.SQLMergeUsingCase;
 import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.QueryMetadata;
@@ -109,6 +112,17 @@ public class SQLListeners implements SQLDetailedListener {
         }
         for (SQLListener listener : listeners) {
             listener.notifyMerges(entity, md, batches);
+        }
+    }
+
+    @Override
+    public void notifyMergeUsing(RelationalPath<?> entity, QueryMetadata md, SimpleExpression<?> usingExpression,
+            Predicate usingOn, List<SQLMergeUsingCase> whens) {
+        if (parent != null) {
+            parent.notifyMergeUsing(entity, md, usingExpression, usingOn, whens);
+        }
+        for (SQLListener listener : listeners) {
+            listener.notifyMergeUsing(entity, md, usingExpression, usingOn, whens);
         }
     }
 

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
@@ -613,6 +613,7 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
                 append(templates.getDelete());
             }
         }
+        append(";");
     }
 
     public void serializeInsert(QueryMetadata metadata, RelationalPath<?> entity, List<Path<?>> columns,

--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
@@ -27,7 +27,9 @@ import java.util.Set;
 import com.querydsl.core.*;
 import com.querydsl.core.QueryFlag.Position;
 import com.querydsl.core.types.*;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.sql.dml.SQLInsertBatch;
+import com.querydsl.sql.dml.SQLMergeUsingCase;
 import com.querydsl.sql.types.Type;
 
 /**
@@ -920,6 +922,26 @@ public class SQLTemplates extends Templates {
             List<Path<?>> keys, List<Path<?>> columns, List<Expression<?>> values,
             SubQueryExpression<?> subQuery, SQLSerializer context) {
         context.serializeForMerge(metadata, entity, keys, columns, values, subQuery);
+
+        if (!metadata.getFlags().isEmpty()) {
+            context.serialize(Position.END, metadata.getFlags());
+        }
+    }
+
+    /**
+     * template method for MERGE USING serialization
+     *
+     * @param metadata
+     * @param entity
+     * @param usingExpression
+     * @param usingOn
+     * @param whens
+     * @param context
+     */
+    public void serializeMergeUsing(QueryMetadata metadata, RelationalPath<?> entity, SimpleExpression<?> usingExpression,
+            Predicate usingOn, List<SQLMergeUsingCase> whens,
+            SQLSerializer context) {
+        context.serializeForMergeUsing(metadata, entity, usingExpression, usingOn, whens);
 
         if (!metadata.getFlags().isEmpty()) {
             context.serialize(Position.END, metadata.getFlags());

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeClause.java
@@ -18,6 +18,7 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.util.function.Supplier;
 
+import com.querydsl.core.types.dsl.SimpleExpression;
 import org.jetbrains.annotations.Nullable;
 
 import com.querydsl.core.util.CollectionUtils;
@@ -98,6 +99,11 @@ public class SQLMergeClause extends AbstractSQLClause<SQLMergeClause> implements
     public SQLMergeClause addFlag(Position position, Expression<?> flag) {
         metadata.addFlag(new QueryFlag(position, flag));
         return this;
+    }
+
+    public SQLMergeUsingClause using(SimpleExpression<?> dataQuery) {
+        clear();
+        return new SQLMergeUsingClause(connection(), configuration, entity, dataQuery);
     }
 
     protected List<? extends Path<?>> getKeys() {

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeUsingCase.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeUsingCase.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.sql.dml;
+
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.sql.types.Null;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code SQLMergeClause} defines a case action for MERGE INTO clause with USING
+ *
+ * @author borgiiri
+ */
+public class SQLMergeUsingCase {
+
+    private final SQLMergeUsingClause parentClause;
+    private final Boolean matched;
+    private final List<Predicate> matchAnds = new ArrayList<>();
+    private Map<Path<?>, Expression<?>> updates = new LinkedHashMap<>();
+    private MergeOperation mergeOperation;
+
+    public enum MergeOperation { UPDATE, INSERT, DELETE }
+
+    public SQLMergeUsingCase(SQLMergeUsingClause parentClause, Boolean matched) {
+        this.parentClause = parentClause;
+        this.matched = matched;
+    }
+
+    public SQLMergeUsingCase and(Predicate predicate) {
+        matchAnds.add(predicate);
+        return this;
+    }
+
+    public SQLMergeUsingClause thenInsert(List<? extends Path<?>> paths, List<?> values) {
+        mergeOperation = MergeOperation.INSERT;
+        set(paths, values);
+        return parentClause.addWhen(this);
+    }
+
+    public SQLMergeUsingClause thenUpdate(List<? extends Path<?>> paths, List<?> values) {
+        mergeOperation = MergeOperation.UPDATE;
+        set(paths, values);
+        return parentClause.addWhen(this);
+    }
+
+    public SQLMergeUsingClause thenDelete() {
+        mergeOperation = MergeOperation.DELETE;
+        return parentClause.addWhen(this);
+    }
+
+    private void set(List<? extends Path<?>> paths, List<?> values) {
+        for (int i = 0; i < paths.size(); i++) {
+            if (values.get(i) instanceof Expression) {
+                updates.put(paths.get(i), (Expression<?>) values.get(i));
+            } else if (values.get(i) != null) {
+                updates.put(paths.get(i), ConstantImpl.create(values.get(i)));
+            } else {
+                updates.put(paths.get(i), Null.CONSTANT);
+            }
+        }
+    }
+
+    public Boolean getMatched() {
+        return matched;
+    }
+
+    public List<Predicate> getMatchAnds() {
+        return matchAnds;
+    }
+
+    public MergeOperation getMergeOperation() {
+        return mergeOperation;
+    }
+
+    public Map<Path<?>, Expression<?>> getUpdates() {
+        return updates;
+    }
+}

--- a/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeUsingClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/dml/SQLMergeUsingClause.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.sql.dml;
+
+import com.querydsl.core.*;
+import com.querydsl.core.QueryFlag.Position;
+import com.querydsl.core.types.*;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.core.util.ResultSetAdapter;
+import com.querydsl.sql.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+/**
+ * {@code SQLMergeUsingClause} defines a MERGE INTO clause with USING
+ *
+ * @author borgiiri
+ */
+public class SQLMergeUsingClause extends AbstractSQLClause<SQLMergeUsingClause> {
+
+    protected static final Logger logger = Logger.getLogger(SQLMergeUsingClause.class.getName());
+
+    protected final RelationalPath<?> entity;
+
+    protected final QueryMetadata metadata = new DefaultQueryMetadata();
+
+    protected SimpleExpression<?> usingExpression;
+
+    protected BooleanBuilder usingOn = new BooleanBuilder();
+    protected List<SQLMergeUsingCase> whens = new ArrayList<SQLMergeUsingCase>();
+    protected transient String queryString;
+
+    protected transient List<Object> constants;
+
+    public SQLMergeUsingClause(Connection connection, SQLTemplates templates, RelationalPath<?> entity) {
+        this(connection, new Configuration(templates), entity);
+    }
+
+    public SQLMergeUsingClause(Connection connection, Configuration configuration, RelationalPath<?> entity) {
+        super(configuration, connection);
+        this.entity = entity;
+        metadata.addJoin(JoinType.DEFAULT, entity);
+    }
+
+    public SQLMergeUsingClause(Supplier<Connection> connection, Configuration configuration, RelationalPath<?> entity) {
+        super(configuration, connection);
+        this.entity = entity;
+        metadata.addJoin(JoinType.DEFAULT, entity);
+    }
+
+    public SQLMergeUsingClause(Connection connection, Configuration configuration, RelationalPath<?> entity, SimpleExpression<?> usingExpression) {
+        super(configuration, connection);
+        this.entity = entity;
+        this.usingExpression = usingExpression;
+        metadata.addJoin(JoinType.DEFAULT, entity);
+    }
+
+    public SQLMergeUsingClause(Supplier<Connection> connection, Configuration configuration, RelationalPath<?> entity, SimpleExpression<?> usingExpression) {
+        super(configuration, connection);
+        this.entity = entity;
+        this.usingExpression = usingExpression;
+        metadata.addJoin(JoinType.DEFAULT, entity);
+    }
+
+    /**
+     * Add the given String literal at the given position as a query flag
+     *
+     * @param position position
+     * @param flag     query flag
+     * @return the current object
+     */
+    public SQLMergeUsingClause addFlag(Position position, String flag) {
+        metadata.addFlag(new QueryFlag(position, flag));
+        return this;
+    }
+
+    /**
+     * Add the given Expression at the given position as a query flag
+     *
+     * @param position position
+     * @param flag     query flag
+     * @return the current object
+     */
+    public SQLMergeUsingClause addFlag(Position position, Expression<?> flag) {
+        metadata.addFlag(new QueryFlag(position, flag));
+        return this;
+    }
+
+    @Override
+    public void clear() {
+        usingExpression = null;
+        whens.clear();
+        usingOn = new BooleanBuilder();
+    }
+
+    /**
+     * Execute the clause and return the generated key with the type of the given path.
+     * If no rows were created, null is returned, otherwise the key of the first row is returned.
+     *
+     * @param <T>
+     * @param path path for key
+     * @return generated key
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    public <T> T executeWithKey(Path<T> path) {
+        return executeWithKey((Class<T>) path.getType(), path);
+    }
+
+    /**
+     * Execute the clause and return the generated key cast to the given type.
+     * If no rows were created, null is returned, otherwise the key of the first row is returned.
+     *
+     * @param <T>
+     * @param type type of key
+     * @return generated key
+     */
+    public <T> T executeWithKey(Class<T> type) {
+        return executeWithKey(type, null);
+    }
+
+    protected <T> T executeWithKey(Class<T> type, @Nullable Path<T> path) {
+        ResultSet rs = executeWithKeys();
+        try {
+            if (rs.next()) {
+                return configuration.get(rs, path, 1, type);
+            } else {
+                return null;
+            }
+        } catch (SQLException e) {
+            throw configuration.translate(e);
+        } finally {
+            close(rs);
+        }
+    }
+
+    /**
+     * Execute the clause and return the generated key with the type of the given path.
+     * If no rows were created, or the referenced column is not a generated key, null is returned.
+     * Otherwise, the key of the first row is returned.
+     *
+     * @param <T>
+     * @param path path for key
+     * @return generated keys
+     */
+    @SuppressWarnings("unchecked")
+    public <T> List<T> executeWithKeys(Path<T> path) {
+        return executeWithKeys((Class<T>) path.getType(), path);
+    }
+
+    public <T> List<T> executeWithKeys(Class<T> type) {
+        return executeWithKeys(type, null);
+    }
+
+    protected <T> List<T> executeWithKeys(Class<T> type, @Nullable Path<T> path) {
+        ResultSet rs = null;
+        try {
+            rs = executeWithKeys();
+            List<T> rv = new ArrayList<T>();
+            while (rs.next()) {
+                rv.add(configuration.get(rs, path, 1, type));
+            }
+            return rv;
+        } catch (SQLException e) {
+            throw configuration.translate(e);
+        } finally {
+            if (rs != null) {
+                close(rs);
+            }
+            reset();
+        }
+    }
+
+    /**
+     * Execute the clause and return the generated keys as a ResultSet
+     *
+     * @return result set with generated keys
+     */
+    public ResultSet executeWithKeys() {
+        context = startContext(connection(), metadata, entity);
+        try {
+            PreparedStatement stmt = null;
+            stmt = createStatement(true);
+            listeners.notifyMergeUsing(entity, metadata, usingExpression, usingOn.getValue(), whens);
+
+            listeners.preExecute(context);
+            stmt.executeUpdate();
+            listeners.executed(context);
+
+            final Statement stmt2 = stmt;
+            ResultSet rs = stmt.getGeneratedKeys();
+            return new ResultSetAdapter(rs) {
+                @Override
+                public void close() throws SQLException {
+                    try {
+                        super.close();
+                    } finally {
+                        stmt2.close();
+                        reset();
+                        endContext(context);
+                    }
+                }
+            };
+        } catch (SQLException e) {
+            onException(context, e);
+            reset();
+            endContext(context);
+            throw configuration.translate(queryString, constants, e);
+        }
+    }
+
+    @Override
+    public long execute() {
+        return executeNativeMerge();
+    }
+
+    @Override
+    public List<SQLBindings> getSQL() {
+        SQLSerializer serializer = createSerializer();
+        serializer.serializeMergeUsing(metadata, entity, usingExpression, usingOn.getValue(), whens);
+        return Collections.singletonList(createBindings(metadata, serializer));
+    }
+
+    public int getBatchCount() {
+        return 0;
+    }
+
+    protected void addListeners(AbstractSQLClause<?> clause) {
+        for (SQLListener listener : listeners.getListeners()) {
+            clause.addListener(listener);
+        }
+    }
+
+    protected PreparedStatement createStatement(boolean withKeys) throws SQLException {
+        boolean addBatches = !configuration.getUseLiterals();
+        listeners.preRender(context);
+        SQLSerializer serializer = createSerializer();
+        PreparedStatement stmt = null;
+
+        serializer.serializeMergeUsing(metadata, entity, usingExpression, usingOn.getValue(), whens);
+        context.addSQL(createBindings(metadata, serializer));
+        listeners.rendered(context);
+
+        listeners.prePrepare(context);
+        stmt = prepareStatementAndSetParameters(serializer, withKeys);
+        context.addPreparedStatement(stmt);
+        listeners.prepared(context);
+        return stmt;
+    }
+
+    protected PreparedStatement prepareStatementAndSetParameters(
+            SQLSerializer serializer,
+            boolean withKeys
+    ) throws SQLException {
+        listeners.prePrepare(context);
+
+        queryString = serializer.toString();
+        constants = serializer.getConstants();
+        logQuery(logger, queryString, constants);
+        PreparedStatement stmt;
+        stmt = connection().prepareStatement(queryString);
+        setParameters(stmt, serializer.getConstants(), serializer.getConstantPaths(), metadata.getParams());
+        context.addPreparedStatement(stmt);
+        listeners.prepared(context);
+
+        return stmt;
+    }
+
+    protected long executeNativeMerge() {
+        context = startContext(connection(), metadata, entity);
+        PreparedStatement stmt = null;
+        try {
+            stmt = createStatement(false);
+            listeners.notifyMergeUsing(entity, metadata, usingExpression, usingOn.getValue(), whens);
+
+            listeners.preExecute(context);
+            int rc = stmt.executeUpdate();
+            listeners.executed(context);
+            return rc;
+        } catch (SQLException e) {
+            onException(context, e);
+            throw configuration.translate(queryString, constants, e);
+        } finally {
+            if (stmt != null) {
+                close(stmt);
+            }
+            reset();
+            endContext(context);
+        }
+    }
+
+    public SQLMergeUsingClause on(Predicate... conditions) {
+        for (Predicate condition : conditions) {
+            on(condition);
+        }
+        return this;
+    }
+
+    public SQLMergeUsingClause on(Predicate condition) {
+        usingOn.and(condition);
+        return this;
+    }
+
+    public SQLMergeUsingClause using(SimpleExpression<?> usingExpression) {
+        this.usingExpression = usingExpression;
+        return this;
+    }
+
+    public SQLMergeUsingClause addWhen(SQLMergeUsingCase mergeCase) {
+        whens.add(mergeCase);
+        return this;
+    }
+
+    public SQLMergeUsingCase whenMatched() {
+        return new SQLMergeUsingCase(this, true);
+    }
+
+    public SQLMergeUsingCase whenNotMatched() {
+        return new SQLMergeUsingCase(this, false);
+    }
+
+    @Override
+    public String toString() {
+        SQLSerializer serializer = createSerializer();
+        serializer.serializeMergeUsing(metadata, entity, usingExpression, usingOn.getValue(), whens);
+        return serializer.toString();
+    }
+
+}

--- a/querydsl-sql/src/test/java/com/querydsl/sql/MergeBase.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/MergeBase.java
@@ -228,7 +228,7 @@ public class MergeBase extends AbstractBaseTest {
     }
 
     @Test
-    @IncludeIn(DB2)
+    @IncludeIn({DB2, SQLSERVER})
     public void merge_with_using() {
         QSurvey usingSubqueryAlias = new QSurvey("USING_SUBSELECT");
         SQLMergeUsingClause merge = merge(survey)

--- a/querydsl-sql/src/test/java/com/querydsl/sql/SQLListenersTest.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/SQLListenersTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.assertThat;
 import java.util.List;
 import java.util.Map;
 
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.sql.dml.SQLMergeUsingCase;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
@@ -168,6 +171,10 @@ public class SQLListenersTest {
 
         @Override
         public void notifyMerges(RelationalPath<?> entity, QueryMetadata md, List<SQLMergeBatch> batches) {
+        }
+
+        @Override
+        public void notifyMergeUsing(RelationalPath<?> entity, QueryMetadata md, SimpleExpression<?> usingExpression, Predicate usingOn, List<SQLMergeUsingCase> whens) {
         }
 
         @Override

--- a/querydsl-sql/src/test/java/com/querydsl/sql/TestLoggingListener.java
+++ b/querydsl-sql/src/test/java/com/querydsl/sql/TestLoggingListener.java
@@ -8,9 +8,12 @@ import java.util.Map;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.sql.dml.SQLInsertBatch;
 import com.querydsl.sql.dml.SQLMergeBatch;
+import com.querydsl.sql.dml.SQLMergeUsingCase;
 import com.querydsl.sql.dml.SQLUpdateBatch;
 
 /**
@@ -127,6 +130,13 @@ public class TestLoggingListener implements SQLDetailedListener {
     public void notifyMerges(RelationalPath<?> entity, QueryMetadata md, List<SQLMergeBatch> batches) {
         if (enabled) {
             System.out.println(format("\t\t\tnotifyMerges %s", entity));
+        }
+    }
+
+    @Override
+    public void notifyMergeUsing(RelationalPath<?> entity, QueryMetadata md, SimpleExpression<?> usingExpression, Predicate usingOn, List<SQLMergeUsingCase> whens) {
+        if (enabled) {
+            System.out.println(format("\t\t\tnotifyMergeUsing %s", entity));
         }
     }
 


### PR DESCRIPTION
Proposal for addition for merge using syntax related to https://github.com/querydsl/querydsl/issues/2520
Few notes:
- This changes interfaces, japicmp-maven-plugin will complain
- Merge using query works also with latest versions of H2 and PostgreSQL, however bumping versions results in other tests breaking
- In case of Oracle it currently produces `Caused by: java.sql.SQLSyntaxErrorException: ORA-00969: missing ON keyword`. Reason being it doesn't put "as" between subquery and its alias, not sure how to fix nicely.