### PR TITLE
Support Java 16+ records in querydsl-apt

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/TypeExtractor.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/TypeExtractor.java
@@ -49,10 +49,11 @@ class TypeExtractor extends SimpleTypeVisitorAdapter<TypeElement, Void> {
     public TypeElement visitDeclared(DeclaredType t, Void p) {
         if (t.asElement() instanceof TypeElement) {
             TypeElement typeElement = (TypeElement) t.asElement();
-            switch (typeElement.getKind()) {
-                case ENUM:      return skipEnum ? null : typeElement;
-                case CLASS:     return typeElement;
-                case INTERFACE: return visitInterface(t);
+            switch (typeElement.getKind().name()) {
+                case "ENUM":      return skipEnum ? null : typeElement;
+                case "RECORD":
+                case "CLASS":     return typeElement;
+                case "INTERFACE": return visitInterface(t);
                 default: throw new IllegalArgumentException("Illegal type: " + typeElement);
             }
         } else {


### PR DESCRIPTION
Records were first time introduced as preview feature in Java SE 14 & 15, and as completed feature in Java SE 16, almost three years ago. Hibernate is supporting records as embeddables since version 6 (see, for example, [article by Thorben Janssen](https://thorben-janssen.com/java-records-embeddables-hibernate/))

Sadly, Java records are still not supported in Querydsl APT 5.1.0.

Change to support records is trivial.since they can (mostly) be treated in a same way as "normal" classes.

