### PR TITLE
Support Elasticsearch annotations for apt.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <hamcrest.veresion>2.2</hamcrest.veresion>
     <kotlin.version>1.7.20</kotlin.version>
     <dokka.version>1.7.20</dokka.version>
+    <spring-data-elasticsearch.version>5.2.2</spring-data-elasticsearch.version>
 
     <!-- Import-Package definitions for maven-bundle-plugin -->
     <osgi.import.package.root>

--- a/querydsl-apt/pom.xml
+++ b/querydsl-apt/pom.xml
@@ -78,6 +78,18 @@
       <version>${morphia.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-elasticsearch</artifactId>
+      <version>${spring-data-elasticsearch.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.parsson</groupId>
+          <artifactId>parsson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     
     <!-- test -->
     <dependency>

--- a/querydsl-apt/src/apt/elasticsearch/META-INF/services/javax.annotation.processing.Processor
+++ b/querydsl-apt/src/apt/elasticsearch/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.querydsl.apt.elasticsearch.ElasticsearchAnnotationProcessor

--- a/querydsl-apt/src/main/elasticsearch.xml
+++ b/querydsl-apt/src/main/elasticsearch.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>elasticsearch</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>src/apt/elasticsearch</directory>
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>   
+      <outputDirectory>/</outputDirectory>
+    </fileSet>          
+  </fileSets>  
+</assembly>

--- a/querydsl-apt/src/main/java/com/querydsl/apt/elasticsearch/ElasticsearchAnnotationProcessor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/elasticsearch/ElasticsearchAnnotationProcessor.java
@@ -1,0 +1,37 @@
+package com.querydsl.apt.elasticsearch;
+
+import com.querydsl.apt.AbstractQuerydslProcessor;
+import com.querydsl.apt.Configuration;
+import com.querydsl.apt.DefaultConfiguration;
+import com.querydsl.core.annotations.QueryEmbedded;
+import com.querydsl.core.annotations.QueryEntities;
+import com.querydsl.core.annotations.QuerySupertype;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+
+/**
+ * Annotation processor to create Querydsl query types for Elasticsearch annotated classes.
+ */
+@SupportedAnnotationTypes({"com.querydsl.core.annotations.*", "org.springframework.data.elasticsearch.annotations.*"})
+public class ElasticsearchAnnotationProcessor extends AbstractQuerydslProcessor {
+    @Override
+    protected Configuration createConfiguration(final RoundEnvironment roundEnvironment) {
+        // elasticsearch annotation
+        Class<? extends Annotation> document = Document.class;
+        Class<? extends Annotation> skip = Transient.class;
+
+        // query-dsl annotation
+        Class<? extends Annotation> entities = QueryEntities.class;
+        Class<? extends Annotation> superType = QuerySupertype.class;
+        Class<? extends Annotation> embedded = QueryEmbedded.class;
+
+        return new DefaultConfiguration(processingEnv, roundEnvironment,
+                Collections.emptySet(),
+                entities, document, superType, null, embedded, skip);
+    }
+}

--- a/querydsl-apt/src/main/java/com/querydsl/apt/elasticsearch/package-info.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/elasticsearch/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * APT Elasticsearch support
+ */
+package com.querydsl.apt.elasticsearch;


### PR DESCRIPTION
To fully understand the `querydsl-lucene` and potentially contribute to the development of `spring-data-elasticsearch`, it is essential to delve deeper into the mechanics of building queries, including the use of the **processor**. One way to enhance this understanding is by exploring the use of a sample **BooleanBuilder** in constructing complex queries. By actively engaging in this pull request, individuals can gain valuable insights and experience in effectively utilizing these tools for optimal query building.