### PR TITLE
Add Jakarta classifier to the Maven integration docs

### DIFF
--- a/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
+++ b/querydsl-docs/src/main/docbook/en-US/content/tutorials/jpa.xml
@@ -29,6 +29,7 @@
   <groupId>com.querydsl</groupId>
   <artifactId>querydsl-apt</artifactId>
   <version>${querydsl.version}</version>
+  <classifier>jakarta</classifier>
   <scope>provided</scope>
 </dependency>
 
@@ -36,8 +37,15 @@
   <groupId>com.querydsl</groupId>
   <artifactId>querydsl-jpa</artifactId>
   <version>${querydsl.version}</version>
+  <classifier>jakarta</classifier>
 </dependency>
 ]]></programlisting>
+
+    <para>
+      The <literal>jakarta</literal> classifier is added to ensure compatibility with Jakarta EE 9+ and Spring Boot 3.x, 
+      which use the <literal>jakarta.*</literal> package namespace instead of <literal>javax.*</literal>. 
+      For projects using older versions of Spring Boot or Java EE, omit this classifier.
+    </para>
 
     <para>
       And now, configure the Maven APT plugin:


### PR DESCRIPTION
Update the Maven integration docs to support Spring Boot 3.x which is based on Jakarta EE 9+ by using the Jakarta classifier.