### PR TITLE
Fixing performance issue related with querydsl spatial on hibernate.

### DIFF
--- a/querydsl-spatial/src/main/java/com/querydsl/spatial/hibernate/HibernateSpatialSupport.java
+++ b/querydsl-spatial/src/main/java/com/querydsl/spatial/hibernate/HibernateSpatialSupport.java
@@ -41,15 +41,15 @@ public final class HibernateSpatialSupport {
         ops.put(SpatialOps.BOUNDARY, "boundary({0})");
         ops.put(SpatialOps.EXTENT, "extent({0})");
 
-        ops.put(SpatialOps.EQUALS, "equals({0}, {1}) = true");
-        ops.put(SpatialOps.DISJOINT, "disjoint({0}, {1}) = true");
-        ops.put(SpatialOps.INTERSECTS, "intersects({0}, {1}) = true");
-        ops.put(SpatialOps.TOUCHES, "touches({0}, {1}) = true");
-        ops.put(SpatialOps.CROSSES, "crosses({0}, {1}) = true");
-        ops.put(SpatialOps.WITHIN, "within({0}, {1}) = true");
-        ops.put(SpatialOps.CONTAINS, "contains({0}, {1}) = true");
-        ops.put(SpatialOps.OVERLAPS, "overlaps({0}, {1}) = true");
-        ops.put(SpatialOps.RELATE, "relate({0}, {1}, {2}) = true");
+        ops.put(SpatialOps.EQUALS, "equals({0}, {1})");
+        ops.put(SpatialOps.DISJOINT, "disjoint({0}, {1})");
+        ops.put(SpatialOps.INTERSECTS, "intersects({0}, {1})");
+        ops.put(SpatialOps.TOUCHES, "touches({0}, {1})");
+        ops.put(SpatialOps.CROSSES, "crosses({0}, {1})");
+        ops.put(SpatialOps.WITHIN, "within({0}, {1})");
+        ops.put(SpatialOps.CONTAINS, "contains({0}, {1})");
+        ops.put(SpatialOps.OVERLAPS, "overlaps({0}, {1})");
+        ops.put(SpatialOps.RELATE, "relate({0}, {1}, {2})");
 
         ops.put(SpatialOps.DISTANCE, "distance({0}, {1})");
         ops.put(SpatialOps.DISTANCE2, "distance({0}, {1}, {2})");
@@ -63,7 +63,7 @@ public final class HibernateSpatialSupport {
         ops.put(SpatialOps.UNION, "geomunion({0}, {1})");
         ops.put(SpatialOps.DIFFERENCE, "difference({0}, {1})");
         ops.put(SpatialOps.SYMDIFFERENCE, "symdifference({0}, {1})");
-        ops.put(SpatialOps.DWITHIN, "dwithin({0}, {1}, {2}) = true");
+        ops.put(SpatialOps.DWITHIN, "dwithin({0}, {1}, {2})");
         ops.put(SpatialOps.TRANSFORM, "transform({0}, {1})");
 
         // custom


### PR DESCRIPTION
As the representation of the operations were doing an equal true (boolean check), the DB engine is not able to use the spatial index, and instead of performing the intersects with the entities using the spatial index and comparing only the ones indicated by this one, was applying the intersects operation to all the entities.

How was discovered? 

While migrating my application from native spatial queries to querydsl-spatial I found a big downgrade on the performance.  Analysing the differences between the native queries that I had and the ones generated by querydsl-spatial, I was able to indentify that queryDSL spatial was adding for most of the operations that I was interested on an = true clause. It is not needed and this comparison makes the db engine to not to use the spatial index on those queries. 

it can be easily analysed by an EXPLAIN clause, that would show that using = true/false, the spatial index is not used, but without this clause, it is used, having exactly the same result in the queries.

In my case, the performance issue was of having queries executed in few milliseconds to more than 10 minutes in some cases