### PR TITLE
Improve Null-Safety for Query Conditions Methods in QueryDSL.

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/StringExpression.java
@@ -15,6 +15,8 @@ package com.querydsl.core.types.dsl;
 
 import org.jetbrains.annotations.Nullable;
 
+import jakarta.validation.constraints.NotNull;
+
 import com.querydsl.core.types.*;
 
 /**
@@ -149,8 +151,9 @@ public abstract class StringExpression extends LiteralExpression<String> {
      * @return this.contains(str)
      * @see java.lang.String#contains(CharSequence)
      */
-    public BooleanExpression contains(String str) {
-        return contains(ConstantImpl.create(str));
+    public BooleanExpression contains(@NotNull String str) {
+        // It can return null or throw an exception.
+        str == null ? null : contains(ConstantImpl.create(str));
     }
 
     /**


### PR DESCRIPTION
Currently, condition methods provided by QueryDSL (e.g., like, contains, etc.) are not null-safe. If a null value is passed, an error occurs in the ConstantImpl constructor.

To address this, I propose adding null checks to these methods to safely handle null values.

By using the `@NotNull` annotation, compile-time warnings can be issued when a null parameter is passed. Additionally, within the method, if null is encountered, we can either **return nul**l or **throw a specific exception** to handle the situation explicitly.

These changes would help prevent potential errors when using QueryDSL and reduce the need for users to perform unnecessary null checks when writing dynamic queries, thus improving the stability of the code and enhancing user convenience.